### PR TITLE
Codex: skip empty premium snapshots when reading rollouts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,21 @@
+# Default to standard Xcode location only if it exists and the user hasn't
+# already chosen a toolchain via `sudo xcode-select -s` / $DEVELOPER_DIR.
+# Unconditionally exporting a path that doesn't exist breaks `make` on machines
+# with only the Command Line Tools installed (xcrun: missing DEVELOPER_DIR).
+ifeq (,$(DEVELOPER_DIR))
+ifneq (,$(wildcard /Applications/Xcode.app/Contents/Developer))
 export DEVELOPER_DIR := /Applications/Xcode.app/Contents/Developer
+endif
+endif
 
 PROJECT := Codenotch.xcodeproj
 SCHEME  := Codenotch
 DEST    := platform=macOS,arch=arm64
+
+# Debug builds are ad-hoc signed so anyone can build without the maintainer's
+# Developer ID certificate (see CONTRIBUTING.md). Release (archive below) keeps
+# the Developer ID identity for notarization + Sparkle.
+DEV_SIGN := CODE_SIGN_IDENTITY="-" DEVELOPMENT_TEAM="" CODE_SIGN_STYLE=Automatic
 
 .PHONY: gen build test run clean
 
@@ -11,11 +24,11 @@ gen:
 
 build: gen
 	xcodebuild -project $(PROJECT) -scheme $(SCHEME) -destination '$(DEST)' \
-		-configuration Debug build
+		-configuration Debug $(DEV_SIGN) build
 
 test: gen
 	xcodebuild -project $(PROJECT) -scheme $(SCHEME) -destination '$(DEST)' \
-		-configuration Debug test
+		-configuration Debug $(DEV_SIGN) test
 
 run: build
 	@APP=$$(xcodebuild -project $(PROJECT) -scheme $(SCHEME) -destination '$(DEST)' \

--- a/README.md
+++ b/README.md
@@ -30,6 +30,13 @@ provider's ring while a session is busy, and becomes a pulsing amber ring when
 one is blocked waiting on you. Hover for every live session by name, where it
 is running, and what it wants.
 
+Two Claude Code logins are two rings. Anyone who keeps a work account apart with
+`CLAUDE_CONFIG_DIR=~/.claude-work claude` gets a **Claude (work)** ring beside the
+personal one, with its own limits, its own sessions and its own row in Settings.
+Any `~/.claude-<slug>` directory Claude Code has run against is found at launch;
+the default `~/.claude` always comes first, the rest in alphabetical order, so the
+rings never swap places.
+
 ## Placement
 
 The notch lives on any of the four screen edges. Right and left keep a

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ two never disagree.
 | **Cursor** | official | The editor's own signed-in session, read from its local SQLite state — no separate sign-in. |
 | **Codex** | official | Codex's own app server, asked live for the current rate limits. Falls back to its rollout log when Codex isn't running. |
 | **Antigravity** | official where licensed, otherwise a request count | Antigravity's local language server first, then Google's quota endpoint; a plain count when neither will answer for the account. |
+| **GLM** | official | Z.ai's Coding Plan monitor endpoint, with a key borrowed from whichever coding tool already holds one — Claude Code's `settings.json`, ZCode, or OpenCode. |
 
 Codenotch never signs in anywhere. Every reading is borrowed from a credential
 or session a tool on your Mac already holds — install and sign in to any of

--- a/Sources/App/AppDelegate.swift
+++ b/Sources/App/AppDelegate.swift
@@ -69,7 +69,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             Log.usage.info("claude profiles: \(self.claudeProfiles.map(\.displayPath).joined(separator: ", "), privacy: .public)")
             let store = UsageStore(
                 providers: claudeProfiles.map { ClaudeOAuthProvider(profile: $0) }
-                    + [CursorLocalProvider(), CodexLocalProvider(), AntigravityProvider()]
+                    + [CursorLocalProvider(), CodexLocalProvider(), AntigravityProvider(),
+                       GLMProvider()]
                     + webProviders,
                 disconnected: preferences.disconnectedProviders
             )

--- a/Sources/App/AppDelegate.swift
+++ b/Sources/App/AppDelegate.swift
@@ -23,6 +23,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             || NSClassFromString("XCTestCase") != nil
     }
 
+    /// Every Claude Code configuration directory on this Mac — `~/.claude` and
+    /// any `~/.claude-<slug>` — found once at launch. Each gets a usage
+    /// provider and a session monitor of its own, keyed by the same id, so a
+    /// work login's sessions spin the work ring and nobody else's.
+    private let claudeProfiles = ClaudeProfile.discover()
+
     func applicationDidFinishLaunching(_ notification: Notification) {
         // Set here, not in the Info.plist: this call is applied at launch and
         // overrides `LSUIElement` either way. Removing the plist key alone left
@@ -60,9 +66,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             // very first list it draws already excludes them. Constructed first,
             // it drew every provider from the archive and only dropped the
             // switched-off ones once the binding below delivered.
+            Log.usage.info("claude profiles: \(self.claudeProfiles.map(\.displayPath).joined(separator: ", "), privacy: .public)")
             let store = UsageStore(
-                providers: [ClaudeOAuthProvider(), CursorLocalProvider(),
-                            CodexLocalProvider(), AntigravityProvider()]
+                providers: claudeProfiles.map { ClaudeOAuthProvider(profile: $0) }
+                    + [CursorLocalProvider(), CodexLocalProvider(), AntigravityProvider()]
                     + webProviders,
                 disconnected: preferences.disconnectedProviders
             )
@@ -177,12 +184,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         // What each agent is doing right now, so the notch can say whether it is
         // still working without you switching to it.
-        let monitors: [String: any AgentActivityMonitor] = [
-            "claude": ClaudeSessionMonitor(),
+        var monitors: [String: any AgentActivityMonitor] = [
             "cursor": CursorActivityMonitor(),
             "codex": CodexActivityMonitor(),
             "gemini": AntigravityActivityMonitor()
         ]
+        for profile in claudeProfiles {
+            monitors[profile.id] = ClaudeSessionMonitor(directory: profile.sessionsDirectory)
+        }
         for (id, monitor) in monitors {
             monitor.sessionsPublisher
                 .receive(on: RunLoop.main)

--- a/Sources/Model/ResetCopy.swift
+++ b/Sources/Model/ResetCopy.swift
@@ -15,9 +15,7 @@ enum ResetCopy {
             return "Resets in \(max(1, minutes)) min"
         }
 
-        let formatter = DateFormatter()
-        formatter.calendar = calendar
-        formatter.locale = .current
+        let formatter = formatter(for: calendar)
 
         // A weekday only identifies a day inside the coming week. Codex's
         // monthly window resets 26 days out, and "Resets Mon 3:55 PM" read as
@@ -36,6 +34,21 @@ enum ResetCopy {
         // design frame and Claude's own usage panel write "4:50 PM".
         formatter.dateFormat = "E h:mm a"
         return "Resets \(formatter.string(from: resetsAt))"
+    }
+
+    /// A formatter that renders in the given calendar's own zone.
+    ///
+    /// Setting `calendar` does not carry its time zone across, and the formatter
+    /// otherwise falls back to the device's — so a date rendered against an
+    /// explicit calendar came out shifted by the difference. Shared because
+    /// `UsageBlock.summary` formats the same kind of vendor reset time from the
+    /// same kind of injected calendar, and had the same defect.
+    static func formatter(for calendar: Calendar) -> DateFormatter {
+        let formatter = DateFormatter()
+        formatter.calendar = calendar
+        formatter.timeZone = calendar.timeZone
+        formatter.locale = .current
+        return formatter
     }
 
     /// Whole days between two instants, counted by calendar day rather than by

--- a/Sources/Model/UsageArchive.swift
+++ b/Sources/Model/UsageArchive.swift
@@ -32,19 +32,30 @@ struct UsageArchive {
     /// request immediately — so a development loop of `make run` walks straight
     /// into the rate limit it is being punished by, and keeps the punishment
     /// alive. Which is exactly what happened.
-    func loadBackoffUntil() -> Date? {
-        guard let date = defaults.object(forKey: backoffKey) as? Date, date > Date() else {
+    ///
+    /// Kept per provider: the limit is per account, so a work profile being
+    /// told to slow down says nothing about the personal one. The default
+    /// profile keeps the key it always had, so a penalty in progress survives
+    /// the update.
+    func loadBackoffUntil(providerID: String = ClaudeProfile.defaultID) -> Date? {
+        guard let date = defaults.object(forKey: backoffKey(for: providerID)) as? Date,
+              date > Date() else {
             return nil
         }
         return date
     }
 
-    func saveBackoffUntil(_ date: Date?) {
+    func saveBackoffUntil(_ date: Date?, providerID: String = ClaudeProfile.defaultID) {
+        let key = backoffKey(for: providerID)
         if let date {
-            defaults.set(date, forKey: backoffKey)
+            defaults.set(date, forKey: key)
         } else {
-            defaults.removeObject(forKey: backoffKey)
+            defaults.removeObject(forKey: key)
         }
+    }
+
+    private func backoffKey(for providerID: String) -> String {
+        providerID == ClaudeProfile.defaultID ? backoffKey : "\(backoffKey).\(providerID)"
     }
 
     func load() -> [String: (snapshot: ProviderSnapshot, fetchedAt: Date)] {

--- a/Sources/Model/UsageModel.swift
+++ b/Sources/Model/UsageModel.swift
@@ -162,6 +162,7 @@ struct ProviderSnapshot: Identifiable, Equatable {
         case "cursor":     return "Sign in to Cursor in the editor"
         case "codex":      return "Sign in to Codex to read your usage"
         case "gemini":     return "Sign in to Antigravity to read your usage"
+        case "glm":        return "Set up a GLM Coding Plan key for a coding tool to read your usage"
         default:           return "Sign in to \(displayName) to read your usage"
         }
     }

--- a/Sources/Model/UsageModel.swift
+++ b/Sources/Model/UsageModel.swift
@@ -90,9 +90,7 @@ struct UsageBlock: Equatable {
     /// The line the tooltip leads with.
     func summary(now: Date = Date(), calendar: Calendar = .current) -> String {
         guard let resetsAt, resetsAt > now else { return reason }
-        let formatter = DateFormatter()
-        formatter.calendar = calendar
-        formatter.locale = .current
+        let formatter = ResetCopy.formatter(for: calendar)
         // The same clock the vendor's own banner uses — "4:13 PM" — rather
         // than a countdown, because that is what you are waiting for.
         formatter.dateFormat = ResetCopy.daysApart(from: now, to: resetsAt,

--- a/Sources/Model/UsageModel.swift
+++ b/Sources/Model/UsageModel.swift
@@ -154,6 +154,11 @@ struct ProviderSnapshot: Identifiable, Equatable {
     private var authPrompt: String {
         switch id {
         case "claude":     return "Sign in to Claude Code to read your usage"
+        // A profile is signed in by running Claude Code against its directory,
+        // which is worth saying: plain `claude` signs the default one in.
+        case _ where ClaudeProfile.isClaude(providerID: id):
+            let slug = ClaudeProfile.slug(fromProviderID: id) ?? ""
+            return "Sign in to Claude Code in ~/.claude-\(slug) to read your usage"
         case "cursor":     return "Sign in to Cursor in the editor"
         case "codex":      return "Sign in to Codex to read your usage"
         case "gemini":     return "Sign in to Antigravity to read your usage"

--- a/Sources/Model/UsageStore.swift
+++ b/Sources/Model/UsageStore.swift
@@ -39,6 +39,14 @@ final class UsageStore: ObservableObject {
 
     private let refreshInterval: TimeInterval
     /// How long a snapshot stays believable after its last successful fetch.
+    ///
+    /// Comfortably above `idleRefreshInterval`, on purpose. With the two equal,
+    /// a ring dimmed the instant the *first* idle refresh attempt failed —
+    /// which reads as "nothing is being read any more" when what actually
+    /// happened is one attempt, five minutes ago, out of what will keep being
+    /// tried every five minutes after. The margin buys room for a couple of
+    /// those attempts to have genuinely failed before the ring says so; it
+    /// must never fire merely because the idle schedule hasn't come round yet.
     private let staleAfter: TimeInterval
     /// How often to look when nothing is running.
     private let idleRefreshInterval: TimeInterval
@@ -57,7 +65,7 @@ final class UsageStore: ObservableObject {
         providers: [UsageProvider],
         refreshInterval: TimeInterval = 60,
         idleRefreshInterval: TimeInterval = 5 * 60,
-        staleAfter: TimeInterval = 5 * 60,
+        staleAfter: TimeInterval = 15 * 60,
         archive: UsageArchive = UsageArchive(),
         disconnected: Set<String> = []
     ) {
@@ -363,6 +371,11 @@ final class UsageStore: ObservableObject {
     /// Exposed for the tests: the store never invents a reading, so what a
     /// failure looks like is worth pinning down.
     static func statusForTesting(_ error: Error) -> ProviderStatus { status(for: error) }
+
+    /// Exposed so a test can hold the shipped defaults to the margin they are
+    /// supposed to keep, without re-typing the numbers on both sides.
+    var staleAfterForTesting: TimeInterval { staleAfter }
+    var idleRefreshIntervalForTesting: TimeInterval { idleRefreshInterval }
 
     private static func status(for error: Error) -> ProviderStatus {
         switch error {

--- a/Sources/Model/UsageStore.swift
+++ b/Sources/Model/UsageStore.swift
@@ -9,6 +9,9 @@ final class UsageStore: ObservableObject {
     @Published private(set) var snapshots: [ProviderSnapshot] = []
     /// Providers with a fetch in flight, so the cell can show it happening.
     @Published private(set) var refreshing: Set<String> = []
+    /// Providers whose last fetch was refused by macOS, cleared as soon as one
+    /// succeeds. The settings row's only honest basis for offering to ask again.
+    @Published private(set) var refusedAccess: Set<String> = []
 
     private let providers: [UsageProvider]
     /// Providers the user has switched off. They are not fetched at all — their
@@ -95,9 +98,11 @@ final class UsageStore: ObservableObject {
 
     /// Enough to list the providers in settings without exposing them.
     var providerSummaries: [ProviderSummary] {
-        providers.map {
-            ProviderSummary(id: $0.id, name: $0.displayName, glyph: $0.glyph,
-                            account: $0.account(), signIn: $0.signInRoute)
+        providers.map { provider in
+            ProviderSummary(id: provider.id, name: provider.displayName,
+                            glyph: provider.glyph, account: provider.account(),
+                            signIn: provider.signInRoute,
+                            wasRefusedAccess: refusedAccess.contains(provider.id))
         }
     }
 
@@ -289,6 +294,7 @@ final class UsageStore: ObservableObject {
             let fresh = try await provider.fetchSnapshot()
             lastGood[provider.id] = (fresh, Date())
             archive.save(lastGood)
+            refusedAccess.remove(provider.id)
             Log.usage.debug("\(provider.id, privacy: .public): \(fresh.windows.count) window(s)")
             return fresh
         } catch {
@@ -301,6 +307,18 @@ final class UsageStore: ObservableObject {
     /// one marked stale, or shows the cell with no reading at all.
     private func degraded(provider: UsageProvider, error: Error) -> ProviderSnapshot {
         let status = Self.status(for: error)
+
+        // Remembered apart from the snapshot on purpose. The snapshot answers
+        // "how good are the numbers I am showing", and for a refusal the honest
+        // answer is "still fine, just ageing" — which is why `supersedesHistory`
+        // keeps the old reading and its status. That deliberately loses the one
+        // fact the settings row needs: whether macOS let us in last time. Two
+        // different questions, so two different places to keep the answer.
+        if case .accessDenied = status {
+            refusedAccess.insert(provider.id)
+        } else {
+            refusedAccess.remove(provider.id)
+        }
 
         // Some failures are statements about the account rather than a hiccup:
         // signed out, or a plan that meters nothing. Re-showing an old reading

--- a/Sources/Notch/NotchWindowController.swift
+++ b/Sources/Notch/NotchWindowController.swift
@@ -391,7 +391,18 @@ final class NotchWindowController {
     /// A click on a ring refetches that provider; a click anywhere else on the
     /// open notch pins it. The ring is the more specific target, so it wins.
     func handleClick() {
-        guard let panel, model.isExpanded else { return togglePinned() }
+        guard let panel, model.isExpanded else {
+            // Opens it, the same as the pointer arriving would — it must not
+            // also pin it. The pill's hot zone is deliberately generous, since
+            // it is a small target on a screen edge, so a click aimed at
+            // something else nearby can land here without the notch ever
+            // having been seen open. Pinning is what a click on a notch that
+            // is *already* open does; folding it back in later is exactly
+            // the ordinary hover behaviour, which a plain `setExpanded` leaves
+            // intact.
+            setExpanded(true)
+            return
+        }
         let local = localCursor(in: panel.frame)
 
         // The handle sits inside the notch, so it has to be tested before the

--- a/Sources/Providers/ClaudeCredentials.swift
+++ b/Sources/Providers/ClaudeCredentials.swift
@@ -15,29 +15,20 @@ struct ClaudeCredentials {
 
     var isExpired: Bool { expiresAt <= Date() }
 
-    static let service = "Claude Code-credentials"
+    /// The service the default profile's token is filed under. Other profiles
+    /// get a suffix — see `ClaudeProfile.keychainService`.
+    static let service = ClaudeProfile.defaultKeychainService
 
-    /// Read once, then held until the token expires — see `CredentialCache`.
-    /// Claude Code rotates this roughly hourly, so this is about one keychain
-    /// read an hour instead of two a minute.
-    private static let cache = CredentialCache<ClaudeCredentials> { $0.isExpired }
+    /// Reads the default profile. Kept for callers that predate profiles.
+    static func load() throws -> ClaudeCredentials { try ClaudeKeychain.default.load() }
+    static func forgetCached() { ClaudeKeychain.default.forgetCached() }
 
-    /// Forget the held copy. Call when the server rejects it: signing into a
-    /// different account replaces the keychain item, and the copy in hand is
-    /// then wrong despite not having expired.
-    static func forgetCached() { cache.forget() }
-
-    /// Reads whatever is stored, expired or not. Judging expiry is the caller's
-    /// job, because "signed out" and "the token has aged out overnight" call for
-    /// different behaviour and only one of them is worth alarming anyone about.
-    static func load() throws -> ClaudeCredentials {
-        try cache.value(
-            itemModifiedAt: { KeychainItem.modifiedAt(service: service) },
-            reload: read
-        )
-    }
-
-    private static func read() throws -> ClaudeCredentials {
+    /// The keychain read itself, for one service name.
+    ///
+    /// `ClaudeKeychain` decides *whether* to read; this is what happens when it
+    /// does. Every failure is turned into the status the UI should show, and
+    /// the raw OSStatus is logged so "not found" and "refused" stay distinct.
+    static func read(service: String) throws -> ClaudeCredentials {
         var item: CFTypeRef?
         let status = SecItemCopyMatching([
             kSecClass: kSecClassGenericPassword,
@@ -51,7 +42,7 @@ struct ClaudeCredentials {
             // in, whereas -25308 (interaction not allowed) or -128 (user
             // cancelled) mean the item is there but this app is not on its
             // access list. Those need very different advice, so record which.
-            Log.usage.error("keychain read failed: OSStatus \(status) (\(Self.explain(status), privacy: .public))")
+            Log.usage.error("keychain read of \(service, privacy: .public) failed: OSStatus \(status) (\(Self.explain(status), privacy: .public))")
             throw Self.wasRefused(status)
                 ? UsageProviderError.accessDenied
                 : UsageProviderError.needsAuth
@@ -104,4 +95,45 @@ struct ClaudeCredentials {
             return (SecCopyErrorMessageString(status, nil) as String?) ?? "unknown"
         }
     }
+}
+
+/// One profile's token, read as rarely as the keychain allows.
+///
+/// One of these per `ClaudeProfile`, because each profile's token is a separate
+/// keychain item with its own access list: macOS prompts once per item, and a
+/// cache shared between them would hand the personal token to the work ring.
+final class ClaudeKeychain: @unchecked Sendable {
+    let service: String
+
+    /// Read once, then held until the token expires — see `CredentialCache`.
+    /// Claude Code rotates this roughly hourly, so this is about one keychain
+    /// read an hour instead of two a minute.
+    private let cache = CredentialCache<ClaudeCredentials> { $0.isExpired }
+
+    init(service: String) {
+        self.service = service
+    }
+
+    convenience init(profile: ClaudeProfile) {
+        self.init(service: profile.keychainService)
+    }
+
+    /// The default profile's reader, shared so that every caller that predates
+    /// profiles keeps sharing one cache — and so one prompt.
+    static let `default` = ClaudeKeychain(service: ClaudeProfile.defaultKeychainService)
+
+    /// Reads whatever is stored, expired or not. Judging expiry is the caller's
+    /// job, because "signed out" and "the token has aged out overnight" call for
+    /// different behaviour and only one of them is worth alarming anyone about.
+    func load() throws -> ClaudeCredentials {
+        try cache.value(
+            itemModifiedAt: { KeychainItem.modifiedAt(service: service) },
+            reload: { try ClaudeCredentials.read(service: service) }
+        )
+    }
+
+    /// Forget the held copy. Call when the server rejects it: signing into a
+    /// different account replaces the keychain item, and the copy in hand is
+    /// then wrong despite not having expired.
+    func forgetCached() { cache.forget() }
 }

--- a/Sources/Providers/ClaudeCredentials.swift
+++ b/Sources/Providers/ClaudeCredentials.swift
@@ -28,19 +28,39 @@ struct ClaudeCredentials {
     /// `ClaudeKeychain` decides *whether* to read; this is what happens when it
     /// does. Every failure is turned into the status the UI should show, and
     /// the raw OSStatus is logged so "not found" and "refused" stay distinct.
+    ///
+    /// Reads the newest item under this service, rather than asking for "one"
+    /// and trusting the answer. Claude Code files a new item on every token
+    /// rotation instead of updating one in place, so an account used for
+    /// months accumulates several under the same service name. A plain
+    /// `kSecMatchLimitOne` query gives no ordering guarantee across them, and
+    /// the failure it produces is silent: the app reads an old, expired
+    /// duplicate, the ring shows "Waiting for the first reading…" forever, and
+    /// nothing about that message suggests a valid token is sitting right next
+    /// to the one that was picked. `KeychainItem.newest` finds it via
+    /// attributes and a persistent reference, neither of which needs
+    /// authorization to read — only this second, targeted fetch of the
+    /// winner's actual data does, which is why it costs the same single prompt
+    /// as before, per profile.
     static func read(service: String) throws -> ClaudeCredentials {
+        guard let winner = KeychainItem.newest(service: service) else {
+            Log.usage.error("keychain read failed: no item under \(service, privacy: .public)")
+            throw UsageProviderError.needsAuth
+        }
+
         var item: CFTypeRef?
         let status = SecItemCopyMatching([
             kSecClass: kSecClassGenericPassword,
-            kSecAttrService: service,
+            kSecValuePersistentRef: winner.persistentRef,
             kSecReturnData: true,
             kSecMatchLimit: kSecMatchLimitOne
         ] as CFDictionary, &item)
 
         guard status == errSecSuccess, let data = item as? Data else {
-            // The status matters: "not found" means Claude Code has never signed
-            // in, whereas -25308 (interaction not allowed) or -128 (user
-            // cancelled) mean the item is there but this app is not on its
+            // The status matters: "not found" means the item was deleted
+            // between enumeration and this read — Claude Code rotating at the
+            // exact wrong instant — whereas -25308 (interaction not allowed) or
+            // -128 (user cancelled) mean it is there and this app is not on its
             // access list. Those need very different advice, so record which.
             Log.usage.error("keychain read of \(service, privacy: .public) failed: OSStatus \(status) (\(Self.explain(status), privacy: .public))")
             throw Self.wasRefused(status)

--- a/Sources/Providers/ClaudeOAuthProvider.swift
+++ b/Sources/Providers/ClaudeOAuthProvider.swift
@@ -4,13 +4,20 @@ import os
 /// Reads the same usage endpoint Claude Code's own `/usage` uses, with the
 /// OAuth token from the keychain.
 ///
+/// One instance per `ClaudeProfile`: a work login kept under `~/.claude-work`
+/// has its own token, its own limits and its own ring, and this reads exactly
+/// one of them.
+///
 /// The numbers are Anthropic's, so this is `.official` — the tooltip shows them
 /// unqualified. The endpoint is not a published API, though, so every failure
 /// path degrades to a status the UI can render honestly rather than to a guess.
 actor ClaudeOAuthProvider: UsageProvider {
-    nonisolated let id = "claude"
-    nonisolated let displayName = "Claude"
+    nonisolated let profile: ClaudeProfile
+    nonisolated let id: String
+    nonisolated let displayName: String
     nonisolated let glyph = ProviderGlyph.claude
+    /// This profile's token, behind its own cache — see `ClaudeKeychain`.
+    nonisolated private let keychain: ClaudeKeychain
 
     private let endpoint = URL(string: "https://api.anthropic.com/api/oauth/usage")!
     private let session: URLSession
@@ -26,21 +33,27 @@ actor ClaudeOAuthProvider: UsageProvider {
     private var consecutiveRateLimits = 0
 
     private let archive: UsageArchive
-    /// How the OAuth token is obtained. Injected for the same reason `session` is:
-    /// the token path had no tests, which is how a back-off that never expired
-    /// shipped. Production passes `ClaudeCredentials.load`.
+    /// How this profile's token is obtained. Injected for the same reason
+    /// `session` is: the token path had no tests, which is how a back-off that
+    /// never expired shipped. Production reads through this profile's own
+    /// `ClaudeKeychain`; a test substitutes a fake credential source instead.
     private let loadCredentials: @Sendable () throws -> ClaudeCredentials
 
-    init(session: URLSession = .shared,
+    init(profile: ClaudeProfile = .default(),
+         session: URLSession = .shared,
          archive: UsageArchive = UsageArchive(),
-         loadCredentials: @escaping @Sendable () throws -> ClaudeCredentials
-             = ClaudeCredentials.load) {
+         loadCredentials: (@Sendable () throws -> ClaudeCredentials)? = nil) {
+        self.profile = profile
+        self.id = profile.id
+        self.displayName = profile.displayName
+        let keychain = ClaudeKeychain(profile: profile)
+        self.keychain = keychain
+        self.loadCredentials = loadCredentials ?? { try keychain.load() }
         self.session = session
         self.archive = archive
-        self.loadCredentials = loadCredentials
         // Pick the back-off back up where the last run left it, so relaunching
         // during a penalty does not spend an attempt extending it.
-        self.retryNoEarlierThan = archive.loadBackoffUntil()
+        self.retryNoEarlierThan = archive.loadBackoffUntil(providerID: profile.id)
     }
 
     func fetchSnapshot() async throws -> ProviderSnapshot {
@@ -53,7 +66,7 @@ actor ClaudeOAuthProvider: UsageProvider {
             let snapshot = try await fetch(retryingOnUnauthorized: true)
             retryNoEarlierThan = nil
             consecutiveRateLimits = 0
-            archive.saveBackoffUntil(nil)
+            archive.saveBackoffUntil(nil, providerID: id)
             return snapshot
         } catch UsageProviderError.needsAuth {
             // The held copy goes, so the next tick re-reads. Backing off is
@@ -72,7 +85,7 @@ actor ClaudeOAuthProvider: UsageProvider {
             if case .rateLimited(let retryAfter) = error {
                 consecutiveRateLimits += 1
                 retryNoEarlierThan = Date().addingTimeInterval(retryAfter)
-                archive.saveBackoffUntil(retryNoEarlierThan)
+                archive.saveBackoffUntil(retryNoEarlierThan, providerID: id)
                 Log.usage.notice("rate limited (\(self.consecutiveRateLimits)x), next attempt in \(retryAfter, format: .fixed(precision: 0))s")
             }
             throw error
@@ -95,7 +108,7 @@ actor ClaudeOAuthProvider: UsageProvider {
         if status == 401 || status == 403 {
             // Rejected but unexpired: the held copy is wrong, which is what
             // signing into a different account looks like from here.
-            ClaudeCredentials.forgetCached()
+            keychain.forgetCached()
             // The cached token went stale mid-flight; re-read once in case
             // Claude Code has refreshed it since.
             credentials = nil
@@ -132,8 +145,14 @@ actor ClaudeOAuthProvider: UsageProvider {
         if let credentials, !credentials.isExpired {
             return credentials.accessToken
         }
+        // No local back-off lock here — `CredentialCache`, behind `keychain`,
+        // already does this correctly: it waits on the item's modification
+        // date rather than on a clock, so a token Claude Code has just
+        // rotated is picked up at once. A second timer here could only ever
+        // be wrong, and was — it stamped itself on every failed tick, so its
+        // own window never expired and the keychain was never read again.
         let fresh = try loadCredentials()
-        Log.usage.debug("read keychain token, expires \(fresh.expiresAt, privacy: .public)")
+        Log.usage.debug("\(self.id, privacy: .public): read keychain token, expires \(fresh.expiresAt, privacy: .public)")
         // Expired is not signed out. Claude Code rotates this token whenever it
         // runs, and this app deliberately does not — minting one would mean
         // writing a credential it does not own, and racing the owner for it. So
@@ -177,17 +196,21 @@ actor ClaudeOAuthProvider: UsageProvider {
 
     /// Read straight from the keychain item rather than from the cached token,
     /// so the settings row reflects what the next fetch will actually use.
-    nonisolated var signInRoute: SignInRoute { .guidance("Run Claude Code once — it signs in and refreshes the token this "
-                  + "reads. Use /login there to change account.") }
+    nonisolated var signInRoute: SignInRoute {
+        // Names the command for a profile, because that is the only way to
+        // reach it: plain `claude` signs the default one in, not this.
+        .guidance("Run `\(profile.signInCommand)` once — it signs in and refreshes "
+                  + "the token this reads. Use /login there to change account.")
+    }
 
-    nonisolated func forgetCachedCredential() { ClaudeCredentials.forgetCached() }
+    nonisolated func forgetCachedCredential() { keychain.forgetCached() }
 
     nonisolated func account() -> ProviderAccount? {
-        guard let credentials = try? ClaudeCredentials.load() else { return nil }
+        guard let credentials = try? keychain.load() else { return nil }
         return ProviderAccount(
             label: nil,   // the credential carries no address
             plan: credentials.subscriptionType,
-            source: "Claude Code",
+            source: profile.sourceName,
             manageURL: URL(string: "https://claude.ai/settings/usage")
         )
     }

--- a/Sources/Providers/ClaudeOAuthProvider.swift
+++ b/Sources/Providers/ClaudeOAuthProvider.swift
@@ -17,11 +17,6 @@ actor ClaudeOAuthProvider: UsageProvider {
     /// Held between refreshes so the keychain is read once per token, not once
     /// per minute — a keychain read can put a prompt in front of the user.
     private var credentials: ClaudeCredentials?
-    /// When the keychain last refused us. Reading the keychain can put a system
-    /// prompt in front of the user, so a refusal has to back off — otherwise
-    /// every refresh tick would raise the dialog again.
-    private var lastAuthFailure: Date?
-    private let authRetryDelay: TimeInterval = 5 * 60
     /// Set when the endpoint returns 429. Until it passes, refreshes are
     /// skipped without touching the network — a poll that keeps firing into a
     /// rate limit is how you stay rate limited.
@@ -31,10 +26,18 @@ actor ClaudeOAuthProvider: UsageProvider {
     private var consecutiveRateLimits = 0
 
     private let archive: UsageArchive
+    /// How the OAuth token is obtained. Injected for the same reason `session` is:
+    /// the token path had no tests, which is how a back-off that never expired
+    /// shipped. Production passes `ClaudeCredentials.load`.
+    private let loadCredentials: @Sendable () throws -> ClaudeCredentials
 
-    init(session: URLSession = .shared, archive: UsageArchive = UsageArchive()) {
+    init(session: URLSession = .shared,
+         archive: UsageArchive = UsageArchive(),
+         loadCredentials: @escaping @Sendable () throws -> ClaudeCredentials
+             = ClaudeCredentials.load) {
         self.session = session
         self.archive = archive
+        self.loadCredentials = loadCredentials
         // Pick the back-off back up where the last run left it, so relaunching
         // during a penalty does not spend an attempt extending it.
         self.retryNoEarlierThan = archive.loadBackoffUntil()
@@ -48,14 +51,19 @@ actor ClaudeOAuthProvider: UsageProvider {
         }
         do {
             let snapshot = try await fetch(retryingOnUnauthorized: true)
-            lastAuthFailure = nil
             retryNoEarlierThan = nil
             consecutiveRateLimits = 0
             archive.saveBackoffUntil(nil)
             return snapshot
         } catch UsageProviderError.needsAuth {
+            // The held copy goes, so the next tick re-reads. Backing off is
+            // `CredentialCache`'s job and it already does it correctly: it
+            // waits on the item's modification date rather than on a clock, so
+            // a token Claude Code has just rotated is picked up at once. A
+            // second timer here could only ever be wrong — and was: it stamped
+            // itself on every failed tick, so its own window never expired and
+            // the keychain was never read again.
             credentials = nil
-            lastAuthFailure = Date()
             throw UsageProviderError.needsAuth
         } catch UsageProviderError.credentialExpired {
             credentials = nil
@@ -124,10 +132,7 @@ actor ClaudeOAuthProvider: UsageProvider {
         if let credentials, !credentials.isExpired {
             return credentials.accessToken
         }
-        if let lastAuthFailure, Date().timeIntervalSince(lastAuthFailure) < authRetryDelay {
-            throw UsageProviderError.needsAuth
-        }
-        let fresh = try ClaudeCredentials.load()
+        let fresh = try loadCredentials()
         Log.usage.debug("read keychain token, expires \(fresh.expiresAt, privacy: .public)")
         // Expired is not signed out. Claude Code rotates this token whenever it
         // runs, and this app deliberately does not — minting one would mean

--- a/Sources/Providers/ClaudeProfile.swift
+++ b/Sources/Providers/ClaudeProfile.swift
@@ -1,0 +1,151 @@
+import CryptoKit
+import Foundation
+
+/// One Claude Code configuration directory, and so one account.
+///
+/// Claude Code keeps everything for an account under a single directory:
+/// `~/.claude` by default, or wherever `CLAUDE_CONFIG_DIR` points. People who
+/// keep a personal and a work login apart do it by aliasing the second one to
+/// `~/.claude-work`, `~/.claude-client`, and so on — each with its own token in
+/// the keychain and its own `sessions` folder. Reading only `~/.claude` showed
+/// one of those accounts and was blind to the others: a work session never
+/// spun the ring, and the work limit was never drawn at all.
+///
+/// A profile is the *convention* `~/.claude-<slug>`, not the environment
+/// variable: the app is launched from Finder, so the alias's variable never
+/// reaches it, and the directories are the only trace the profiles leave.
+struct ClaudeProfile: Equatable, Hashable {
+    /// The provider id the default profile has always had. Kept so archived
+    /// readings, connection choices and the hover-band keys survive the change.
+    static let defaultID = "claude"
+    /// What every profile directory starts with.
+    static let directoryPrefix = ".claude"
+
+    /// Nil for `~/.claude`; the part after `.claude-` otherwise.
+    let slug: String?
+    let configDirectory: URL
+
+    /// `~/.claude`, whether or not it exists — the app has always read it.
+    static func `default`(home: URL = homeDirectory) -> ClaudeProfile {
+        ClaudeProfile(slug: nil,
+                      configDirectory: home.appendingPathComponent(directoryPrefix))
+    }
+
+    static var homeDirectory: URL { URL(fileURLWithPath: NSHomeDirectory()) }
+
+    /// The default profile followed by every `~/.claude-<slug>` that Claude
+    /// Code has actually used, slugs in alphabetical order so the rings never
+    /// swap places between launches.
+    ///
+    /// "Actually used" is judged by the files Claude Code writes on its first
+    /// run — an empty directory, or a stray one someone made by hand, would
+    /// otherwise put a permanent "sign in" ring in the notch for an account
+    /// that does not exist.
+    static func discover(home: URL = homeDirectory,
+                         fileManager: FileManager = .default) -> [ClaudeProfile] {
+        let names = (try? fileManager.contentsOfDirectory(atPath: home.path)) ?? []
+        let extras = names.compactMap { name -> ClaudeProfile? in
+            guard let slug = slug(fromDirectoryName: name) else { return nil }
+            let directory = home.appendingPathComponent(name)
+            guard isProfileDirectory(directory, fileManager: fileManager) else { return nil }
+            return ClaudeProfile(slug: slug, configDirectory: directory)
+        }
+        return [ClaudeProfile.default(home: home)]
+            + extras.sorted { $0.slug! < $1.slug! }
+    }
+
+    /// `.claude-work` → `work`; anything else → nil. The bare `.claude` is the
+    /// default and is handled separately; `.claude.json` is a file that lives
+    /// beside it and is not a profile at all.
+    static func slug(fromDirectoryName name: String) -> String? {
+        let prefix = directoryPrefix + "-"
+        guard name.hasPrefix(prefix) else { return nil }
+        let slug = String(name.dropFirst(prefix.count))
+        return slug.isEmpty ? nil : slug
+    }
+
+    /// Any of the files Claude Code creates the first time it runs against a
+    /// directory. One is enough: they are not all present on every version.
+    private static let markers = ["sessions", "projects", "settings.json",
+                                  "history.jsonl", ".claude.json"]
+
+    static func isProfileDirectory(_ url: URL, fileManager: FileManager = .default) -> Bool {
+        var isDirectory: ObjCBool = false
+        guard fileManager.fileExists(atPath: url.path, isDirectory: &isDirectory),
+              isDirectory.boolValue else { return false }
+        return markers.contains {
+            fileManager.fileExists(atPath: url.appendingPathComponent($0).path)
+        }
+    }
+
+    // MARK: - Identity
+
+    /// `claude` for the default, `claude-<slug>` for the rest. Doubles as the
+    /// usage provider id and the activity monitor key, so a profile's sessions
+    /// land in its own ring.
+    var id: String { slug.map { "\(Self.defaultID)-\($0)" } ?? Self.defaultID }
+
+    /// `Claude`, or `Claude (work)`. The cell draws the same glyph for every
+    /// profile; this is what tells them apart in the tooltip and in Settings.
+    var displayName: String { slug.map { "Claude (\($0))" } ?? "Claude" }
+
+    /// Whether a provider id names a Claude profile, default or otherwise.
+    static func isClaude(providerID: String) -> Bool {
+        providerID == defaultID || providerID.hasPrefix(defaultID + "-")
+    }
+
+    /// The slug back out of a provider id, for code that only has the id.
+    static func slug(fromProviderID id: String) -> String? {
+        guard id.hasPrefix(defaultID + "-") else { return nil }
+        let slug = String(id.dropFirst(defaultID.count + 1))
+        return slug.isEmpty ? nil : slug
+    }
+
+    /// The directory as a person would type it.
+    var displayPath: String {
+        Self.tilde(configDirectory.path)
+    }
+
+    static func tilde(_ path: String) -> String {
+        let home = NSHomeDirectory()
+        guard path.hasPrefix(home + "/") else { return path }
+        return "~" + path.dropFirst(home.count)
+    }
+
+    // MARK: - What Claude Code keeps where
+
+    /// Where Claude Code writes one file per running process.
+    var sessionsDirectory: URL { configDirectory.appendingPathComponent("sessions") }
+
+    /// The keychain service the OAuth token is filed under.
+    ///
+    /// The default directory uses the bare name. Any other `CLAUDE_CONFIG_DIR`
+    /// gets a suffix so two profiles cannot overwrite each other's token: the
+    /// first eight hex digits of the SHA-256 of the directory's absolute path,
+    /// no trailing slash. That is Claude Code's rule, not ours — it is what
+    /// makes `Claude Code-credentials-1c731050` findable at all.
+    var keychainService: String {
+        guard slug != nil else { return Self.defaultKeychainService }
+        return "\(Self.defaultKeychainService)-\(Self.keychainSuffix(forPath: configDirectory.path))"
+    }
+
+    static let defaultKeychainService = "Claude Code-credentials"
+
+    static func keychainSuffix(forPath path: String) -> String {
+        let digest = SHA256.hash(data: Data(path.utf8))
+        return digest.map { String(format: "%02x", $0) }.joined().prefix(8).description
+    }
+
+    // MARK: - Copy
+
+    /// Which tool the credential is borrowed from, said so that two Claude rows
+    /// in Settings can be told apart.
+    var sourceName: String {
+        slug == nil ? "Claude Code" : "Claude Code in \(displayPath)"
+    }
+
+    /// The command that signs this profile in, for the row that has no button.
+    var signInCommand: String {
+        slug == nil ? "claude" : "CLAUDE_CONFIG_DIR=\(displayPath) claude"
+    }
+}

--- a/Sources/Providers/CodexLocalProvider.swift
+++ b/Sources/Providers/CodexLocalProvider.swift
@@ -37,21 +37,35 @@ actor CodexLocalProvider: UsageProvider {
             )
         }
 
-        guard let rollout = CodexStore.newestRollout(in: stateStore) else {
+        let rollouts = CodexStore.recentRollouts(in: stateStore)
+        guard !rollouts.isEmpty else {
             throw UsageProviderError.nothingMetered("No Codex threads on this machine yet")
         }
-        let text = try tail(of: rollout)
-        let windows = try CodexUsage.windows(fromRollout: text)
-
-        return ProviderSnapshot(
-            id: id,
-            displayName: displayName,
-            glyph: glyph,
-            fidelity: .official,
-            status: Self.status(recordedAt: CodexUsage.recordedAt(inRollout: text)),
-            windows: windows,
-            headlineID: "primary"
-        )
+        // The newest thread wins — unless it carries nothing usable. Newer
+        // builds can record a `premium`-typed snapshot with null windows, in
+        // which case the previous thread's percentages are still the truest
+        // thing Codex wrote down. First rollout with windows wins; its own
+        // timestamp decides staleness.
+        for rollout in rollouts {
+            let text: String
+            do {
+                text = try tail(of: rollout)
+            } catch {
+                continue
+            }
+            guard let windows = try? CodexUsage.windows(fromRollout: text),
+                  !windows.isEmpty else { continue }
+            return ProviderSnapshot(
+                id: id,
+                displayName: displayName,
+                glyph: glyph,
+                fidelity: .official,
+                status: Self.status(recordedAt: CodexUsage.recordedAt(inRollout: text)),
+                windows: windows,
+                headlineID: "primary"
+            )
+        }
+        throw UsageProviderError.nothingMetered("Codex reported no usage windows")
     }
 
     /// Ask Codex's app server for the live figure.
@@ -156,15 +170,24 @@ enum CodexStore {
 
     /// The rollout of the most recently touched thread.
     static func newestRollout(in store: URL) -> URL? {
-        guard let db = SQLiteStore.open(store) else { return nil }
+        recentRollouts(in: store).first
+    }
+
+    /// Recent rollouts, newest first. The usage read walks this list and takes
+    /// the first one carrying usable windows, so a new-format snapshot with
+    /// null windows does not hide an older thread's real percentages.
+    /// The activity monitor still uses only the first entry: recency of writes
+    /// is what it measures, not what the writes contain.
+    static func recentRollouts(in store: URL, limit: Int = 8) -> [URL] {
+        guard let db = SQLiteStore.open(store) else { return [] }
         defer { sqlite3_close(db) }
 
         let paths = SQLiteStore.rows(
             in: db,
-            sql: "SELECT rollout_path FROM threads WHERE archived = 0 ORDER BY updated_at_ms DESC LIMIT 8"
+            sql: "SELECT rollout_path FROM threads WHERE archived = 0 ORDER BY updated_at_ms DESC LIMIT \(limit)"
         )
         return paths
             .map { URL(fileURLWithPath: ($0 as NSString).expandingTildeInPath) }
-            .first { FileManager.default.fileExists(atPath: $0.path) }
+            .filter { FileManager.default.fileExists(atPath: $0.path) }
     }
 }

--- a/Sources/Providers/CodexLocalProvider.swift
+++ b/Sources/Providers/CodexLocalProvider.swift
@@ -44,8 +44,8 @@ actor CodexLocalProvider: UsageProvider {
         // The newest thread wins — unless it carries nothing usable. Newer
         // builds can record a `premium`-typed snapshot with null windows, in
         // which case the previous thread's percentages are still the truest
-        // thing Codex wrote down. First rollout with windows wins; its own
-        // timestamp decides staleness.
+        // thing Codex wrote down. First rollout with *current* windows wins;
+        // its own timestamp decides staleness.
         for rollout in rollouts {
             let text: String
             do {
@@ -55,17 +55,32 @@ actor CodexLocalProvider: UsageProvider {
             }
             guard let windows = try? CodexUsage.windows(fromRollout: text),
                   !windows.isEmpty else { continue }
+            let current = Self.current(windows)
+            guard !current.isEmpty else { continue }
             return ProviderSnapshot(
                 id: id,
                 displayName: displayName,
                 glyph: glyph,
                 fidelity: .official,
                 status: Self.status(recordedAt: CodexUsage.recordedAt(inRollout: text)),
-                windows: windows,
+                windows: current,
                 headlineID: "primary"
             )
         }
-        throw UsageProviderError.nothingMetered("Codex reported no usage windows")
+        throw UsageProviderError.nothingMetered("Codex hasn't recorded current usage yet")
+    }
+
+    /// Windows from a rollout that still measure the present.
+    ///
+    /// A file is a record of what was true during the last turn, and a window
+    /// whose reset has passed no longer exists — its old percentage is false
+    /// rather than merely old. Showing a three-day-old 0% on a 5h window next
+    /// to a Codex that just refused a prompt is exactly how a correct reading
+    /// looks wrong. Windows with no reset carry no expiry to judge and are
+    /// kept. Live answers never pass through here: they are current by
+    /// construction.
+    static func current(_ windows: [LimitWindow], now: Date = Date()) -> [LimitWindow] {
+        windows.filter { $0.resetsAt.map { $0 > now } ?? true }
     }
 
     /// Ask Codex's app server for the live figure.

--- a/Sources/Providers/CursorCredentials.swift
+++ b/Sources/Providers/CursorCredentials.swift
@@ -19,6 +19,12 @@ struct CursorCredentials {
             .appendingPathComponent("Library/Application Support/Cursor/User/globalStorage/state.vscdb")
     }
 
+    /// Minted by ToDesktop, who build Cursor — stable across updates, but not
+    /// across Cursor leaving ToDesktop or rebranding. Kept here beside the store
+    /// path so the two facts about a Cursor installation change together: the
+    /// activity monitor and the sign-in route both read this one.
+    static let bundleID = "com.todesktop.230313mzl4w4u92"
+
     /// Identity, read from the same store as the session. Non-secret: the email
     /// and plan the editor caches for its own UI.
     static func account(from url: URL = storeURL) -> ProviderAccount? {

--- a/Sources/Providers/CursorLocalProvider.swift
+++ b/Sources/Providers/CursorLocalProvider.swift
@@ -20,7 +20,7 @@ actor CursorLocalProvider: UsageProvider {
         self.session = session
     }
 
-    nonisolated var signInRoute: SignInRoute { .openApp(bundleID: "com.todesktop.230313mzl4w4u92", name: "Cursor") }
+    nonisolated var signInRoute: SignInRoute { .openApp(bundleID: CursorCredentials.bundleID, name: "Cursor") }
 
     nonisolated func account() -> ProviderAccount? { CursorCredentials.account() }
 

--- a/Sources/Providers/GLMCredentials.swift
+++ b/Sources/Providers/GLMCredentials.swift
@@ -1,0 +1,193 @@
+import Foundation
+
+/// The Z.ai key behind a GLM Coding Plan, borrowed from whichever tool holds
+/// it.
+///
+/// Z.ai does not ship a desktop app for the plan, so there is no single
+/// session to borrow the way Claude Code's or Cursor's is borrowed. What it
+/// has is an API key that several coding tools will hold on the user's behalf,
+/// and a notch that wants to read one of them rather than ask for a key of its
+/// own. The sources, in the order they are tried:
+///
+/// 1. **Claude Code** — `~/.claude/settings.json`, the documented way to point
+///    Claude Code at the plan. Only claimed when the base URL alongside the
+///    token is a Z.ai one: `ANTHROPIC_AUTH_TOKEN` aimed at api.anthropic.com
+///    is somebody's Anthropic key, and claiming it would read the wrong
+///    account and report it under GLM's name.
+/// 2. **ZCode** — two files. `~/.zcode/v2/config.json` is where a plan key is
+///    pasted in directly: an enabled `builtin:*-coding-plan` entry with a
+///    plaintext `apiKey`, and the `baseURL` beside it says which console the
+///    key belongs to. `~/.zcode/v2/credentials.json` holds the token from
+///    signing into the plan through the app instead; recent builds encrypt it
+///    at rest behind an `enc:v1:` marker, and those are skipped rather than
+///    guessed at — decrypting them is ZCode's business, and a wrong guess
+///    would read as a signed-out plan.
+/// 3. **OpenCode** — `~/.local/share/opencode/auth.json`, keyed under a
+///    handful of provider names for the global (`z.ai`) and China
+///    (`bigmodel.cn`) consoles.
+enum GLMCredentials {
+    struct Credential {
+        let token: String
+        /// The console this key belongs to — it decides the monitor host the
+        /// usage is read from. A China-console key asked of api.z.ai answers
+        /// as an auth failure, which would read as a signed-out plan that is
+        /// merely pointed at the other country.
+        let baseURL: URL
+        /// The tool the key was found under, for the settings row.
+        let source: String
+    }
+
+    static var claudeSettingsURL: URL {
+        URL(fileURLWithPath: NSHomeDirectory()).appendingPathComponent(".claude/settings.json")
+    }
+    static var zcodeConfigURL: URL {
+        URL(fileURLWithPath: NSHomeDirectory()).appendingPathComponent(".zcode/v2/config.json")
+    }
+    static var zcodeCredentialsURL: URL {
+        URL(fileURLWithPath: NSHomeDirectory()).appendingPathComponent(".zcode/v2/credentials.json")
+    }
+    static var openCodeAuthURL: URL {
+        URL(fileURLWithPath: NSHomeDirectory())
+            .appendingPathComponent(".local/share/opencode/auth.json")
+    }
+
+    static func load() -> Credential? {
+        load(claudeSettings: claudeSettingsURL,
+             zcodeConfig: zcodeConfigURL,
+             zcodeCredentials: zcodeCredentialsURL,
+             openCodeAuth: openCodeAuthURL)
+    }
+
+    /// Every path is a parameter so a test can point each source at its own
+    /// fixture without touching a real one. A nil path simply drops that
+    /// source.
+    static func load(claudeSettings: URL?, zcodeConfig: URL?,
+                     zcodeCredentials: URL?, openCodeAuth: URL?) -> Credential? {
+        claudeSettings.flatMap(claudeCode)
+            ?? zcodeConfig.flatMap(zcodePlanKey)
+            ?? zcodeCredentials.flatMap(zcode)
+            ?? openCodeAuth.flatMap(openCode)
+    }
+
+    // MARK: Claude Code
+
+    /// `~/.claude/settings.json` → `env.ANTHROPIC_AUTH_TOKEN` plus
+    /// `env.ANTHROPIC_BASE_URL`.
+    static func claudeCode(_ url: URL) -> Credential? {
+        guard let root = dictionary(at: url), let env = root["env"] as? [String: Any],
+              let token = string(env["ANTHROPIC_AUTH_TOKEN"]) ?? string(env["ANTHROPIC_API_KEY"])
+        else { return nil }
+
+        // The base URL is what makes this a GLM key. Without it, or pointed
+        // somewhere else, the token is not ours to claim.
+        guard let base = string(env["ANTHROPIC_BASE_URL"]),
+              let url = URL(string: base),
+              let host = url.host,
+              isZaiHost(host)
+        else { return nil }
+
+        return Credential(token: token, baseURL: consoleBase(from: host), source: "Claude Code")
+    }
+
+    // MARK: ZCode
+
+    static let encryptedMarker = "enc:v1:"
+
+    /// `~/.zcode/v2/config.json` → an enabled `builtin:*-coding-plan` provider
+    /// with the plan key pasted in. The `baseURL` beside it is the tool's own
+    /// Anthropic endpoint — its *host* decides which console the usage is read
+    /// from, the path is dropped: the monitor lives at the console root, and
+    /// asking it under `/api/anthropic` answers a misleading 404.
+    static func zcodePlanKey(_ url: URL) -> Credential? {
+        guard let root = dictionary(at: url), let providers = root["provider"] as? [String: Any]
+        else { return nil }
+
+        for (id, value) in providers.sorted(by: { $0.key < $1.key }) {
+            guard id.contains("coding-plan"), let provider = value as? [String: Any],
+                  let options = provider["options"] as? [String: Any],
+                  let key = string(options["apiKey"])
+            else { continue }
+            // Explicitly disabled entries are not keys being used; claiming
+            // one would read an account the user switched off.
+            if let enabled = provider["enabled"] as? Bool, !enabled { continue }
+            let console = (string(options["baseURL"]))
+                .flatMap { URL(string: $0) }
+                .flatMap { $0.host }
+                .map(consoleBase(from:)) ?? URL(string: "https://api.z.ai")!
+            return Credential(token: key, baseURL: console, source: "ZCode")
+        }
+        return nil
+    }
+
+    static func zcode(_ url: URL) -> Credential? {
+        guard let root = dictionary(at: url),
+              let token = string(root["oauth:zai:access_token"])
+        else { return nil }
+
+        // Encrypted at rest: a string we cannot read is a string we must not
+        // send. Skipping the source means "not found", which the row reports
+        // honestly, rather than a 401 from the monitor that means nothing.
+        guard !token.hasPrefix(encryptedMarker) else { return nil }
+
+        return Credential(token: token, baseURL: URL(string: "https://api.z.ai")!, source: "ZCode")
+    }
+
+    // MARK: OpenCode
+
+    /// The provider names OpenCode's own sign-in writes, most specific first.
+    private static let openCodeProviderIDs = ["zai-coding-plan", "zai", "z-ai", "z.ai", "zhipu", "zhipuai"]
+
+    static func openCode(_ url: URL) -> Credential? {
+        guard let root = dictionary(at: url) else { return nil }
+        for id in openCodeProviderIDs {
+            guard let entry = root[id] else { continue }
+            // The entry is either the key itself or an object carrying it —
+            // both shapes have shipped.
+            if let token = string(entry) {
+                return Credential(token: token, baseURL: console(forProviderID: id), source: "OpenCode")
+            }
+            if let object = entry as? [String: Any] {
+                let key = ["apiKey", "api_key", "token", "key", "accessToken", "auth_token"]
+                    .compactMap { string(object[$0]) }.first
+                if let key {
+                    return Credential(token: key, baseURL: console(forProviderID: id), source: "OpenCode")
+                }
+            }
+        }
+        return nil
+    }
+
+    /// The provider id decides the console: the `zhipu` names sign into the
+    /// China console, everything else the global one.
+    static func console(forProviderID id: String) -> URL {
+        id.hasPrefix("zhipu")
+            ? URL(string: "https://open.bigmodel.cn")!
+            : URL(string: "https://api.z.ai")!
+    }
+
+    // MARK: Shared
+
+    static func isZaiHost(_ host: String) -> Bool {
+        host == "api.z.ai" || host.hasSuffix(".z.ai")
+            || host == "open.bigmodel.cn" || host.hasSuffix(".bigmodel.cn")
+    }
+
+    static func consoleBase(from host: String) -> URL {
+        host.hasSuffix("bigmodel.cn")
+            ? URL(string: "https://open.bigmodel.cn")!
+            : URL(string: "https://api.z.ai")!
+    }
+
+    private static func dictionary(at url: URL) -> [String: Any]? {
+        guard let data = try? Data(contentsOf: url),
+              let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else { return nil }
+        return root
+    }
+
+    /// Non-empty strings only: an empty key is worse than a missing one, it is
+    /// a request that cannot succeed being sent all the same.
+    private static func string(_ value: Any?) -> String? {
+        (value as? String).flatMap { $0.isEmpty ? nil : $0 }
+    }
+}

--- a/Sources/Providers/GLMProvider.swift
+++ b/Sources/Providers/GLMProvider.swift
@@ -1,0 +1,156 @@
+import Foundation
+import os
+
+/// Reads GLM Coding Plan usage from Z.ai's own monitor endpoint, with the key
+/// one of the coding tools already holds — see `GLMCredentials` for whose.
+///
+/// The numbers are Z.ai's, so this is `.official`. The endpoint is not a
+/// published API, though, and it is known to throttle — so like Claude's, every
+/// failure degrades to a status the UI can render honestly, and a 429 backs off
+/// on a schedule that outlives the process rather than polling into the limit.
+actor GLMProvider: UsageProvider {
+    nonisolated let id = "glm"
+    nonisolated let displayName = "GLM"
+    nonisolated let glyph = ProviderGlyph.glm
+
+    private let session: URLSession
+    private let archive: UsageArchive
+    /// Set when the endpoint returns 429. Until it passes, refreshes are
+    /// skipped without touching the network — the same bargain Claude's makes.
+    private var retryNoEarlierThan: Date?
+    private var consecutiveRateLimits = 0
+
+    /// The plan level the last successful answer named, for the settings row.
+    /// Kept here rather than re-derived: it is a fact about the account, not
+    /// about this fetch. `nonisolated(unsafe)` because `account()` reads it
+    /// off the actor; the worst a race can do is show the previous level for
+    /// one row-draw.
+    nonisolated(unsafe) private var lastKnownPlan: String?
+
+    init(session: URLSession = .shared, archive: UsageArchive = UsageArchive()) {
+        self.session = session
+        self.archive = archive
+        self.retryNoEarlierThan = archive.loadBackoffUntil(providerID: id)
+    }
+
+    nonisolated var signInRoute: SignInRoute {
+        .guidance("Usage rides on a Z.ai GLM Coding Plan key held by a coding tool — Claude "
+                  + "Code's settings.json, ZCode or OpenCode. Set one up there and the notch reads it.")
+    }
+
+    nonisolated func forgetCachedCredential() {
+        // Nothing is cached: the key is re-read from disk on every fetch,
+        // which is prompt-free, unlike a keychain read.
+    }
+
+    nonisolated func account() -> ProviderAccount? {
+        guard let credentials = GLMCredentials.load() else { return nil }
+        return ProviderAccount(
+            label: nil,   // none of the borrowed keys carries an address
+            plan: lastKnownPlan,
+            source: credentials.source,
+            manageURL: credentials.baseURL.host == "open.bigmodel.cn"
+                ? URL(string: "https://open.bigmodel.cn/usage")
+                : URL(string: "https://z.ai/manage-apikey/apikey-list")
+        )
+    }
+
+    func fetchSnapshot() async throws -> ProviderSnapshot {
+        if let retryNoEarlierThan, retryNoEarlierThan > Date() {
+            let remaining = retryNoEarlierThan.timeIntervalSinceNow
+            Log.usage.debug("glm: skipping fetch, backing off for \(remaining, format: .fixed(precision: 0))s")
+            throw UsageProviderError.rateLimited(retryAfter: remaining)
+        }
+
+        // Re-read on every fetch. These are ordinary files, not keychain items:
+        // reading them puts no prompt in front of anyone, which is why this
+        // provider needs none of Claude's credential caching.
+        guard let credentials = GLMCredentials.load() else {
+            throw UsageProviderError.needsAuth
+        }
+
+        do {
+            let data = try await fetch(credentials: credentials)
+            let payload = try GLMUsage.parse(data)
+
+            consecutiveRateLimits = 0
+            retryNoEarlierThan = nil
+            archive.saveBackoffUntil(nil, providerID: id)
+            lastKnownPlan = payload.level
+
+            return ProviderSnapshot(
+                id: id,
+                displayName: displayName,
+                glyph: glyph,
+                fidelity: .official,
+                status: .ok,
+                windows: payload.windows,
+                headlineID: "session"
+            )
+        } catch UsageProviderError.rateLimited(let retryAfter) {
+            // Bookkeeping where the answer was, not down in `fetch`: the wait
+            // has to outlive the request that earned it.
+            consecutiveRateLimits += 1
+            retryNoEarlierThan = Date().addingTimeInterval(retryAfter)
+            archive.saveBackoffUntil(retryNoEarlierThan, providerID: id)
+            Log.usage.notice("glm: rate limited (\(self.consecutiveRateLimits)x), next attempt in \(retryAfter, format: .fixed(precision: 0))s")
+            throw UsageProviderError.rateLimited(retryAfter: retryAfter)
+        }
+    }
+
+    private func fetch(credentials: GLMCredentials.Credential) async throws -> Data {
+        let url = credentials.baseURL.appendingPathComponent("api/monitor/usage/quota/limit")
+        var request = URLRequest(url: url)
+        // The monitor takes the key raw — no "Bearer" scheme. Prefixing it is
+        // exactly what an auth failure looks like from here.
+        request.setValue(credentials.token, forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.timeoutInterval = 15
+
+        Log.usage.debug("GET \(url.host ?? "", privacy: .public)/api/monitor/usage/quota/limit")
+        let (data, response) = try await session.data(for: request)
+        let status = (response as? HTTPURLResponse)?.statusCode ?? 0
+        Log.usage.debug("quota endpoint answered \(status)")
+
+        if status == 401 || status == 403 { throw UsageProviderError.needsAuth }
+        if status == 429 {
+            throw UsageProviderError.rateLimited(
+                retryAfter: Self.backoff(
+                    forAttempt: consecutiveRateLimits,
+                    retryAfter: Self.retryAfter(from: response)
+                )
+            )
+        }
+        guard (200..<300).contains(status) else {
+            throw UsageProviderError.badResponse(status: status)
+        }
+        return data
+    }
+
+    /// How long to wait after a 429 — a minute, doubling per consecutive
+    /// limit, capped so it always recovers on its own. The server's own hint
+    /// is honoured only as a floor-raiser, for the reason Claude's records.
+    static func backoff(forAttempt attempt: Int, retryAfter: TimeInterval?) -> TimeInterval {
+        let floor: TimeInterval = 60
+        let ceiling: TimeInterval = 15 * 60
+        let doubled = floor * pow(2, Double(min(attempt, 4)))
+        return min(ceiling, max(doubled, retryAfter ?? 0))
+    }
+
+    /// `Retry-After` is either a number of seconds or an HTTP date.
+    static func retryAfter(from response: URLResponse?) -> TimeInterval? {
+        guard let header = (response as? HTTPURLResponse)?
+            .value(forHTTPHeaderField: "Retry-After")?
+            .trimmingCharacters(in: .whitespaces)
+        else { return nil }
+
+        if let seconds = TimeInterval(header) { return max(0, seconds) }
+
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(identifier: "GMT")
+        formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
+        guard let date = formatter.date(from: header) else { return nil }
+        return max(0, date.timeIntervalSinceNow)
+    }
+}

--- a/Sources/Providers/GLMUsage.swift
+++ b/Sources/Providers/GLMUsage.swift
@@ -1,0 +1,166 @@
+import Foundation
+
+/// Parses the answer from Z.ai's own usage monitor,
+/// `GET /api/monitor/usage/quota/limit`.
+///
+/// The Coding Plan does not meter tokens the way Anthropic meters prompts — it
+/// reports three separate allowances in one response, and the window each
+/// token limit belongs to is encoded rather than named:
+///
+/// ```json
+/// { "code": 200, "success": true,
+///   "data": { "level": "pro",
+///     "limits": [
+///       { "type": "TOKENS_LIMIT", "unit": 3, "number": 5,
+///         "percentage": 12.5, "currentValue": 1250000, "usage": 12000000,
+///         "nextResetTime": 1788682200000 },
+///       { "type": "TOKENS_LIMIT", "unit": 6, "number": 1,
+///         "percentage": 8.1, "nextResetTime": 1789190400000 },
+///       { "type": "TIME_LIMIT", "percentage": 4.0,
+///         "currentValue": 40, "usage": 1000 } ] } }
+/// ```
+///
+/// `unit`/`number` pair up as (hours, 5) for the rolling session and
+/// (weeks, 1) for the weekly allowance; `TIME_LIMIT` is the monthly MCP call
+/// budget. What is being metered inside a window varies by plan — token plans
+/// answer `TOKENS_LIMIT`, credit plans `CREDIT_LIMIT` — and both pair the
+/// window length with the same `unit`/`number`, so it is the length the
+/// identity is built from, not the meter. The shape is pinned by tests,
+/// including a response recorded from a live credit plan: the endpoint is not
+/// a published API, and this is the first place a change would show.
+///
+/// Two things about this endpoint differ from the others here, and both are
+/// load-bearing. Errors ride in under an HTTP 200 — `{ "code": 401, "success":
+/// false }` is what an expired token looks like on the wire — so the envelope
+/// is read before the payload is trusted. And the MCP row never carries a
+/// reset time, so unlike Claude's windows a row is not dropped for lacking
+/// one; a percentage with no countdown is still a reading.
+enum GLMUsage {
+    struct Payload {
+        /// The plan's own name for itself, lowercase — "pro", "max". Nil when
+        /// the response declines to say.
+        let level: String?
+        let windows: [LimitWindow]
+    }
+
+    /// The envelope plus payload shape.
+    struct Response: Decodable {
+        struct Limit: Decodable {
+            let type: String?
+            let unit: Int?
+            let number: Int?
+            let percentage: Double?
+            let currentValue: Double?
+            let usage: Double?
+            let total: Double?
+            /// Milliseconds since the epoch, not seconds — the one unit this
+            /// API shares with JavaScript rather than with Unix.
+            let nextResetTime: Double?
+        }
+        struct Data: Decodable {
+            let level: String?
+            let limits: [Limit]?
+        }
+
+        let code: Int?
+        let success: Bool?
+        let msg: String?
+        let data: Data?
+    }
+
+    /// True only when the envelope says the request itself succeeded.
+    static func succeeded(_ response: Response) -> Bool {
+        (response.success ?? false) || response.code == nil || response.code == 200
+    }
+
+    /// The failure the envelope describes, if it describes one.
+    static func failure(in response: Response) -> UsageProviderError? {
+        guard !succeeded(response) else { return nil }
+        switch response.code {
+        case 401, 403: return .needsAuth
+        case 429:      return .rateLimited(retryAfter: 0)
+        case .some(let code): return .badResponse(status: code)
+        case nil:      return .badResponse(status: 200)
+        }
+    }
+
+    static func parse(_ data: Data) throws -> Payload {
+        let response = try JSONDecoder().decode(Response.self, from: data)
+        if let failure = failure(in: response) { throw failure }
+        return Payload(level: response.data?.level,
+                       windows: windows(in: response.data?.limits ?? []))
+    }
+
+    /// Turns the limits array into limit windows, session first.
+    static func windows(in limits: [Response.Limit]) -> [LimitWindow] {
+        limits.compactMap { window(for: $0) }.sorted(by: Self.displayOrder)
+    }
+
+    private static func window(for limit: Response.Limit) -> LimitWindow? {
+        // Without a percentage there is nothing to draw: a bare count from an
+        // unnamed allowance would be a reading we invented a scale for.
+        guard let percentage = limit.percentage else { return nil }
+
+        return LimitWindow(
+            id: Self.id(for: limit),
+            label: Self.label(for: limit),
+            usedFraction: percentage / 100,
+            resetsAt: limit.nextResetTime.map { Date(timeIntervalSince1970: $0 / 1000) }
+        )
+    }
+
+    /// Which window this is, encoded in `unit`/`number`.
+    ///
+    /// (hours, 5) is the rolling session — the Coding Plan's "next 5-hour
+    /// cycle" — and (weeks, 1) the weekly allowance. The *type* token is
+    /// deliberately not part of the identity: token plans answer
+    /// `TOKENS_LIMIT`, credit plans answer `CREDIT_LIMIT`, and both encode the
+    /// window length the same way. `TIME_LIMIT` is the monthly MCP budget and
+    /// carries no unit/number at all.
+    static func id(for limit: Response.Limit) -> String {
+        switch limit.type {
+        case "TIME_LIMIT":
+            return "mcp"
+        default:
+            switch (limit.unit, limit.number) {
+            case (3?, 5?):    return "session"
+            case (6?, 1?):    return "weekly"
+            case (.some(let unit), .some(let number)):
+                return "window-\(unit)x\(number)"
+            default:
+                return limit.type?.lowercased() ?? "unknown"
+            }
+        }
+    }
+
+    /// The frame's wording, for the windows it knows.
+    static func label(for limit: Response.Limit) -> String {
+        switch id(for: limit) {
+        case "session": return "Current session"
+        case "weekly":  return "Weekly"
+        case "mcp":     return "MCP (1 month)"
+        case let id     where id.hasPrefix("window-"):
+            switch (limit.unit, limit.number) {
+            case (3?, .some(let number)): return "Usage (\(number) h)"
+            case (6?, .some(let number)): return "Usage (\(number) wk)"
+            default:                      return "Usage"
+            }
+        default:        return "Usage"
+        }
+    }
+
+    /// Session first, then weekly, then MCP — the order the plan's own panel
+    /// leads with.
+    private static func displayOrder(_ a: LimitWindow, _ b: LimitWindow) -> Bool {
+        func rank(_ id: String) -> Int {
+            switch id {
+            case "session": return 0
+            case "weekly":  return 1
+            case "mcp":     return 2
+            default:        return 3
+            }
+        }
+        let (ra, rb) = (rank(a.id), rank(b.id))
+        return ra == rb ? a.id < b.id : ra < rb
+    }
+}

--- a/Sources/Providers/GlyphOutline.swift
+++ b/Sources/Providers/GlyphOutline.swift
@@ -393,4 +393,20 @@ enum GlyphOutline {
         ]
     ]
 
+    /// The Z.ai mark: the plan's own logo is a sharp geometric Z, so unlike
+    /// the traced marks above this one is defined rather than traced — ten
+    /// vertices in the unit box, exact at any size, in the spirit of
+    /// `cursor` being flattened from its source SVG.
+    ///
+    /// One loop, no counters, so the even-odd fill that keeps the OpenAI knot
+    /// open is a plain solid here. The diagonal's horizontal extent matches
+    /// the bar depths (0.2 top and bottom) so the stroke reads at one weight.
+    static let glm: [[CGPoint]] = [
+        [CGPoint(x: 0.0200, y: 0.0000), CGPoint(x: 0.9800, y: 0.0000),
+         CGPoint(x: 0.9800, y: 0.1850), CGPoint(x: 0.3180, y: 0.8000),
+         CGPoint(x: 0.9800, y: 0.8000), CGPoint(x: 0.9800, y: 1.0000),
+         CGPoint(x: 0.0200, y: 1.0000), CGPoint(x: 0.0200, y: 0.8150),
+         CGPoint(x: 0.6820, y: 0.2000), CGPoint(x: 0.0200, y: 0.2000)]
+    ]
+
 }

--- a/Sources/Providers/KeychainItem.swift
+++ b/Sources/Providers/KeychainItem.swift
@@ -12,22 +12,72 @@ import Security
 /// That is what makes it worth asking often. The expensive read — the one that
 /// can interrupt someone — then only has to happen when this says the item has
 /// actually changed.
+///
+/// It is also what makes duplicates safe to resolve without a prompt. Claude
+/// Code files a new keychain item on every token rotation rather than
+/// updating one in place, so a login that has been used for months
+/// accumulates several under the same service name — six, on the machine this
+/// was found on. `kSecMatchLimitOne` gives no ordering guarantee across them,
+/// so a plain query can return an old, expired duplicate while a valid one
+/// sits beside it: the app reads a token that expired days ago, `security
+/// find-generic-password` run at the same moment returns a different and
+/// current one. `kSecMatchLimitAll` against attributes enumerates every
+/// duplicate for free, so the newest is found by comparison rather than luck.
 enum KeychainItem {
-    /// When the owning app last wrote this item, or nil if there is no such
-    /// item or macOS declined to say.
-    static func modifiedAt(service: String, account: String? = nil) -> Date? {
+    /// One matching item, without its secret: when the owning app last wrote
+    /// it, and a handle that can fetch its data later without searching again.
+    struct Match {
+        let modifiedAt: Date?
+        /// Opaque to everything but `SecItemCopyMatching`. Reading the item
+        /// this points at is the one call that can prompt; enumerating to find
+        /// it, like reading `modifiedAt`, never does.
+        let persistentRef: Data
+    }
+
+    /// The most recently modified item under a service, or nil if there is
+    /// none or macOS declined to say. Ties do not arise in practice —
+    /// `kSecAttrModificationDate` is a timestamp, not a version counter — and
+    /// where they would, either duplicate is an equally good answer.
+    static func newest(service: String, account: String? = nil) -> Match? {
         var query: [CFString: Any] = [
             kSecClass: kSecClassGenericPassword,
             kSecAttrService: service,
             kSecReturnAttributes: true,
-            kSecMatchLimit: kSecMatchLimitOne
+            kSecReturnPersistentRef: true,
+            kSecMatchLimit: kSecMatchLimitAll
         ]
         if let account { query[kSecAttrAccount] = account }
 
-        var item: CFTypeRef?
-        guard SecItemCopyMatching(query as CFDictionary, &item) == errSecSuccess,
-              let attributes = item as? [CFString: Any]
+        var result: CFTypeRef?
+        guard SecItemCopyMatching(query as CFDictionary, &result) == errSecSuccess
         else { return nil }
-        return attributes[kSecAttrModificationDate] as? Date
+
+        // A single match still comes back as one dictionary rather than an
+        // array of one — `kSecMatchLimitAll` promises "every match", not "an
+        // array", and one is not the many it means.
+        let items = (result as? [[CFString: Any]]) ?? (result as? [CFString: Any]).map { [$0] } ?? []
+        return winner(among: items)
+    }
+
+    /// The selection itself, apart from the query that produces its input.
+    /// `SecItemCopyMatching` cannot run in a unit test — there is no keychain
+    /// to point it at — so this is the half that can be, and is: given several
+    /// duplicates, does the newest one actually win.
+    static func winner(among items: [[CFString: Any]]) -> Match? {
+        items
+            .compactMap { item -> Match? in
+                guard let ref = item[kSecValuePersistentRef] as? Data else { return nil }
+                return Match(modifiedAt: item[kSecAttrModificationDate] as? Date, persistentRef: ref)
+            }
+            // A duplicate with no modification date is possible in principle
+            // and worth keeping rather than discarding; `.distantPast` only
+            // decides its rank against the others, never whether it exists.
+            .max { ($0.modifiedAt ?? .distantPast) < ($1.modifiedAt ?? .distantPast) }
+    }
+
+    /// When the owning app last wrote the newest item under this service, or
+    /// nil if there is no such item or macOS declined to say.
+    static func modifiedAt(service: String, account: String? = nil) -> Date? {
+        newest(service: service, account: account)?.modifiedAt
     }
 }

--- a/Sources/Providers/ProviderAccount.swift
+++ b/Sources/Providers/ProviderAccount.swift
@@ -112,7 +112,7 @@ struct ProviderSummary: Identifiable, Equatable {
     /// refused. Cursor and Codex read ordinary files and never prompt, so
     /// offering them an "allow access" button would be offering a cure for an
     /// illness they cannot catch.
-    var usesKeychain: Bool { id == "claude" || id == "gemini" }
+    var usesKeychain: Bool { ClaudeProfile.isClaude(providerID: id) || id == "gemini" }
 
     let id: String
     let name: String

--- a/Sources/Providers/ProviderAccount.swift
+++ b/Sources/Providers/ProviderAccount.swift
@@ -119,4 +119,14 @@ struct ProviderSummary: Identifiable, Equatable {
     let glyph: ProviderGlyph
     let account: ProviderAccount?
     let signIn: SignInRoute
+    /// Whether macOS refused this credential on the last fetch — the one state
+    /// "Allow access…" can actually repair.
+    ///
+    /// Deliberately *not* read off the snapshot's status. A refusal leaves the
+    /// last reading standing and its status untouched, because the number is
+    /// still true; the refusal itself is remembered separately by the store.
+    /// Offering to re-ask macOS for a credential it is already handing over is a
+    /// cure for an illness the provider does not have, and a button that does
+    /// nothing is indistinguishable from a broken one.
+    var wasRefusedAccess: Bool = false
 }

--- a/Sources/Providers/ProviderGlyph.swift
+++ b/Sources/Providers/ProviderGlyph.swift
@@ -10,6 +10,7 @@ enum ProviderGlyph: String, Codable, Equatable {
     /// written under, and renaming it would make every stored reading for this
     /// provider undecodable.
     case antigravity = "gemini"
+    case glm
 
     /// If an asset with this name is in the bundle it wins over the traced
     /// outline — drop a PDF/SVG export from Figma in and it is picked up.
@@ -32,6 +33,7 @@ enum ProviderGlyph: String, Codable, Equatable {
         case .cursor: return 0.97
         case .openai: return 0.94
         case .antigravity: return 1.0
+        case .glm:    return 0.95
         case .third:  return 1.0
         }
     }
@@ -43,6 +45,7 @@ enum ProviderGlyph: String, Codable, Equatable {
         case .third:  return GlyphOutline.third
         case .cursor: return GlyphOutline.cursor
         case .antigravity: return GlyphOutline.antigravity
+        case .glm:    return GlyphOutline.glm
         }
     }
 }

--- a/Sources/Sessions/ClaudeSessionMonitor.swift
+++ b/Sources/Sessions/ClaudeSessionMonitor.swift
@@ -2,8 +2,9 @@ import AppKit
 import Combine
 import Foundation
 
-/// Watches `~/.claude/sessions` and publishes the Claude Code sessions that are
-/// actually running.
+/// Watches one profile's `sessions` directory — `~/.claude/sessions` by
+/// default — and publishes the Claude Code sessions that are actually running.
+/// One monitor per `ClaudeProfile`; see `AppDelegate`.
 ///
 /// The directory is watched rather than polled, because Claude Code writes a
 /// session file the moment its state changes — so "Claude just finished" shows

--- a/Sources/Sessions/CursorActivityMonitor.swift
+++ b/Sources/Sessions/CursorActivityMonitor.swift
@@ -22,11 +22,26 @@ final class CursorActivityMonitor: ObservableObject, AgentActivityMonitor {
 
     private let store: URL
     private let interval: TimeInterval
+    /// How long a conversation may go without being written to before its run
+    /// is treated as over.
+    ///
+    /// Measured over 33,484 gaps between consecutive writes inside a run on a
+    /// real store: p50 0.7s, p99 38.1s, p99.9 239.3s, longest 826.0s. So the
+    /// window has to clear fourteen minutes to never cut a live run, and the
+    /// asymmetry says to clear it: dropping the spinner on an agent that is
+    /// still working is visible on the headline surface, while an abandoned run
+    /// lingering another five minutes is not — and the killed-editor case,
+    /// which is the one that used to linger for ever, is now retired instantly
+    /// by the launch check rather than by waiting this out.
+    private let staleAfter: TimeInterval
     private var timer: Timer?
 
-    init(store: URL = CursorCredentials.storeURL, interval: TimeInterval = 2) {
+    init(store: URL = CursorCredentials.storeURL,
+         interval: TimeInterval = 2,
+         staleAfter: TimeInterval = 15 * 60) {
         self.store = store
         self.interval = interval
+        self.staleAfter = staleAfter
     }
 
     func start() {
@@ -47,12 +62,43 @@ final class CursorActivityMonitor: ObservableObject, AgentActivityMonitor {
     }
 
     private func rescan() {
-        let found = Self.read(store: store)
+        let found = Self.read(store: store, cursorLaunchedAt: Self.cursorLaunchDate(),
+                              staleAfter: staleAfter)
         guard found != sessions else { return }
         sessions = found
     }
 
-    static func read(store: URL) -> [AgentSession] {
+    /// When the running editor started, or nil if Cursor is not running at all.
+    ///
+    /// The same question `ProcessLiveness` answers for agents that write a pid —
+    /// "does the process that claimed this still exist?" — asked the only way a
+    /// composer row allows, since it records no pid: against the editor as a
+    /// whole. `session(fromHeader:...)` below says what it is needed for.
+    ///
+    /// A bundle-id miss would be indistinguishable from a closed editor and
+    /// would silently retire every Cursor row for ever, so fall back to the
+    /// bundle name. `launchDate` needs the same care for a different reason: it
+    /// is optional and usually absent — of 123 running applications on the
+    /// machine this was written on, 105 had none, Finder and Chrome among them.
+    /// "Running, start time unknown" must not collapse into "not running", so it
+    /// answers `.distantPast`: every row then predates it and the staleness
+    /// window alone decides, which is the behaviour we had before this check.
+    static func cursorLaunchDate() -> Date? {
+        let running = NSWorkspace.shared.runningApplications
+        let cursor = running.first { $0.bundleIdentifier == CursorCredentials.bundleID }
+            ?? running.first { $0.bundleURL?.lastPathComponent == "Cursor.app" }
+        return launchDate(found: cursor != nil, launchDate: cursor?.launchDate)
+    }
+
+    /// The two-state answer above, split out because `NSRunningApplication`
+    /// cannot be built in a test and this is the half worth pinning.
+    static func launchDate(found: Bool, launchDate: Date?) -> Date? {
+        guard found else { return nil }
+        return launchDate ?? .distantPast
+    }
+
+    static func read(store: URL, cursorLaunchedAt: Date?,
+                     staleAfter: TimeInterval, now: Date = Date()) -> [AgentSession] {
         guard let db = SQLiteStore.open(store) else { return [] }
         defer { sqlite3_close(db) }
 
@@ -60,12 +106,41 @@ final class CursorActivityMonitor: ObservableObject, AgentActivityMonitor {
             in: db,
             sql: "SELECT value FROM composerHeaders WHERE isArchived = 0 ORDER BY recency DESC LIMIT 40"
         )
-        return values.compactMap(session(fromHeader:)).sorted { $0.since > $1.since }
+        return values
+            .compactMap {
+                session(fromHeader: $0, cursorLaunchedAt: cursorLaunchedAt,
+                        staleAfter: staleAfter, now: now)
+            }
+            .sorted { $0.since > $1.since }
     }
 
     /// Only sessions that are *doing* something are worth a row — an editor
     /// with forty idle chats in its history is not forty things happening.
-    static func session(fromHeader json: String) -> AgentSession? {
+    ///
+    /// `unfinishedRunAt` is set when a run begins and cleared when it ends, but
+    /// two things leave it set on a run that is over and neither clears it: the
+    /// editor killed mid-run, and a run abandoned with the editor still up.
+    ///
+    /// It cannot date either of them. Measured against a real store, its value
+    /// is the *composer's creation time*, not the current run's: one row there
+    /// has two user turns seven minutes apart, was killed during the second,
+    /// and still reports the first. So it is a flag, and the timestamp that
+    /// answers "is this still going" has to be
+    /// `conversationCheckpointLastUpdatedAt`, which Cursor moves on every
+    /// message and tool result (falling back to `lastUpdatedAt`, which a
+    /// quarter of rows carry instead).
+    ///
+    /// That one timestamp settles both cases:
+    ///
+    /// - Written before the editor's current launch, it belongs to a process
+    ///   that is already gone — as does everything, when Cursor is not running
+    ///   at all and `cursorLaunchedAt` is nil.
+    /// - Written longer than `staleAfter` ago, the conversation has stopped
+    ///   being written to, which is the only evidence an abandoned run leaves.
+    static func session(fromHeader json: String,
+                        cursorLaunchedAt: Date?,
+                        staleAfter: TimeInterval,
+                        now: Date = Date()) -> AgentSession? {
         guard let data = json.data(using: .utf8),
               let head = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
               let id = head["composerId"] as? String
@@ -73,16 +148,35 @@ final class CursorActivityMonitor: ObservableObject, AgentActivityMonitor {
 
         let blocked = (head["hasBlockingPendingActions"] as? Bool) == true
             || (head["hasPendingPlan"] as? Bool) == true
-        let running = (head["unfinishedRunAt"] as? NSNumber)?.doubleValue
+        let runStart = date(head["unfinishedRunAt"])
+        // A quarter of rows carry `lastUpdatedAt` and no checkpoint at all.
+        let lastWrite = date(head["conversationCheckpointLastUpdatedAt"])
+            ?? date(head["lastUpdatedAt"])
+
+        let isRunning: Bool = {
+            guard let runStart, let cursorLaunchedAt else { return false }
+            // Nothing written yet means the composer was only just created, and
+            // since `unfinishedRunAt` *is* its creation time that is the most
+            // recent thing to have happened to it. The same value on a chat
+            // opened last week is correctly stale.
+            let touched = lastWrite ?? runStart
+            guard touched >= cursorLaunchedAt else { return false }
+            return now.timeIntervalSince(touched) <= staleAfter
+        }()
 
         let state: AgentSession.State
         if blocked { state = .waiting }
-        else if running != nil { state = .busy }
+        else if isRunning { state = .busy }
         else { return nil }
 
-        let millis = running
-            ?? (head["lastUpdatedAt"] as? NSNumber)?.doubleValue
-            ?? (head["createdAt"] as? NSNumber)?.doubleValue
+        // `runStart` is the composer's creation time, so it dates a busy row the
+        // way it always has — from when the chat began. A row that is merely
+        // waiting must not borrow it: a session blocked since this morning did
+        // not start waiting when the chat was opened last week.
+        let since = (isRunning ? runStart : nil)
+            ?? lastWrite
+            ?? date(head["createdAt"])
+            ?? now
 
         return AgentSession(
             id: "cursor.\(id)",
@@ -90,7 +184,12 @@ final class CursorActivityMonitor: ObservableObject, AgentActivityMonitor {
             detail: (head["subtitle"] as? String) ?? "Cursor",
             state: state,
             waitingFor: blocked ? "needs your input" : nil,
-            since: millis.map { Date(timeIntervalSince1970: $0 / 1000) } ?? Date()
+            since: since
         )
+    }
+
+    /// Cursor writes its timestamps as milliseconds since the epoch.
+    private static func date(_ value: Any?) -> Date? {
+        (value as? NSNumber).map { Date(timeIntervalSince1970: $0.doubleValue / 1000) }
     }
 }

--- a/Sources/Settings/ReleaseNotes.swift
+++ b/Sources/Settings/ReleaseNotes.swift
@@ -31,6 +31,48 @@ struct ReleaseNote: Equatable {
 enum ReleaseNotes {
     static let all: [ReleaseNote] = [
         ReleaseNote(
+            version: "1.4.0",
+            headline: "Two more accounts, four community fixes, and honest duplicates.",
+            changes: [
+                ReleaseNote.Change(
+                    title: "Multiple Claude Code accounts",
+                    detail: "Keep a work login apart with CLAUDE_CONFIG_DIR? It "
+                          + "now gets its own ring, its own limits, and its own "
+                          + "row in Settings, beside your personal one."
+                ),
+                ReleaseNote.Change(
+                    title: "GLM added",
+                    detail: "Z.ai's Coding Plan reads live now too, with a key "
+                          + "borrowed from whichever tool already holds one."
+                ),
+                ReleaseNote.Change(
+                    title: "A stuck Claude ring recovers on its own",
+                    detail: "One momentary failure — the Mac waking from sleep, "
+                          + "most often — used to lock the ring until the app "
+                          + "restarted. It now clears itself on the next check."
+                ),
+                ReleaseNote.Change(
+                    title: "Cursor sessions stop reporting work that already ended",
+                    detail: "A crashed or abandoned chat could read as \"still "
+                          + "working\" for a day or more. It now notices when "
+                          + "the writing has actually stopped."
+                ),
+                ReleaseNote.Change(
+                    title: "A months-old duplicate can no longer win",
+                    detail: "Claude Code files a new keychain entry on every "
+                          + "token rotation. An account signed in for a while "
+                          + "could pick an old, expired one at random and show "
+                          + "\"waiting for the first reading\" forever."
+                ),
+                ReleaseNote.Change(
+                    title: "A stray click no longer pins the notch open",
+                    detail: "Clicking near the screen edge before the notch had "
+                          + "even opened could leave it stuck open with nothing "
+                          + "on screen explaining why."
+                )
+            ]
+        ),
+        ReleaseNote(
             version: "1.3.0",
             headline: "Codex reads live, and Always show stays on.",
             changes: [

--- a/Sources/Settings/SettingsView.swift
+++ b/Sources/Settings/SettingsView.swift
@@ -269,10 +269,13 @@ private struct AccountRow: View {
                 // whenever the real thing is one launch away.
                 // The way back from a declined keychain prompt, and the only
                 // one: declining is easy to do by reflex, and nothing else on
-                // screen will ask macOS again. Shown for providers whose
-                // credential actually lives in the keychain — for the others
-                // there is no prompt to raise.
-                if isConnected, provider.usesKeychain {
+                // screen will ask macOS again.
+                //
+                // Shown only while macOS is actually refusing. It used to be
+                // permanent for any keychain-backed provider, which meant it sat
+                // there next to a working account offering to fix nothing — and
+                // when it *was* needed there was no way to tell the two apart.
+                if isConnected, provider.wasRefusedAccess {
                     Button("Allow access…") { retry(provider.id) }
                         .controlSize(.small)
                         .help("Asks macOS for \(provider.name)'s saved login again. "
@@ -324,6 +327,14 @@ private struct AccountRow: View {
                     .foregroundStyle(.tertiary)
                     .fixedSize(horizontal: false, vertical: true)
             }
+        } else if provider.wasRefusedAccess {
+            // Not a sign-in problem, so do not send them off to sign in. The
+            // credential is right there and macOS is the one saying no — the
+            // remedy is the button on this same row.
+            Text("macOS is not letting Codenotch read \(provider.name)'s saved "
+                 + "login. Choose Allow access… above, then Always Allow.")
+                .foregroundStyle(.orange)
+                .fixedSize(horizontal: false, vertical: true)
         } else {
             HStack(spacing: 8) {
                 Text(provider.signIn.explanation)

--- a/Tests/ActivitySummaryTests.swift
+++ b/Tests/ActivitySummaryTests.swift
@@ -1,3 +1,4 @@
+import SQLite3
 import XCTest
 @testable import Codenotch
 
@@ -35,20 +36,178 @@ final class ActivitySummaryTests: XCTestCase {
     }
 }
 
+/// The instant every fixture's `unfinishedRunAt` names. At file scope so it can
+/// serve as a default argument, which a stored property cannot.
+private let runAt = Date(timeIntervalSince1970: 1787981829.823)
+
 /// Cursor publishes no session registry, so its working state is read out of the
 /// editor's `composerHeaders` rows. These pin what counts as working.
 @MainActor
 final class CursorActivityTests: XCTestCase {
-    private func session(_ json: String) -> AgentSession? {
-        CursorActivityMonitor.session(fromHeader: json)
+    /// Cursor writes its timestamps as milliseconds since the epoch.
+    private func millis(_ date: Date) -> NSNumber {
+        NSNumber(value: (date.timeIntervalSince1970 * 1000).rounded())
+    }
+
+    /// One `composerHeaders` row. Built rather than pasted so a fixture differs
+    /// from its neighbour only where the test means it to, and so the epoch
+    /// literal exists once instead of once per test.
+    private func header(id: String? = "abc",
+                        run: Date? = runAt,
+                        checkpoint: Date? = nil,
+                        lastUpdated: Date? = nil,
+                        created: Date? = nil,
+                        name: String? = nil,
+                        subtitle: String? = nil,
+                        blocking: Bool? = nil,
+                        plan: Bool? = nil) -> String {
+        var head: [String: Any] = [:]
+        head["composerId"] = id
+        head["unfinishedRunAt"] = run.map(millis)
+        head["conversationCheckpointLastUpdatedAt"] = checkpoint.map(millis)
+        head["lastUpdatedAt"] = lastUpdated.map(millis)
+        head["createdAt"] = created.map(millis)
+        head["name"] = name
+        head["subtitle"] = subtitle
+        head["hasBlockingPendingActions"] = blocking
+        head["hasPendingPlan"] = plan
+        let data = try! JSONSerialization.data(withJSONObject: head)
+        return String(data: data, encoding: .utf8)!
+    }
+
+    /// `launchedAt: .distantPast` stands for "Cursor is running and has been
+    /// for longer than any row in the fixture" — the ordinary case. `now`
+    /// defaults to a second after the run started, since a fixture read against
+    /// the wall clock would be hours stale and never busy.
+    private func session(_ json: String,
+                         launchedAt: Date? = .distantPast,
+                         staleAfter: TimeInterval = 15 * 60,
+                         now: Date? = nil) -> AgentSession? {
+        CursorActivityMonitor.session(fromHeader: json,
+                                      cursorLaunchedAt: launchedAt,
+                                      staleAfter: staleAfter,
+                                      now: now ?? runAt.addingTimeInterval(1))
+    }
+
+    /// The bug this exists to stop: Cursor is killed mid-run, `unfinishedRunAt`
+    /// is never cleared, and the notch reports three agents working a day later
+    /// with the editor not even open.
+    func testARunIsNotBusyWhenCursorIsNotRunning() {
+        XCTAssertNil(session(header(), launchedAt: nil))
+    }
+
+    /// Same row, same absent editor, but Cursor has since been restarted: the
+    /// run belongs to the process that is gone, not the one now open.
+    func testARunFromBeforeThisLaunchIsNotBusy() {
+        XCTAssertNil(session(header(), launchedAt: runAt.addingTimeInterval(1)))
+    }
+
+    func testARunStartedAfterThisLaunchIsBusy() throws {
+        let s = try XCTUnwrap(session(header(), launchedAt: runAt.addingTimeInterval(-1)))
+        XCTAssertEqual(s.state, .busy)
+    }
+
+    /// The one process liveness cannot see: a run abandoned with the editor
+    /// still open. `unfinishedRunAt` stays set for ever, so the only thing that
+    /// says the run is over is a checkpoint that stopped moving.
+    func testARunWhoseCheckpointWentSilentIsNotBusy() {
+        XCTAssertNil(session(header(checkpoint: runAt.addingTimeInterval(160)),
+                             now: runAt.addingTimeInterval(3600)))
+    }
+
+    /// The other side of it: an agent between tool calls is quiet for seconds,
+    /// not hours, and must keep its spinner.
+    func testARunStillWritingIsBusy() throws {
+        let s = try XCTUnwrap(session(header(checkpoint: runAt.addingTimeInterval(160)),
+                                      now: runAt.addingTimeInterval(200)))
+        XCTAssertEqual(s.state, .busy)
+    }
+
+    /// A blocked row still counts with the editor shut — it really is waiting
+    /// on you — but it must not be dated by a run that never finished.
+    func testWaitingSurvivesAClosedEditorButNotAStaleRunTime() throws {
+        let checkpoint = runAt.addingTimeInterval(18_170)
+        let s = try XCTUnwrap(session(header(checkpoint: checkpoint, plan: true),
+                                      launchedAt: nil))
+        XCTAssertEqual(s.state, .waiting)
+        XCTAssertEqual(s.since, checkpoint)
+    }
+
+    /// `unfinishedRunAt` is the composer's creation time, not the current run's:
+    /// a chat with two turns seven minutes apart, killed during the second,
+    /// still reports the first. So a chat opened long before Cursor last started
+    /// and working right now must still spin — gating on that field would have
+    /// silently retired every conversation older than the current launch.
+    func testAnOldChatWritingRightNowIsBusy() throws {
+        let checkpoint = runAt.addingTimeInterval(18_170)
+        let s = try XCTUnwrap(session(header(checkpoint: checkpoint),
+                                      launchedAt: runAt.addingTimeInterval(8_170),
+                                      now: checkpoint.addingTimeInterval(60)))
+        XCTAssertEqual(s.state, .busy)
+    }
+
+    /// The restart case, read off the timestamp that actually moves: a
+    /// conversation last written to before this Cursor started belongs to the
+    /// process that is gone.
+    func testAConversationLastWrittenBeforeThisLaunchIsNotBusy() {
+        XCTAssertNil(session(header(checkpoint: runAt.addingTimeInterval(160)),
+                             launchedAt: runAt.addingTimeInterval(8_170),
+                             now: runAt.addingTimeInterval(8_230)))
+    }
+
+    /// The boundary: a conversation written at the very instant Cursor launched
+    /// is the current process's, not the dead one's.
+    func testAWriteAtTheLaunchInstantCountsAsThisProcess() throws {
+        let s = try XCTUnwrap(session(header(checkpoint: runAt), launchedAt: runAt))
+        XCTAssertEqual(s.state, .busy)
+    }
+
+    /// A quarter of real rows carry `lastUpdatedAt` and no checkpoint. Dropping
+    /// it from the chain dated them from `createdAt` instead — a chat blocked
+    /// ten minutes ago reading as blocked for weeks.
+    func testLastUpdatedAtStandsInForAMissingCheckpoint() throws {
+        let touched = runAt.addingTimeInterval(18_170)
+        let s = try XCTUnwrap(session(header(run: nil, lastUpdated: touched,
+                                             created: runAt.addingTimeInterval(-981_829),
+                                             plan: true),
+                                      launchedAt: nil))
+        XCTAssertEqual(s.state, .waiting)
+        XCTAssertEqual(s.since, touched)
+    }
+
+    /// The last rung. A row blocked with nothing written to it since it was
+    /// opened is dated from when it was opened — not from the wall clock, which
+    /// would restamp it on every two-second poll and republish for ever.
+    func testAWaitingRowWithNoWritesFallsBackToCreatedAt() throws {
+        let created = runAt.addingTimeInterval(-981_829)
+        let s = try XCTUnwrap(session(header(run: nil, created: created, plan: true),
+                                      launchedAt: nil))
+        XCTAssertEqual(s.since, created)
+    }
+
+    /// `launchDate` is usually absent — of 123 running applications on the
+    /// machine this was written on, 105 had none, Finder and Chrome among them.
+    /// Reporting that as "Cursor is closed" would silently retire every Cursor
+    /// row while the editor sat there working.
+    func testARunningCursorWithNoLaunchDateIsStillRunning() {
+        XCTAssertEqual(CursorActivityMonitor.launchDate(found: true, launchDate: nil),
+                       .distantPast)
+        XCTAssertNil(CursorActivityMonitor.launchDate(found: false, launchDate: nil))
+    }
+
+    /// The window is a boundary, and it is inclusive — the siblings' is too.
+    func testTheStalenessBoundaryIsInclusive() throws {
+        let fixture = header(checkpoint: runAt)
+        let atTheEdge = try XCTUnwrap(session(fixture, staleAfter: 60,
+                                              now: runAt.addingTimeInterval(60)))
+        XCTAssertEqual(atTheEdge.state, .busy)
+        XCTAssertNil(session(fixture, staleAfter: 60, now: runAt.addingTimeInterval(61)))
     }
 
     /// `unfinishedRunAt` is set while a run is in flight and cleared when it ends.
     func testAnUnfinishedRunIsBusy() throws {
-        let s = try XCTUnwrap(session("""
-        {"composerId":"abc","name":"General chat","subtitle":"Read SKILL.md",
-         "unfinishedRunAt":1787981829823,"hasBlockingPendingActions":false}
-        """))
+        let s = try XCTUnwrap(session(header(name: "General chat",
+                                             subtitle: "Read SKILL.md", blocking: false)))
         XCTAssertEqual(s.state, .busy)
         XCTAssertEqual(s.name, "General chat")
         XCTAssertEqual(s.detail, "Read SKILL.md")
@@ -57,31 +216,68 @@ final class CursorActivityTests: XCTestCase {
     /// A finished run is not a session worth a row — an editor with a long chat
     /// history is not a pile of things happening.
     func testAFinishedRunIsNotListed() {
-        XCTAssertNil(session(#"{"composerId":"abc","hasBlockingPendingActions":false}"#))
+        XCTAssertNil(session(header(run: nil, blocking: false)))
     }
 
     /// Blocked outranks busy: it is the only state asking for something.
     func testBlockingActionsOutrankARunningTurn() throws {
-        let s = try XCTUnwrap(session("""
-        {"composerId":"abc","unfinishedRunAt":1787981829823,"hasBlockingPendingActions":true}
-        """))
+        let s = try XCTUnwrap(session(header(blocking: true)))
         XCTAssertEqual(s.state, .waiting)
         XCTAssertEqual(s.waitingFor, "needs your input")
     }
 
     func testAPendingPlanAlsoCountsAsWaiting() throws {
-        let s = try XCTUnwrap(session(#"{"composerId":"abc","hasPendingPlan":true}"#))
-        XCTAssertEqual(s.state, .waiting)
+        XCTAssertEqual(try XCTUnwrap(session(header(run: nil, plan: true))).state, .waiting)
     }
 
     /// Ids are namespaced, so a Cursor composer can never collide with a Claude pid.
     func testIdsAreNamespaced() throws {
-        let s = try XCTUnwrap(session(#"{"composerId":"abc","unfinishedRunAt":1}"#))
-        XCTAssertEqual(s.id, "cursor.abc")
+        XCTAssertEqual(try XCTUnwrap(session(header())).id, "cursor.abc")
     }
 
     func testRejectsRubbish() {
         XCTAssertNil(session("not json"))
-        XCTAssertNil(session(#"{"noComposerId":true,"unfinishedRunAt":1}"#))
+        XCTAssertNil(session(header(id: nil)))
+    }
+
+    // MARK: - The store read
+
+    /// Rows land newest-first, and an archived chat is not something happening —
+    /// both are in the SQL rather than in Swift, so only a real store shows them.
+    func testReadOrdersNewestFirstAndSkipsArchivedRows() throws {
+        let older = runAt
+        let newer = runAt.addingTimeInterval(100)
+        let url = try makeStore([
+            (header(id: "older", run: older, checkpoint: older), archived: 0),
+            (header(id: "newer", run: newer, checkpoint: newer), archived: 0),
+            (header(id: "filed", run: newer, checkpoint: newer), archived: 1),
+        ])
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let found = CursorActivityMonitor.read(store: url, cursorLaunchedAt: .distantPast,
+                                               staleAfter: 10 * 60,
+                                               now: newer.addingTimeInterval(1))
+        XCTAssertEqual(found.map(\.id), ["cursor.newer", "cursor.older"])
+    }
+
+    /// Mirrors `SQLiteStoreTests.makeDatabase`: closing checkpoints the WAL, so
+    /// the file reads back the way it would after the editor has quit.
+    private func makeStore(_ rows: [(String, archived: Int)]) throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cursor-\(UUID().uuidString).sqlite")
+        var db: OpaquePointer?
+        XCTAssertEqual(sqlite3_open(url.path, &db), SQLITE_OK)
+        sqlite3_exec(db, "PRAGMA journal_mode=WAL;", nil, nil, nil)
+        sqlite3_exec(db, """
+        CREATE TABLE composerHeaders (value TEXT, isArchived INT, recency INT);
+        """, nil, nil, nil)
+        for (index, row) in rows.enumerated() {
+            let escaped = row.0.replacingOccurrences(of: "'", with: "''")
+            sqlite3_exec(db, """
+            INSERT INTO composerHeaders VALUES ('\(escaped)', \(row.archived), \(index));
+            """, nil, nil, nil)
+        }
+        sqlite3_close(db)
+        return url
     }
 }

--- a/Tests/AntigravityTests.swift
+++ b/Tests/AntigravityTests.swift
@@ -909,6 +909,7 @@ final class KeychainProviderTests: XCTestCase {
 
     func testOnlyKeychainBackedProvidersOfferIt() {
         XCTAssertTrue(summary("claude").usesKeychain)
+        XCTAssertTrue(summary("claude-work").usesKeychain, "every profile's token is a keychain item")
         XCTAssertTrue(summary("gemini").usesKeychain)
         XCTAssertFalse(summary("cursor").usesKeychain, "Cursor reads a file, not the keychain")
         XCTAssertFalse(summary("codex").usesKeychain, "Codex reads a file, not the keychain")

--- a/Tests/AntigravityTests.swift
+++ b/Tests/AntigravityTests.swift
@@ -915,3 +915,86 @@ final class KeychainProviderTests: XCTestCase {
         XCTAssertFalse(summary("codex").usesKeychain, "Codex reads a file, not the keychain")
     }
 }
+
+/// Claude Code files a new keychain item on every token rotation rather than
+/// updating one in place, so an account used for months accumulates several
+/// under `Claude Code-credentials` — six, on the machine this was found on.
+/// `kSecMatchLimitOne` gives no ordering guarantee across them, so the app
+/// could read an old, expired duplicate while a valid one sat beside it: the
+/// ring showed "Waiting for the first reading…" forever, with a working token
+/// one item away. `KeychainItem.winner` is the selection that replaced it —
+/// the query it is chosen from cannot run in a test, since there is no real
+/// keychain to point it at.
+final class KeychainDuplicateTests: XCTestCase {
+    private func item(ref: String, modified: Date?) -> [CFString: Any] {
+        var item: [CFString: Any] = [kSecValuePersistentRef: Data(ref.utf8)]
+        if let modified { item[kSecAttrModificationDate] = modified }
+        return item
+    }
+
+    /// The reported case: an old duplicate must not beat a newer one merely by
+    /// being asked about first.
+    func testTheMostRecentlyModifiedItemWins() {
+        let old = Date(timeIntervalSince1970: 1_000)
+        let new = Date(timeIntervalSince1970: 2_000)
+        let winner = KeychainItem.winner(among: [
+            item(ref: "old", modified: old),
+            item(ref: "new", modified: new)
+        ])
+        XCTAssertEqual(winner?.persistentRef, Data("new".utf8))
+        XCTAssertEqual(winner?.modifiedAt, new)
+    }
+
+    /// Order in the array must not decide it — that is exactly the bug being
+    /// replaced, moved into this function instead of out of it.
+    func testOrderInTheArrayDoesNotDecideIt() {
+        let old = Date(timeIntervalSince1970: 1_000)
+        let new = Date(timeIntervalSince1970: 2_000)
+        let winner = KeychainItem.winner(among: [
+            item(ref: "new", modified: new),
+            item(ref: "old", modified: old)
+        ])
+        XCTAssertEqual(winner?.persistentRef, Data("new".utf8))
+    }
+
+    /// The single-item case, which is nearly everyone: one duplicate is still
+    /// a field of one to win.
+    func testASingleItemWinsByDefault() {
+        let winner = KeychainItem.winner(among: [item(ref: "only", modified: Date())])
+        XCTAssertEqual(winner?.persistentRef, Data("only".utf8))
+    }
+
+    func testNoItemsMeansNoWinner() {
+        XCTAssertNil(KeychainItem.winner(among: []))
+    }
+
+    /// A duplicate with no recorded modification date is worth keeping, not
+    /// discarding — `.distantPast` only ranks it against the others.
+    func testAnUndatedDuplicateStillLosesToADatedOne() {
+        let dated = Date(timeIntervalSince1970: 1_000)
+        let winner = KeychainItem.winner(among: [
+            item(ref: "undated", modified: nil),
+            item(ref: "dated", modified: dated)
+        ])
+        XCTAssertEqual(winner?.persistentRef, Data("dated".utf8))
+    }
+
+    /// But it can still win outright if it is the only one there is.
+    func testAnUndatedDuplicateWinsWhenAloneWithNoDateAtAll() {
+        let winner = KeychainItem.winner(among: [item(ref: "only", modified: nil)])
+        XCTAssertEqual(winner?.persistentRef, Data("only".utf8))
+        XCTAssertNil(winner?.modifiedAt)
+    }
+
+    /// An entry with no persistent reference at all cannot be read later no
+    /// matter how it ranks, so it is dropped rather than allowed to win and
+    /// then fail.
+    func testAnItemWithNoPersistentRefIsNeverThePick() {
+        let broken: [CFString: Any] = [kSecAttrModificationDate: Date(timeIntervalSince1970: 9_999)]
+        let winner = KeychainItem.winner(among: [
+            broken,
+            item(ref: "usable", modified: Date(timeIntervalSince1970: 1))
+        ])
+        XCTAssertEqual(winner?.persistentRef, Data("usable".utf8))
+    }
+}

--- a/Tests/ClaudeOAuthProviderTests.swift
+++ b/Tests/ClaudeOAuthProviderTests.swift
@@ -1,0 +1,201 @@
+import XCTest
+@testable import Codenotch
+
+/// The token path of `ClaudeOAuthProvider`.
+///
+/// It had no tests at all — only the pure helpers (`backoff`, `retryAfter`) were
+/// covered — which is how a back-off that re-stamped itself on every failed tick
+/// shipped and locked the provider until the app was restarted.
+///
+/// Every assertion here is about one question: **after a failure, does the next
+/// tick actually go and ask again?** Hence the counters. Asserting on the returned
+/// error is not enough — the broken version returned exactly the right error while
+/// never touching the keychain or the network.
+final class ClaudeOAuthProviderTests: XCTestCase {
+
+    override func tearDown() {
+        StubEndpoint.reset([])
+        super.tearDown()
+    }
+
+    /// A 401 must not stop the next tick from trying.
+    ///
+    /// The endpoint rejects the token and then starts answering again — a token
+    /// rotated behind the app's back. This is the manual repro (a local server
+    /// switched from 401 to 200) reduced to a test.
+    func testA401DoesNotStopTheNextTickFromTrying() async throws {
+        StubEndpoint.reset([
+            .init(status: 401),                       // the tick's first attempt
+            .init(status: 401),                       // its one retry on unauthorized
+            .init(status: 200, body: Self.usagePayload)
+        ])
+        let source = CredentialSource(readable: true)
+        let provider = makeProvider(source: source)
+
+        await assertNeedsAuth(from: provider)
+        XCTAssertEqual(StubEndpoint.requestCount, 2, "the retry on 401 did not happen")
+
+        let snapshot = try await provider.fetchSnapshot()
+
+        XCTAssertEqual(StubEndpoint.requestCount, 3,
+                       "the next tick never reached the endpoint")
+        XCTAssertEqual(snapshot.status, .ok)
+        XCTAssertEqual(snapshot.windows.first?.id, "session")
+    }
+
+    /// A keychain read that failed must not stop the next tick from reading again.
+    ///
+    /// This is what happened in the field: the Mac was in dark wake, the keychain
+    /// answered `-25320` ("no UI possible"), and that fell through to `needsAuth`.
+    /// The credential was readable again seconds later; the provider never looked.
+    func testAKeychainFailureDoesNotStopTheNextTickFromReading() async throws {
+        StubEndpoint.reset([.init(status: 200, body: Self.usagePayload)])
+        let source = CredentialSource(readable: false)
+        let provider = makeProvider(source: source)
+
+        await assertNeedsAuth(from: provider)
+        XCTAssertEqual(source.reads, 1)
+        XCTAssertEqual(StubEndpoint.requestCount, 0,
+                       "it went to the network without a token")
+
+        source.makeReadable()   // the machine woke up
+
+        let snapshot = try await provider.fetchSnapshot()
+
+        XCTAssertEqual(source.reads, 2, "the next tick never went back to the keychain")
+        XCTAssertEqual(snapshot.status, .ok)
+    }
+
+    /// Failing repeatedly must not become failing silently.
+    ///
+    /// The bug's signature was a request count frozen at two while the poll kept
+    /// firing every 60 seconds. Three ticks against a rejecting endpoint have to
+    /// produce three attempts, not one.
+    func testItKeepsAskingWhileTheEndpointKeepsRejecting() async {
+        StubEndpoint.reset(Array(repeating: .init(status: 401), count: 6))
+        let provider = makeProvider(source: CredentialSource(readable: true))
+
+        for _ in 0..<3 { await assertNeedsAuth(from: provider) }
+
+        XCTAssertEqual(StubEndpoint.requestCount, 6,
+                       "the provider stopped asking after the first failure")
+    }
+
+    // MARK: - Helpers
+
+    private static let usagePayload = Data("""
+    {"limits":[{"kind":"session","percent":42,"resets_at":"2099-01-01T00:00:00Z"}]}
+    """.utf8)
+
+    private func makeProvider(source: CredentialSource) -> ClaudeOAuthProvider {
+        // A private defaults suite per test: the archive persists the 429 back-off
+        // deadline, and a leaked one would silently skip fetches in the next test.
+        let name = "ClaudeOAuthProviderTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: name)!
+        defaults.removePersistentDomain(forName: name)
+
+        return ClaudeOAuthProvider(session: StubEndpoint.session(),
+                                   archive: UsageArchive(defaults: defaults),
+                                   loadCredentials: { try source.read() })
+    }
+
+    private func assertNeedsAuth(from provider: ClaudeOAuthProvider,
+                                 file: StaticString = #filePath,
+                                 line: UInt = #line) async {
+        do {
+            _ = try await provider.fetchSnapshot()
+            XCTFail("expected needsAuth, got a snapshot", file: file, line: line)
+        } catch UsageProviderError.needsAuth {
+            // expected
+        } catch {
+            XCTFail("expected needsAuth, got \(error)", file: file, line: line)
+        }
+    }
+}
+
+/// Stands in for the keychain, and counts reads.
+///
+/// "Did it go back and ask?" is the whole question, and only a counter answers it.
+private final class CredentialSource: @unchecked Sendable {
+    private let lock = NSLock()
+    private var readable: Bool
+    private var readCount = 0
+
+    init(readable: Bool) { self.readable = readable }
+
+    var reads: Int {
+        lock.lock(); defer { lock.unlock() }
+        return readCount
+    }
+
+    func makeReadable() {
+        lock.lock(); readable = true; lock.unlock()
+    }
+
+    func read() throws -> ClaudeCredentials {
+        lock.lock()
+        readCount += 1
+        let allowed = readable
+        lock.unlock()
+
+        // The shape a dark-wake or not-found read takes by the time it leaves
+        // `ClaudeCredentials.read()`.
+        guard allowed else { throw UsageProviderError.needsAuth }
+        return ClaudeCredentials(accessToken: "token",
+                                 expiresAt: .distantFuture,
+                                 subscriptionType: "max")
+    }
+}
+
+/// Canned answers for the usage endpoint, and a count of how many requests
+/// actually arrived. The repo had no URL stubbing, which is why nothing above
+/// `retryAfter(from:)` was ever tested.
+private final class StubEndpoint: URLProtocol {
+    struct Answer {
+        let status: Int
+        var body: Data = Data()
+    }
+
+    private static let lock = NSLock()
+    private static var queued: [Answer] = []
+    private static var served = 0
+
+    static func reset(_ answers: [Answer]) {
+        lock.lock(); queued = answers; served = 0; lock.unlock()
+    }
+
+    static var requestCount: Int {
+        lock.lock(); defer { lock.unlock() }
+        return served
+    }
+
+    static func session() -> URLSession {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [StubEndpoint.self]
+        return URLSession(configuration: configuration)
+    }
+
+    private static func next() -> Answer {
+        lock.lock(); defer { lock.unlock() }
+        served += 1
+        // Running dry is a test bug, and a 500 says so more clearly than a crash
+        // inside URLSession's callback would.
+        return queued.isEmpty ? Answer(status: 500) : queued.removeFirst()
+    }
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        let answer = Self.next()
+        let response = HTTPURLResponse(url: request.url!,
+                                       statusCode: answer.status,
+                                       httpVersion: "HTTP/1.1",
+                                       headerFields: ["Content-Type": "application/json"])!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: answer.body)
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+}

--- a/Tests/ClaudeProfileTests.swift
+++ b/Tests/ClaudeProfileTests.swift
@@ -1,0 +1,202 @@
+import XCTest
+@testable import Codenotch
+
+/// A second Claude Code login kept under `~/.claude-<slug>` is its own account,
+/// with its own token, its own limits and its own sessions. Reading only
+/// `~/.claude` showed one of them and was blind to the rest.
+final class ClaudeProfileTests: XCTestCase {
+    private func home(_ layout: [String: [String]]) throws -> URL {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ClaudeProfileTests.\(UUID().uuidString)")
+        for (directory, files) in layout {
+            let url = root.appendingPathComponent(directory)
+            try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+            for file in files {
+                FileManager.default.createFile(atPath: url.appendingPathComponent(file).path,
+                                               contents: Data())
+            }
+        }
+        addTeardownBlock { try? FileManager.default.removeItem(at: root) }
+        return root
+    }
+
+    // MARK: - Identity
+
+    /// The default keeps the id it has always had, so archived readings and
+    /// connection choices survive the update.
+    func testTheDefaultProfileIsUnchanged() {
+        let profile = ClaudeProfile.default(home: URL(fileURLWithPath: "/Users/vinz"))
+        XCTAssertNil(profile.slug)
+        XCTAssertEqual(profile.id, "claude")
+        XCTAssertEqual(profile.displayName, "Claude")
+        XCTAssertEqual(profile.keychainService, "Claude Code-credentials")
+        XCTAssertEqual(profile.sessionsDirectory.path, "/Users/vinz/.claude/sessions")
+        XCTAssertEqual(profile.sourceName, "Claude Code")
+        XCTAssertEqual(profile.signInCommand, "claude")
+    }
+
+    func testAProfileIsNamedAfterItsSlug() {
+        let profile = ClaudeProfile(slug: "work",
+                                    configDirectory: URL(fileURLWithPath: "/Users/vinz/.claude-work"))
+        XCTAssertEqual(profile.id, "claude-work")
+        XCTAssertEqual(profile.displayName, "Claude (work)")
+        XCTAssertEqual(profile.sessionsDirectory.path, "/Users/vinz/.claude-work/sessions")
+    }
+
+    /// Claude Code files a non-default profile's token under the service name
+    /// plus the first eight hex digits of the SHA-256 of the directory path.
+    /// Getting this wrong means "sign in" on a ring for an account that is
+    /// signed in.
+    func testTheKeychainServiceCarriesClaudeCodesHashOfThePath() {
+        let profile = ClaudeProfile(slug: "work",
+                                    configDirectory: URL(fileURLWithPath: "/Users/vinz/.claude-work"))
+        // `shasum -a 256` of the path, no trailing slash, no newline.
+        XCTAssertEqual(profile.keychainService, "Claude Code-credentials-19914660")
+    }
+
+    /// The path is hashed as Claude Code sees it, and Claude Code does not see
+    /// a trailing slash.
+    func testATrailingSlashDoesNotChangeTheHash() {
+        let slashed = ClaudeProfile(slug: "work",
+                                    configDirectory: URL(fileURLWithPath: "/Users/vinz/.claude-work/"))
+        XCTAssertEqual(slashed.keychainService, "Claude Code-credentials-19914660")
+    }
+
+    func testProviderIDsAreRecognised() {
+        XCTAssertTrue(ClaudeProfile.isClaude(providerID: "claude"))
+        XCTAssertTrue(ClaudeProfile.isClaude(providerID: "claude-work"))
+        XCTAssertFalse(ClaudeProfile.isClaude(providerID: "claudex"))
+        XCTAssertFalse(ClaudeProfile.isClaude(providerID: "cursor"))
+        XCTAssertEqual(ClaudeProfile.slug(fromProviderID: "claude-work"), "work")
+        XCTAssertNil(ClaudeProfile.slug(fromProviderID: "claude"))
+        XCTAssertNil(ClaudeProfile.slug(fromProviderID: "claude-"))
+    }
+
+    // MARK: - Discovery
+
+    func testDirectoryNamesAreParsedStrictly() {
+        XCTAssertEqual(ClaudeProfile.slug(fromDirectoryName: ".claude-work"), "work")
+        XCTAssertEqual(ClaudeProfile.slug(fromDirectoryName: ".claude-client-a"), "client-a")
+        XCTAssertNil(ClaudeProfile.slug(fromDirectoryName: ".claude"), "the default is not a slug")
+        XCTAssertNil(ClaudeProfile.slug(fromDirectoryName: ".claude-"), "an empty slug is no profile")
+        XCTAssertNil(ClaudeProfile.slug(fromDirectoryName: ".claude.json"), "a file beside the default")
+        XCTAssertNil(ClaudeProfile.slug(fromDirectoryName: ".claudette"))
+        XCTAssertNil(ClaudeProfile.slug(fromDirectoryName: "claude-work"), "not hidden, not ours")
+    }
+
+    /// The default comes first, then the rest by slug, so the rings keep their
+    /// places from one launch to the next.
+    func testDiscoveryFindsEveryUsedProfileInAStableOrder() throws {
+        let home = try home([
+            ".claude": ["settings.json"],
+            ".claude-work": ["settings.json"],
+            ".claude-alpha": ["history.jsonl"]
+        ])
+        let found = ClaudeProfile.discover(home: home)
+        XCTAssertEqual(found.map(\.id), ["claude", "claude-alpha", "claude-work"])
+        XCTAssertEqual(found[2].configDirectory.path, home.appendingPathComponent(".claude-work").path)
+    }
+
+    /// An empty directory is not a profile: a permanent "sign in" ring for an
+    /// account that does not exist is worse than no ring.
+    func testDirectoriesClaudeCodeHasNeverUsedAreIgnored() throws {
+        let home = try home([
+            ".claude": ["settings.json"],
+            ".claude-empty": [],
+            ".claude-notes": ["README.md"]
+        ])
+        XCTAssertEqual(ClaudeProfile.discover(home: home).map(\.id), ["claude"])
+    }
+
+    /// Any one of the files Claude Code writes on first run is enough — they
+    /// are not all present on every version.
+    func testAnyFirstRunMarkerCounts() throws {
+        let home = try home([
+            ".claude-a": ["sessions"],
+            ".claude-b": ["projects"],
+            ".claude-c": [".claude.json"]
+        ])
+        XCTAssertEqual(ClaudeProfile.discover(home: home).map(\.id),
+                       ["claude", "claude-a", "claude-b", "claude-c"])
+    }
+
+    /// A file named like a profile is not one, and must not crash discovery.
+    func testAFileNamedLikeAProfileIsIgnored() throws {
+        let home = try home([".claude": ["settings.json"]])
+        FileManager.default.createFile(atPath: home.appendingPathComponent(".claude-work").path,
+                                       contents: Data("not a directory".utf8))
+        XCTAssertEqual(ClaudeProfile.discover(home: home).map(\.id), ["claude"])
+    }
+
+    /// `~/.claude` has always been read whether or not it exists yet, and a
+    /// fresh Mac with no Claude Code still gets the ring that says so.
+    func testTheDefaultIsAlwaysPresent() throws {
+        let home = try home([:])
+        XCTAssertEqual(ClaudeProfile.discover(home: home).map(\.id), ["claude"])
+    }
+
+    // MARK: - What the rest of the app derives from the id
+
+    /// The tooltip's sign-in prompt has to name the directory, because plain
+    /// `claude` signs the default profile in, not this one.
+    func testTheSignInPromptNamesTheDirectory() {
+        let snapshot = ProviderSnapshot(
+            id: "claude-work", displayName: "Claude (work)", glyph: .claude,
+            fidelity: .official, status: .needsAuth, windows: []
+        )
+        XCTAssertEqual(snapshot.statusMessage,
+                       "Sign in to Claude Code in ~/.claude-work to read your usage")
+    }
+
+    /// Every profile's token is a keychain item, so every profile can be
+    /// refused and needs the "Allow access…" button.
+    func testEveryProfileUsesTheKeychain() {
+        let summary = ProviderSummary(id: "claude-work", name: "Claude (work)", glyph: .claude,
+                                      account: nil, signIn: .guidance("x"))
+        XCTAssertTrue(summary.usesKeychain)
+    }
+
+    /// The rate limit is per account. A penalty on the work profile must not
+    /// hold the personal one back, and the default keeps its old key so a
+    /// penalty in progress survives the update.
+    func testBackoffIsRememberedPerProfile() throws {
+        let name = "ClaudeProfileTests.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: name))
+        defaults.removePersistentDomain(forName: name)
+        let archive = UsageArchive(defaults: defaults)
+
+        let until = Date().addingTimeInterval(300)
+        archive.saveBackoffUntil(until, providerID: "claude-work")
+        XCTAssertNil(archive.loadBackoffUntil(providerID: "claude"))
+        XCTAssertNil(archive.loadBackoffUntil(), "the no-argument form is the default profile")
+        XCTAssertNotNil(archive.loadBackoffUntil(providerID: "claude-work"))
+
+        archive.saveBackoffUntil(until)
+        XCTAssertNotNil(defaults.object(forKey: "backoffUntil"), "the default's key is unchanged")
+        archive.saveBackoffUntil(nil, providerID: "claude-work")
+        XCTAssertNil(archive.loadBackoffUntil(providerID: "claude-work"))
+        XCTAssertNotNil(archive.loadBackoffUntil(providerID: "claude"))
+    }
+
+    /// Two providers, one id each, both drawn: the store has no idea they are
+    /// the same tool and must not collapse them.
+    @MainActor
+    func testTwoProfilesAreTwoCells() {
+        let name = "ClaudeProfileTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: name)!
+        defaults.removePersistentDomain(forName: name)
+        let home = URL(fileURLWithPath: "/Users/vinz")
+        let store = UsageStore(
+            providers: [
+                ClaudeOAuthProvider(profile: .default(home: home), archive: UsageArchive(defaults: defaults)),
+                ClaudeOAuthProvider(profile: ClaudeProfile(slug: "work",
+                                                           configDirectory: home.appendingPathComponent(".claude-work")),
+                                    archive: UsageArchive(defaults: defaults))
+            ],
+            archive: UsageArchive(defaults: defaults)
+        )
+        XCTAssertEqual(store.snapshots.map(\.id), ["claude", "claude-work"])
+        XCTAssertEqual(store.snapshots.map(\.displayName), ["Claude", "Claude (work)"])
+        XCTAssertEqual(store.providerSummaries.map(\.name), ["Claude", "Claude (work)"])
+    }
+}

--- a/Tests/CodexUsageTests.swift
+++ b/Tests/CodexUsageTests.swift
@@ -86,6 +86,65 @@ final class CodexUsageTests: XCTestCase {
     }
 }
 
+/// Newer builds record a `premium`-typed snapshot with null windows. That is
+/// "nothing usable in this file", not a zero — and it must not hide an older
+/// thread's real percentages when the provider walks recent rollouts.
+final class CodexRolloutFallbackTests: XCTestCase {
+    /// Verbatim shape from `~/.codex/sessions/2026/09/06/rollout-…jsonl`.
+    private let premium = """
+    {"timestamp":"2026-09-06T06:13:52.937Z","type":"event_msg","payload":{\
+    "type":"token_count","rate_limits":{"limit_id":"premium","primary":null,\
+    "secondary":null,"credits":{"has_credits":false,"unlimited":false,\
+    "balance":"0"},"plan_type":"plus"}}}
+    """
+
+    func testPremiumSnapshotWithNullWindowsReportsNothingMetered() {
+        XCTAssertThrowsError(try CodexUsage.windows(fromRollout: premium)) { error in
+            guard case UsageProviderError.nothingMetered(let why) = error else {
+                return XCTFail("expected nothingMetered, got \(error)")
+            }
+            XCTAssertEqual(why, "Codex reported no usage windows")
+        }
+    }
+
+    /// The read takes the first rollout *with windows*, so the list has to be
+    /// newest-first with missing files dropped rather than a single newest URL.
+    func testRecentRolloutsAreNewestFirstAndSkipMissingFiles() throws {
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("codex-rollouts-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let old = dir.appendingPathComponent("old.jsonl")
+        let new = dir.appendingPathComponent("new.jsonl")
+        try "x".write(to: old, atomically: true, encoding: .utf8)
+        try "x".write(to: new, atomically: true, encoding: .utf8)
+
+        let store = dir.appendingPathComponent("state.sqlite")
+        var db: OpaquePointer?
+        XCTAssertEqual(sqlite3_open(store.path, &db), SQLITE_OK)
+        defer { sqlite3_close(db) }
+        sqlite3_exec(db, """
+            CREATE TABLE threads (
+                rollout_path TEXT, archived INTEGER, updated_at_ms INTEGER);
+            """, nil, nil, nil)
+        // Newest first in time, plus a missing file and an archived thread —
+        // both must be dropped rather than returned.
+        for (path, ms, archived) in [
+            (new.path, 300, 0), ("/nonexistent/gone.jsonl", 250, 0),
+            (old.path, 200, 0), (old.path, 400, 1),
+        ] as [(String, Int, Int)] {
+            sqlite3_exec(db, """
+                INSERT INTO threads (rollout_path, archived, updated_at_ms)
+                VALUES ('\(path)', \(archived), \(ms));
+                """, nil, nil, nil)
+        }
+
+        XCTAssertEqual(CodexStore.recentRollouts(in: store), [new, old])
+        XCTAssertEqual(CodexStore.newestRollout(in: store), new)
+    }
+}
+
 /// The activity signal is a heuristic — a rollout written moments ago — so what
 /// it will and will not claim is worth pinning down.
 @MainActor

--- a/Tests/CodexUsageTests.swift
+++ b/Tests/CodexUsageTests.swift
@@ -145,6 +145,39 @@ final class CodexRolloutFallbackTests: XCTestCase {
     }
 }
 
+/// A rollout is a record, not a reading: a window whose reset has passed no
+/// longer exists, and its percentage is false rather than merely old. The
+/// case that prompted this: a three-day-old 0% on the 5h window beside a
+/// Codex that had just refused a prompt for lack of that same allowance.
+final class CodexExpiredWindowTests: XCTestCase {
+    private let now = Date(timeIntervalSince1970: 1_788_000_000)
+
+    private func window(id: String, resetsIn seconds: TimeInterval?) -> LimitWindow {
+        LimitWindow(id: id, label: id,
+                    usedFraction: 0,
+                    resetsAt: seconds.map { now.addingTimeInterval($0) })
+    }
+
+    func testAResetWindowIsDropped() {
+        let kept = CodexLocalProvider.current(
+            [window(id: "primary", resetsIn: -3600),
+             window(id: "secondary", resetsIn: 3600)],
+            now: now)
+        XCTAssertEqual(kept.map(\.id), ["secondary"])
+    }
+
+    func testAWindowWithNoResetCarriesNoExpiry() {
+        let kept = CodexLocalProvider.current(
+            [window(id: "primary", resetsIn: nil)], now: now)
+        XCTAssertEqual(kept.map(\.id), ["primary"])
+    }
+
+    func testAllExpiredLeavesNothing() {
+        XCTAssertTrue(CodexLocalProvider.current(
+            [window(id: "primary", resetsIn: -10)], now: now).isEmpty)
+    }
+}
+
 /// The activity signal is a heuristic — a rollout written moments ago — so what
 /// it will and will not claim is worth pinning down.
 @MainActor

--- a/Tests/GLMUsageTests.swift
+++ b/Tests/GLMUsageTests.swift
@@ -1,0 +1,452 @@
+import XCTest
+@testable import Codenotch
+
+/// Guards the shape of `GET /api/monitor/usage/quota/limit`. It is not a
+/// published API, so these are the tests that will fail first if Z.ai changes
+/// it.
+final class GLMQuotaResponseTests: XCTestCase {
+    private func parse(_ json: String) throws -> GLMUsage.Payload {
+        try GLMUsage.parse(Data(json.utf8))
+    }
+
+    /// Trimmed from a real response: the envelope rides under HTTP 200, and
+    /// the session window's reset time is milliseconds since the epoch.
+    private let live = """
+    { "code": 200, "success": true, "msg": "",
+      "data": { "level": "pro",
+        "limits": [
+          { "type": "TOKENS_LIMIT", "unit": 3, "number": 5, "percentage": 12.5,
+            "currentValue": 1250000, "usage": 12000000,
+            "nextResetTime": 1788682200000 },
+          { "type": "TOKENS_LIMIT", "unit": 6, "number": 1, "percentage": 8.1,
+            "nextResetTime": 1789190400000 },
+          { "type": "TIME_LIMIT", "percentage": 4.0,
+            "currentValue": 40, "usage": 1000 } ] } }
+    """
+
+    func testDecodesTheLiveShape() throws {
+        let payload = try parse(live)
+        XCTAssertEqual(payload.level, "pro")
+        XCTAssertEqual(payload.windows.map(\.id), ["session", "weekly", "mcp"])
+        XCTAssertEqual(payload.windows[0].label, "Current session")
+        XCTAssertEqual(payload.windows[0].usedFraction ?? -1, 0.125, accuracy: 0.0001)
+        XCTAssertEqual(payload.windows[1].label, "Weekly")
+        XCTAssertEqual(payload.windows[2].label, "MCP (1 month)")
+    }
+
+    /// Milliseconds, not seconds — parsed as seconds the reset lands in
+    /// January 1970 and the countdown reads as overdue forever.
+    func testResetTimesAreMillisecondsSinceTheEpoch() throws {
+        let windows = try parse(live).windows
+        XCTAssertEqual(windows[0].resetsAt?.timeIntervalSince1970 ?? -1,
+                       1_788_682_200, accuracy: 0.001)
+    }
+
+    func testSessionSortsFirstWhateverOrderTheEndpointLists() throws {
+        let reversed = """
+        { "code": 200, "success": true,
+          "data": { "limits": [
+            { "type": "TIME_LIMIT", "percentage": 4.0 },
+            { "type": "TOKENS_LIMIT", "unit": 6, "number": 1, "percentage": 8.1 },
+            { "type": "TOKENS_LIMIT", "unit": 3, "number": 5, "percentage": 12.5 } ] } }
+        """
+        XCTAssertEqual(try parse(reversed).windows.map(\.id), ["session", "weekly", "mcp"])
+    }
+
+    /// Unlike Claude's windows, a row without a reset time is kept: the MCP
+    /// allowance never carries one, and dropping it would hide a real quota.
+    func testAWindowWithoutAResetTimeIsKept() throws {
+        let noResets = """
+        { "code": 200, "success": true,
+          "data": { "limits": [ { "type": "TIME_LIMIT", "percentage": 4.0 } ] } }
+        """
+        let windows = try parse(noResets).windows
+        XCTAssertEqual(windows.count, 1)
+        XCTAssertNil(windows[0].resetsAt)
+    }
+
+    /// A window that reports no percentage has nothing to draw — dropping it
+    /// beats inventing a scale for a bare count.
+    func testAWindowWithoutAPercentageIsDropped() throws {
+        let json = """
+        { "code": 200, "success": true,
+          "data": { "limits": [ { "type": "TIME_LIMIT", "currentValue": 40 } ] } }
+        """
+        XCTAssertTrue(try parse(json).windows.isEmpty)
+    }
+
+    /// Over the limit is a reading, not an error: the ring sits at full and
+    /// the tooltip says so.
+    func testAPercentageOverOneHundredIsKept() throws {
+        let json = """
+        { "code": 200, "success": true,
+          "data": { "limits": [ { "type": "TOKENS_LIMIT", "unit": 3, "number": 5,
+                                  "percentage": 128.0 } ] } }
+        """
+        let window = try XCTUnwrap(try parse(json).windows.first)
+        XCTAssertEqual(window.usedFraction ?? -1, 1.28, accuracy: 0.0001)
+    }
+
+    /// A token window the encodings do not name yet still renders, with an
+    /// identity derived from its own window length rather than a borrowed one.
+    func testAnUnfamiliarWindowKeepsItsOwnIdentity() throws {
+        let json = """
+        { "code": 200, "success": true,
+          "data": { "limits": [ { "type": "TOKENS_LIMIT", "unit": 4, "number": 2,
+                                  "percentage": 10.0 } ] } }
+        """
+        let window = try XCTUnwrap(try parse(json).windows.first)
+        XCTAssertEqual(window.id, "window-4x2")
+        XCTAssertEqual(window.label, "Usage")
+    }
+
+    /// Recorded from a live credit plan — the Lite tier meters credits rather
+    /// than tokens, answers `CREDIT_LIMIT` instead of `TOKENS_LIMIT`, and
+    /// encodes the window length the same way. The identity has to come from
+    /// the length, or a whole plan renders as an unlabelled row.
+    func testACreditPlanDecodesWithTheSameWindowIdentities() throws {
+        let credit = """
+        { "code": 200, "success": true,
+          "data": { "level": "lite",
+            "limits": [
+              { "type": "CREDIT_LIMIT", "unit": 3, "number": 5, "percentage": 1,
+                "currentValue": 1, "usage": 2000, "nextResetTime": 1788654095358 },
+              { "type": "CREDIT_LIMIT", "unit": 6, "number": 1, "percentage": 17,
+                "currentValue": 1775, "usage": 10000, "nextResetTime": 1789073479999 } ] } }
+        """
+        let payload = try parse(credit)
+        XCTAssertEqual(payload.level, "lite")
+        XCTAssertEqual(payload.windows.map(\.id), ["session", "weekly"])
+        XCTAssertEqual(payload.windows[0].usedFraction ?? -1, 0.01, accuracy: 0.0001)
+        XCTAssertEqual(payload.windows[1].usedFraction ?? -1, 0.17, accuracy: 0.0001)
+    }
+
+    func testMissingEnvelopeKeysStillReadAsSuccess() throws {
+        let bare = """
+        { "data": { "limits": [ { "type": "TIME_LIMIT", "percentage": 4.0 } ] } }
+        """
+        XCTAssertEqual(try parse(bare).windows.count, 1)
+    }
+}
+
+/// Errors ride in under an HTTP 200, so the envelope is read before the
+/// payload is trusted. What each business code means is pinned here.
+final class GLMEnvelopeFailureTests: XCTestCase {
+    private func parse(_ json: String) throws -> GLMUsage.Payload {
+        try GLMUsage.parse(Data(json.utf8))
+    }
+
+    /// `UsageProviderError` carries associated values, so equality here is
+    /// case-by-case rather than `==`.
+    private func assertError(
+        _ body: String, matches expected: UsageProviderError,
+        file: StaticString = #filePath, line: UInt = #line
+    ) {
+        do {
+            _ = try parse(body)
+            XCTFail("the envelope reported failure, but parse succeeded", file: file, line: line)
+        } catch let actual as UsageProviderError {
+            let same: Bool
+            switch (actual, expected) {
+            case (.needsAuth, .needsAuth):
+                same = true
+            case (.rateLimited(let a), .rateLimited(let b)):
+                same = a == b
+            case (.badResponse(let a), .badResponse(let b)):
+                same = a == b
+            default:
+                same = false
+            }
+            XCTAssertTrue(same, "got \(actual), expected \(expected)", file: file, line: line)
+        } catch {
+            XCTFail("unexpected error \(error)", file: file, line: line)
+        }
+    }
+
+    /// Recorded verbatim from an expired-token request: HTTP 200, and the
+    /// failure entirely inside the body.
+    func testAnExpiredTokenRidesInUnderHTTP200() {
+        assertError(#"{"code":401,"msg":"token expired or incorrect","success":false}"#,
+                    matches: .needsAuth)
+    }
+
+    func testARefusedKeyIsNotAnErrorButASignOut() {
+        assertError(#"{"code":403,"success":false}"#, matches: .needsAuth)
+    }
+
+    func testAThrottledAnswerReadsAsRateLimited() {
+        assertError(#"{"code":429,"success":false}"#, matches: .rateLimited(retryAfter: 0))
+    }
+
+    func testAnUnrecognisedBusinessCodeIsABadResponse() {
+        assertError(#"{"code":1305,"msg":"overloaded","success":false}"#,
+                    matches: .badResponse(status: 1305))
+    }
+}
+
+/// The key is borrowed from whichever tool holds it, and each source has its
+/// own file, shape and failure mode. All of these run against fixture files,
+/// never against a real one.
+final class GLMCredentialsTests: XCTestCase {
+    private var scratch: URL!
+
+    override func setUpWithError() throws {
+        scratch = FileManager.default.temporaryDirectory
+            .appendingPathComponent("GLMCredentialsTests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: scratch, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: scratch)
+    }
+
+    private func write(_ json: String, to name: String) throws -> URL {
+        let url = scratch.appendingPathComponent(name)
+        try Data(json.utf8).write(to: url)
+        return url
+    }
+
+    private func load(claude: String? = nil, zcodeConfig: String? = nil,
+                      zcode: String? = nil,
+                      openCode: String? = nil) throws -> GLMCredentials.Credential? {
+        func fixture(_ contents: String?, _ name: String) throws -> URL? {
+            guard let contents else { return nil }
+            return try write(contents, to: name)
+        }
+        return GLMCredentials.load(
+            claudeSettings: try fixture(claude, "claude.json"),
+            zcodeConfig: try fixture(zcodeConfig, "zcode-config.json"),
+            zcodeCredentials: try fixture(zcode, "zcode-credentials.json"),
+            openCodeAuth: try fixture(openCode, "opencode.json")
+        )
+    }
+
+    // MARK: Claude Code
+
+    func testReadsAClaudeCodeKeyPointedAtZDotAI() throws {
+        let credential = try load(claude: """
+        { "env": { "ANTHROPIC_BASE_URL": "https://api.z.ai/api/anthropic",
+                   "ANTHROPIC_AUTH_TOKEN": "sk-glm-abc123" } }
+        """)
+        XCTAssertEqual(credential?.token, "sk-glm-abc123")
+        XCTAssertEqual(credential?.source, "Claude Code")
+        XCTAssertEqual(credential?.baseURL.host, "api.z.ai")
+    }
+
+    /// The base URL is what makes the token GLM's. A settings file aimed at
+    /// Anthropic holds somebody's Anthropic key, and claiming it would read
+    /// the wrong account under GLM's name.
+    func testDoesNotClaimAClaudeCodeKeyAimedAtAnthropic() throws {
+        let anthropic = try load(claude: """
+        { "env": { "ANTHROPIC_BASE_URL": "https://api.anthropic.com",
+                   "ANTHROPIC_AUTH_TOKEN": "sk-ant-abc123" } }
+        """)
+        XCTAssertNil(anthropic)
+    }
+
+    func testDoesNotClaimATokenWithNoBaseURLAtAll() throws {
+        let bare = try load(claude: #"{"env": {"ANTHROPIC_AUTH_TOKEN": "sk-glm-abc123"}}"#)
+        XCTAssertNil(bare)
+    }
+
+    func testTheChinaConsoleKeyReadsFromTheChinaConsole() throws {
+        let credential = try load(claude: """
+        { "env": { "ANTHROPIC_BASE_URL": "https://open.bigmodel.cn/api/anthropic",
+                   "ANTHROPIC_AUTH_TOKEN": "key-abc" } }
+        """)
+        XCTAssertEqual(credential?.baseURL.host, "open.bigmodel.cn")
+    }
+
+    // MARK: ZCode
+
+    func testReadsAZCodePlanKeyFromTheConfiguredProvider() throws {
+        let credential = try load(zcodeConfig: """
+        { "provider": { "builtin:zai-coding-plan": {
+            "kind": "anthropic", "enabled": true,
+            "options": { "apiKey": "zai-plan-key",
+                         "baseURL": "https://api.z.ai/api/anthropic" } } } }
+        """)
+        XCTAssertEqual(credential?.token, "zai-plan-key")
+        XCTAssertEqual(credential?.source, "ZCode")
+        XCTAssertEqual(credential?.baseURL.host, "api.z.ai")
+    }
+
+    /// The baseURL is the tool's own Anthropic endpoint; only its host
+    /// decides the console. Asking the monitor under `/api/anthropic`
+    /// answers a misleading 404, so the path is dropped.
+    func testTheChinaConsolePlanKeyReadsFromTheChinaConsole() throws {
+        let credential = try load(zcodeConfig: """
+        { "provider": { "builtin:bigmodel-coding-plan": {
+            "enabled": true,
+            "options": { "apiKey": "cn-key",
+                         "baseURL": "https://open.bigmodel.cn/api/anthropic" } } } }
+        """)
+        XCTAssertEqual(credential?.baseURL.host, "open.bigmodel.cn")
+    }
+
+    /// A provider switched off in ZCode is an account the user is not using;
+    /// claiming its key would read an account they turned off.
+    func testADisabledPlanProviderIsSkipped() throws {
+        let credential = try load(zcodeConfig: """
+        { "provider": { "builtin:zai-coding-plan": {
+            "enabled": false,
+            "options": { "apiKey": "zai-plan-key",
+                         "baseURL": "https://api.z.ai/api/anthropic" } } } }
+        """)
+        XCTAssertNil(credential)
+    }
+
+    /// A plain API provider is pay-as-you-go, not the plan — the monitor
+    /// reports plan quota, so an entry without `coding-plan` in its name is
+    /// none of ours.
+    func testAPlanlessZCodeProviderIsIgnored() throws {
+        let credential = try load(zcodeConfig: """
+        { "provider": { "builtin:zai": {
+            "enabled": true,
+            "options": { "apiKey": "payg-key",
+                         "baseURL": "https://api.z.ai/api/anthropic" } } } }
+        """)
+        XCTAssertNil(credential)
+    }
+
+    func testReadsAZCodeOAuthKey() throws {
+        let credential = try load(zcode: #"{"oauth:zai:access_token": "zai-token-xyz"}"#)
+        XCTAssertEqual(credential?.token, "zai-token-xyz")
+        XCTAssertEqual(credential?.source, "ZCode")
+    }
+
+    /// Encrypted at rest is a string we cannot read, so it is a string we
+    /// must not send. The source is skipped rather than guessed at.
+    func testSkipsAZCodeKeyEncryptedAtRest() throws {
+        let encrypted = try load(
+            zcode: #"{"oauth:zai:access_token": "enc:v1:uJqn18qD-not-a-real-key"}"#
+        )
+        XCTAssertNil(encrypted)
+    }
+
+    // MARK: OpenCode
+
+    func testReadsAnOpenCodeKeyFromTheCodingPlanEntry() throws {
+        let credential = try load(openCode: #"{"zai-coding-plan": "opencode-key"}"#)
+        XCTAssertEqual(credential?.token, "opencode-key")
+        XCTAssertEqual(credential?.baseURL.host, "api.z.ai")
+    }
+
+    /// The entry is sometimes an object carrying the key rather than the key
+    /// itself; both shapes have shipped.
+    func testReadsAnOpenCodeKeyWrappedInAnObject() throws {
+        let credential = try load(
+            openCode: #"{"zai": {"apiKey": "opencode-key", "type": "api"}}"#
+        )
+        XCTAssertEqual(credential?.token, "opencode-key")
+    }
+
+    func testAZhipuEntryReadsFromTheChinaConsole() throws {
+        let credential = try load(openCode: #"{"zhipu": "cn-key"}"#)
+        XCTAssertEqual(credential?.baseURL.host, "open.bigmodel.cn")
+    }
+
+    // MARK: Priority
+
+    /// The sources are tried in a fixed order, so a machine with two holds a
+    /// stable answer rather than a directory-listing lottery.
+    func testClaudeCodeWinsWhenTwoSourcesArePresent() throws {
+        let credential = try load(
+            claude: #"{"env": {"ANTHROPIC_BASE_URL": "https://api.z.ai/api/anthropic", "ANTHROPIC_AUTH_TOKEN": "claude-key"}}"#,
+            zcode: #"{"oauth:zai:access_token": "zcode-key"}"#
+        )
+        XCTAssertEqual(credential?.token, "claude-key")
+    }
+
+    /// Within ZCode, the key pasted into the plan provider is the one in use;
+    /// the OAuth token is what is left when there is no paste.
+    func testThePlanKeyWinsOverTheOAuthToken() throws {
+        let credential = try load(
+            zcodeConfig: """
+            { "provider": { "builtin:zai-coding-plan": {
+                "enabled": true,
+                "options": { "apiKey": "zai-plan-key",
+                             "baseURL": "https://api.z.ai/api/anthropic" } } } }
+            """,
+            zcode: #"{"oauth:zai:access_token": "zcode-oauth-key"}"#
+        )
+        XCTAssertEqual(credential?.token, "zai-plan-key")
+    }
+
+    func testNoSourceAtAllIsNil() throws {
+        XCTAssertNil(try load())
+    }
+}
+
+/// The monitor endpoint is known to throttle. A poll that keeps firing into a
+/// 429 is how you stay rate-limited, so the back-off is pinned the way
+/// Claude's is.
+final class GLMBackoffTests: XCTestCase {
+    func testTheWaitDoublesWhileTheLimitPersists() {
+        XCTAssertEqual(GLMProvider.backoff(forAttempt: 0, retryAfter: nil), 60)
+        XCTAssertEqual(GLMProvider.backoff(forAttempt: 1, retryAfter: nil), 120)
+        XCTAssertEqual(GLMProvider.backoff(forAttempt: 2, retryAfter: nil), 240)
+    }
+
+    func testItIsCappedSoItAlwaysRecovers() {
+        XCTAssertEqual(GLMProvider.backoff(forAttempt: 99, retryAfter: nil), 15 * 60)
+    }
+
+    func testAZeroHintStillWaitsAMinute() {
+        XCTAssertEqual(GLMProvider.backoff(forAttempt: 0, retryAfter: 0), 60)
+    }
+
+    func testAGenerousHintWins() {
+        XCTAssertEqual(GLMProvider.backoff(forAttempt: 0, retryAfter: 600), 600)
+    }
+
+    private func response(retryAfter: String?) -> HTTPURLResponse {
+        HTTPURLResponse(
+            url: URL(string: "https://api.z.ai/api/monitor/usage/quota/limit")!,
+            statusCode: 429, httpVersion: nil,
+            headerFields: retryAfter.map { ["Retry-After": $0] }
+        )!
+    }
+
+    func testReadsRetryAfterInSeconds() {
+        XCTAssertEqual(GLMProvider.retryAfter(from: response(retryAfter: "120")), 120)
+    }
+
+    func testMissingOrUnparseableHeaderIsNil() {
+        XCTAssertNil(GLMProvider.retryAfter(from: response(retryAfter: nil)))
+        XCTAssertNil(GLMProvider.retryAfter(from: response(retryAfter: "soon")))
+    }
+}
+
+/// The mark is defined rather than traced, so its geometry is pinned: one
+/// loop, inside the unit box, reading as a Z.
+final class GLMGlyphTests: XCTestCase {
+    func testTheOutlineIsASingleLoopInsideTheUnitBox() {
+        let outline = GlyphOutline.glm
+        XCTAssertEqual(outline.count, 1, "one loop; even-odd fill has no counters to keep open")
+        let loop = outline[0]
+        XCTAssertEqual(loop.count, 10)
+        for point in loop {
+            XCTAssertTrue(point.x >= 0 && point.x <= 1, "x \(point.x) outside the unit box")
+            XCTAssertTrue(point.y >= 0 && point.y <= 1, "y \(point.y) outside the unit box")
+        }
+    }
+
+    func testTheMarkMatchesTheProviderGlyph() {
+        XCTAssertEqual(ProviderGlyph.glm.rawValue, "glm")
+        XCTAssertEqual(ProviderGlyph.glm.outline, GlyphOutline.glm)
+        XCTAssertEqual(ProviderGlyph.glm.assetName, "glyph-glm")
+    }
+
+    /// A ring with no reading still draws the glyph: the shape has to have
+    /// ink, or the cell renders an empty ring.
+    func testTheOutlineHasInk() {
+        let loop = GlyphOutline.glm[0]
+        var area = 0.0
+        for (index, point) in loop.enumerated() {
+            let next = loop[(index + 1) % loop.count]
+            area += Double(point.x * next.y - next.x * point.y)
+        }
+        XCTAssertGreaterThan(abs(area) / 2, 0.3, "the mark covers less than a third of its box")
+    }
+}

--- a/Tests/NotchLayoutTests.swift
+++ b/Tests/NotchLayoutTests.swift
@@ -883,7 +883,7 @@ final class StatusMessageHeightTests: XCTestCase {
             ("stale", .stale(since: .distantPast)),
             ("ok", .ok)
         ]
-        return [("claude", "Claude"), ("cursor", "Cursor"),
+        return [("claude", "Claude"), ("claude-work", "Claude (work)"), ("cursor", "Cursor"),
                 ("codex", "Codex"), ("gemini", "Antigravity")].flatMap { id, name in
             states.map { state in
                 ("\(id)/\(state.0)",

--- a/Tests/NotchRenderTests.swift
+++ b/Tests/NotchRenderTests.swift
@@ -394,3 +394,119 @@ final class AlwaysShowTests: XCTestCase {
         XCTAssertTrue(controller.model.staysOpen)
     }
 }
+
+/// A click that arrives while the notch is still folded used to pin it —
+/// permanently, via `togglePinned()` — even though nobody had seen it open.
+/// The pill's own hot zone is deliberately generous, since it is a small
+/// target on a screen edge, which made it easy to trip by accident: reported
+/// as "hover mode sticks open after a stray click".
+///
+/// Pinning stays exactly what a click on a notch that is *already* open does
+/// — that part is documented and unchanged. What changes is the other guard:
+/// a click that arrives before the notch has opened now just opens it, the
+/// same as the pointer arriving would, so it folds back on its own once the
+/// pointer leaves.
+@MainActor
+final class StrayClickPinTests: XCTestCase {
+    func testAClickOnAFoldedNotchOpensWithoutPinning() {
+        let controller = NotchWindowController()
+        XCTAssertFalse(controller.model.isExpanded)
+        XCTAssertFalse(controller.model.isPinned)
+
+        controller.handleClick()
+
+        XCTAssertTrue(controller.model.isExpanded, "the click did not open it at all")
+        XCTAssertFalse(controller.model.isPinned, "a click before it ever opened pinned it")
+    }
+
+    /// However many times it arrives before the notch is actually open — the
+    /// pill's hot zone is large enough that more than one could land.
+    func testRepeatedClicksBeforeOpeningNeverPin() {
+        let controller = NotchWindowController()
+        for _ in 0..<3 { controller.handleClick() }
+        XCTAssertFalse(controller.model.isPinned)
+        XCTAssertTrue(controller.model.isExpanded)
+    }
+}
+
+/// A ring dimmed the instant the very first idle refresh attempt failed,
+/// because `staleAfter` and `idleRefreshInterval` were the same value — so a
+/// reading was *guaranteed* to reach the dimming threshold before an idle
+/// schedule could even try to refresh it once. Reported as "rings dim to
+/// invisibility on every idle cycle".
+final class StaleAfterMarginTests: XCTestCase {
+    private final class FailingProvider: UsageProvider, @unchecked Sendable {
+        let id = "x"
+        let displayName = "X"
+        let glyph = ProviderGlyph.claude
+        private var succeedOnce = true
+
+        func fetchSnapshot() async throws -> ProviderSnapshot {
+            defer { succeedOnce = false }
+            if succeedOnce {
+                return ProviderSnapshot(id: id, displayName: displayName, glyph: glyph,
+                                        fidelity: .official, status: .ok,
+                                        windows: [LimitWindow(id: "w", label: "W",
+                                                              usedFraction: 0.1)])
+            }
+            throw UsageProviderError.badResponse(status: 500)
+        }
+        nonisolated func account() -> ProviderAccount? { nil }
+        nonisolated var signInRoute: SignInRoute { .guidance("") }
+        func signOut() async {}
+        func presentSignIn() {}
+        nonisolated func forgetCachedCredential() {}
+    }
+
+    private func defaults() -> UserDefaults {
+        let name = "StaleAfterMarginTests.\(UUID().uuidString)"
+        let d = UserDefaults(suiteName: name)!
+        d.removePersistentDomain(forName: name)
+        return d
+    }
+
+    /// One failed attempt, well inside the margin, must not dim the ring —
+    /// that is the ordinary shape of an idle afternoon, not a fault.
+    @MainActor
+    func testOneFailedIdleAttemptDoesNotDimTheRing() async throws {
+        let store = UsageStore(
+            providers: [FailingProvider()],
+            refreshInterval: 0.05, idleRefreshInterval: 0.15, staleAfter: 0.45,
+            archive: UsageArchive(defaults: defaults())
+        )
+        await store.refresh()
+        XCTAssertEqual(store.snapshots.first?.status, .ok)
+
+        try await Task.sleep(nanoseconds: 200_000_000)   // > idleRefreshInterval
+        await store.refresh()                            // the attempt that fails
+
+        let status = try XCTUnwrap(store.snapshots.first?.status)
+        XCTAssertFalse(status.isStale,
+                       "the ring dimmed after a single failed attempt, well inside the margin")
+    }
+
+    /// Once genuinely stale for longer than the margin, it does dim — the
+    /// mechanism still works, it just no longer fires prematurely.
+    @MainActor
+    func testItStillDimsOnceGenuinelyStale() async throws {
+        let store = UsageStore(
+            providers: [FailingProvider()],
+            refreshInterval: 0.05, idleRefreshInterval: 0.05, staleAfter: 0.2,
+            archive: UsageArchive(defaults: defaults())
+        )
+        await store.refresh()
+        try await Task.sleep(nanoseconds: 300_000_000)   // > staleAfter
+        await store.refresh()
+
+        let status = try XCTUnwrap(store.snapshots.first?.status)
+        XCTAssertTrue(status.isStale, "the mechanism no longer dims a genuinely old reading")
+    }
+
+    /// The shipped defaults keep the same three-to-one margin verified above,
+    /// not just some values that happen to satisfy it.
+    @MainActor
+    func testTheShippedDefaultsKeepTheSameMargin() {
+        let store = UsageStore(providers: [])
+        XCTAssertGreaterThan(store.staleAfterForTesting, store.idleRefreshIntervalForTesting)
+    }
+}

--- a/Tests/ProviderSummaryTests.swift
+++ b/Tests/ProviderSummaryTests.swift
@@ -1,0 +1,133 @@
+import XCTest
+@testable import Codenotch
+
+/// What the settings row is allowed to offer.
+///
+/// "Allow access…" used to be shown for every keychain-backed provider,
+/// unconditionally. That put a remedy on screen next to a perfectly working
+/// account, and — because the same row looked identical when the remedy *was*
+/// needed — gave no way to tell a button that had nothing to do from one that
+/// was failing to do it.
+@MainActor
+final class ProviderSummaryTests: XCTestCase {
+
+    /// A refusal reaches the row. It did not before: `ProviderSummary` carried
+    /// no notion of one.
+    func testARefusalReachesTheRow() async {
+        let provider = SwitchableProvider(outcome: .failure(.accessDenied))
+        let store = makeStore(provider)
+
+        await store.refresh()
+
+        XCTAssertTrue(store.providerSummaries.first?.wasRefusedAccess ?? false)
+    }
+
+    /// The case the first attempt at this got wrong.
+    ///
+    /// With a good reading already in hand, `supersedesHistory` keeps the old
+    /// snapshot *and its status* through a refusal — on purpose, because the
+    /// number is still true. Anything reading the refusal off the snapshot sees
+    /// `.ok` and shows nothing, which is exactly what happened on screen.
+    func testARefusalReachesTheRowEvenWithAGoodReadingInHand() async {
+        let provider = SwitchableProvider(outcome: .success)
+        let store = makeStore(provider)
+
+        await store.refresh()
+        XCTAssertFalse(store.providerSummaries.first?.wasRefusedAccess ?? true)
+        // The snapshot deliberately keeps saying the reading is fine.
+        provider.outcome = .failure(.accessDenied)
+
+        await store.refresh()
+
+        XCTAssertNotEqual(store.snapshots.first?.status, .accessDenied,
+                          "the remembered reading should have survived the refusal")
+        XCTAssertTrue(store.providerSummaries.first?.wasRefusedAccess ?? false,
+                      "the row could not tell it had been refused")
+    }
+
+    /// And it clears as soon as macOS lets us back in, so the remedy stops being
+    /// offered the moment it stops being needed.
+    func testTheRemedyGoesAwayOnceAccessIsGrantedAgain() async {
+        let provider = SwitchableProvider(outcome: .failure(.accessDenied))
+        let store = makeStore(provider)
+
+        await store.refresh()
+        XCTAssertTrue(store.providerSummaries.first?.wasRefusedAccess ?? false)
+
+        provider.outcome = .success
+        await store.refresh()
+
+        XCTAssertFalse(store.providerSummaries.first?.wasRefusedAccess ?? true,
+                       "the button would have stayed on screen with nothing to fix")
+    }
+
+    /// Other failures are not refusals. `needsAuth` in particular has no
+    /// keychain dialogue behind it to raise.
+    func testOtherFailuresDoNotOfferTheAccessRemedy() async {
+        for error in [UsageProviderError.needsAuth,
+                      .badResponse(status: 500),
+                      .rateLimited(retryAfter: 60)] {
+            let store = makeStore(SwitchableProvider(outcome: .failure(error)))
+            await store.refresh()
+            XCTAssertFalse(store.providerSummaries.first?.wasRefusedAccess ?? true,
+                           "\(error) was treated as a keychain refusal")
+        }
+    }
+
+    /// Before the first fetch nothing has been refused, so nothing is offered.
+    ///
+    /// The store seeds its snapshots at init rather than leaving them absent, so
+    /// the row must reach its verdict from an actual refusal and not from the
+    /// mere presence — or absence — of a reading.
+    func testWithoutAFetchTheRowOffersNothing() {
+        let store = makeStore(SwitchableProvider(outcome: .failure(.accessDenied)))
+
+        XCTAssertFalse(store.providerSummaries.first?.wasRefusedAccess ?? true,
+                       "a remedy was offered before anything had failed")
+    }
+
+    // MARK: - Helpers
+
+    private func makeStore(_ provider: SwitchableProvider) -> UsageStore {
+        let name = "ProviderSummaryTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: name)!
+        defaults.removePersistentDomain(forName: name)
+        return UsageStore(providers: [provider], archive: UsageArchive(defaults: defaults))
+    }
+}
+
+/// A provider whose answer can be changed between refreshes, so a test can put
+/// a good reading in the store's hands before taking access away.
+private final class SwitchableProvider: UsageProvider, @unchecked Sendable {
+    enum Outcome {
+        case success
+        case failure(UsageProviderError)
+    }
+
+    let id = "claude"
+    let displayName = "Claude"
+    let glyph = ProviderGlyph.claude
+    var outcome: Outcome
+
+    init(outcome: Outcome) { self.outcome = outcome }
+
+    func fetchSnapshot() async throws -> ProviderSnapshot {
+        switch outcome {
+        case .failure(let error):
+            throw error
+        case .success:
+            return ProviderSnapshot(
+                id: id, displayName: displayName, glyph: glyph,
+                fidelity: .official, status: .ok,
+                windows: [LimitWindow(id: "session", label: "Current session",
+                                      usedFraction: 0.42,
+                                      resetsAt: Date().addingTimeInterval(3600))]
+            )
+        }
+    }
+    func account() -> ProviderAccount? { nil }
+    nonisolated var signInRoute: SignInRoute { .guidance("—") }
+    func signOut() async {}
+    func presentSignIn() {}
+    nonisolated func forgetCachedCredential() {}
+}

--- a/project.yml
+++ b/project.yml
@@ -13,8 +13,8 @@ settings:
     # Sources/Info.plist reads both from here — hardcoding them there instead
     # silently pins every build to one version, so no customer ever sees an
     # update. Bump CURRENT_PROJECT_VERSION on every release.
-    MARKETING_VERSION: "1.3.0"
-    CURRENT_PROJECT_VERSION: "4"
+    MARKETING_VERSION: "1.4.0"
+    CURRENT_PROJECT_VERSION: "5"
     # Signed with a stable identity on purpose. The app reads Claude Code's
     # OAuth token out of the login keychain, and the keychain's ACL remembers
     # *which signed binary* was allowed. Ad-hoc or unsigned builds get a new


### PR DESCRIPTION
Merge after #8 (stacked; diff shrinks once #8 lands — this PR's own commit is the Codex one).

Newer Codex builds write a premium-typed snapshot with null windows into the newest thread; the provider read that thread only and reported 'no usage windows', hiding older real readings. Now it walks recent rollouts newest-first and takes the first with usable windows (its own timestamp decides staleness). Activity monitor unchanged.

Test: make test green, incl. new CodexRolloutFallbackTests.