### PR TITLE
fix: stop disconnected providers reading accounts or restoring usage

### DIFF
--- a/Sources/Model/UsageStore.swift
+++ b/Sources/Model/UsageStore.swift
@@ -14,13 +14,20 @@ final class UsageStore: ObservableObject {
     @Published private(set) var refusedAccess: Set<String> = []
 
     private let providers: [UsageProvider]
+    /// A response belongs to the connection that started it. Checking only
+    /// `disconnected` would accept an old response after a quick off/on toggle.
+    private var connectionVersions: [String: UUID] = [:]
     /// Providers the user has switched off. They are not fetched at all — their
     /// credential is never read, which is the whole point of switching one off.
     /// Filtering the results afterwards would still touch the keychain.
     @Published var disconnected: Set<String> = [] {
         didSet {
             guard disconnected != oldValue else { return }
+            for id in disconnected.symmetricDifference(oldValue) {
+                connectionVersions[id] = UUID()
+            }
             snapshots.removeAll { disconnected.contains($0.id) }
+            refusedAccess.subtract(disconnected)
             // The remembered reading has to go as well. Dropping it from
             // `snapshots` alone left it in `lastGood`, which is written to the
             // archive wholesale on every fetch — so a switched-off provider was
@@ -108,7 +115,8 @@ final class UsageStore: ObservableObject {
     var providerSummaries: [ProviderSummary] {
         providers.map { provider in
             ProviderSummary(id: provider.id, name: provider.displayName,
-                            glyph: provider.glyph, account: provider.account(),
+                            glyph: provider.glyph,
+                            account: disconnected.contains(provider.id) ? nil : provider.account(),
                             signIn: provider.signInRoute,
                             wasRefusedAccess: refusedAccess.contains(provider.id))
         }
@@ -179,13 +187,18 @@ final class UsageStore: ObservableObject {
 
     func refresh() async {
         let live = providers.filter { !disconnected.contains($0.id) }
+        let versions = connectionVersions
         refreshing = Set(live.map(\.id))
         defer { refreshing = [] }
         var next: [ProviderSnapshot] = []
         for provider in live {
-            next.append(await snapshot(from: provider))
+            if let fresh = await snapshot(from: provider, version: versions[provider.id]) {
+                next.append(fresh)
+            }
         }
-        snapshots = next
+        // An earlier result can have been disconnected while a later provider
+        // was awaiting its response. Do not put that reading back on screen.
+        snapshots = next.filter { isCurrent($0.id, version: versions[$0.id]) }
     }
 
     /// Refetch one provider, leaving the others alone.
@@ -199,9 +212,11 @@ final class UsageStore: ObservableObject {
               !refreshing.contains(providerID) else { return }
 
         refreshing.insert(providerID)
+        let version = connectionVersions[providerID]
         Task { [weak self] in
-            let fresh = await self?.snapshot(from: provider)
-            guard let self, let fresh else { return }
+            guard let self else { return }
+            defer { self.refreshing.remove(providerID) }
+            guard let fresh = await self.snapshot(from: provider, version: version) else { return }
             if let index = self.snapshots.firstIndex(where: { $0.id == providerID }) {
                 self.snapshots[index] = fresh
             }
@@ -209,7 +224,6 @@ final class UsageStore: ObservableObject {
             // A beat of visible work even when the answer was instant: a spinner
             // that flashes for one frame reads as a glitch, not as a refresh.
             try? await Task.sleep(nanoseconds: 380_000_000)
-            self.refreshing.remove(providerID)
         }
     }
 
@@ -228,6 +242,10 @@ final class UsageStore: ObservableObject {
     func signOut(providerID: String) {
         guard let provider = providers.first(where: { $0.id == providerID }) else { return }
 
+        // The settings binding calls signOut before delivering disconnected.
+        // Invalidate pending responses immediately, before that binding arrives.
+        connectionVersions[providerID] = UUID()
+        refusedAccess.remove(providerID)
         snapshots.removeAll { $0.id == providerID }
         lastGood.removeValue(forKey: providerID)
         archive.forget(providerID)
@@ -297,15 +315,25 @@ final class UsageStore: ObservableObject {
         }
     }
 
-    private func snapshot(from provider: UsageProvider) async -> ProviderSnapshot {
+    private func isCurrent(_ providerID: String, version: UUID?) -> Bool {
+        !Task.isCancelled && !disconnected.contains(providerID)
+            && connectionVersions[providerID] == version
+    }
+
+    private func snapshot(from provider: UsageProvider, version: UUID?) async -> ProviderSnapshot? {
+        // A provider may have been switched off while waiting behind another
+        // provider in the serial refresh. Do not read its credential at all.
+        guard isCurrent(provider.id, version: version) else { return nil }
         do {
             let fresh = try await provider.fetchSnapshot()
+            guard isCurrent(provider.id, version: version) else { return nil }
             lastGood[provider.id] = (fresh, Date())
             archive.save(lastGood)
             refusedAccess.remove(provider.id)
             Log.usage.debug("\(provider.id, privacy: .public): \(fresh.windows.count) window(s)")
             return fresh
         } catch {
+            guard isCurrent(provider.id, version: version) else { return nil }
             Log.usage.error("\(provider.id, privacy: .public) failed: \(String(describing: error), privacy: .public)")
             return degraded(provider: provider, error: error)
         }

--- a/Tests/ProviderDisconnectionTests.swift
+++ b/Tests/ProviderDisconnectionTests.swift
@@ -1,0 +1,238 @@
+import Combine
+import XCTest
+@testable import Codenotch
+
+@MainActor
+final class ProviderDisconnectionTests: XCTestCase {
+    private func makeStore(_ providers: [UsageProvider], disconnected: Set<String> = [])
+        -> (UsageStore, UsageArchive) {
+        let name = "ProviderDisconnectionTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: name)!
+        addTeardownBlock { defaults.removePersistentDomain(forName: name) }
+        let archive = UsageArchive(defaults: defaults)
+        return (UsageStore(providers: providers, archive: archive, disconnected: disconnected), archive)
+    }
+
+    func testSettingsDoesNotReadADisconnectedAccount() {
+        let disabled = Probe(id: "disabled")
+        let enabled = Probe(id: "enabled")
+        let (store, _) = makeStore([disabled, enabled], disconnected: [disabled.id])
+
+        let summaries = store.providerSummaries
+
+        XCTAssertEqual(summaries.map(\.id), [disabled.id, enabled.id])
+        XCTAssertNil(summaries.first?.account)
+        XCTAssertEqual(disabled.accountReads, 0)
+        XCTAssertEqual(enabled.accountReads, 1)
+    }
+
+    func testDisconnectDiscardsAnInFlightReadingAndItsArchive() async {
+        let started = expectation(description: "Request started")
+        let provider = Probe(id: "a", started: started)
+        let (store, archive) = makeStore([provider])
+        store.refreshNow()
+        await fulfillment(of: [started], timeout: 2)
+
+        store.disconnected = [provider.id]
+        await finish(provider, in: store)
+
+        XCTAssertTrue(store.snapshots.isEmpty)
+        XCTAssertNil(archive.load()[provider.id])
+    }
+
+    func testDisconnectDiscardsAnInFlightAccessRefusal() async {
+        let started = expectation(description: "Request started")
+        let provider = Probe(id: "a", started: started)
+        let (store, archive) = makeStore([provider])
+        store.refreshNow()
+        await fulfillment(of: [started], timeout: 2)
+
+        store.disconnected = [provider.id]
+        await finish(provider, in: store, error: .accessDenied)
+
+        XCTAssertTrue(store.snapshots.isEmpty)
+        XCTAssertTrue(store.refusedAccess.isEmpty)
+        XCTAssertNil(archive.load()[provider.id])
+    }
+
+    func testAQueuedProviderIsNotReadAfterItIsDisconnected() async {
+        let started = expectation(description: "First request started")
+        let first = Probe(id: "a", started: started)
+        let queued = Probe(id: "b")
+        let (store, archive) = makeStore([first, queued])
+        store.refreshNow()
+        await fulfillment(of: [started], timeout: 2)
+
+        store.disconnected = [queued.id]
+        await finish(first, in: store)
+
+        XCTAssertEqual(queued.calls, 0)
+        XCTAssertEqual(store.snapshots.map(\.id), [first.id])
+        XCTAssertNil(archive.load()[queued.id])
+        XCTAssertNotNil(archive.load()[first.id])
+    }
+
+    func testAnEarlierResultCannotReturnWhileALaterProviderIsWaiting() async {
+        let started = expectation(description: "Second request started")
+        let first = Probe(id: "a")
+        let second = Probe(id: "b", started: started)
+        let (store, archive) = makeStore([first, second])
+        store.refreshNow()
+        await fulfillment(of: [started], timeout: 2)
+        XCTAssertNotNil(archive.load()[first.id])
+
+        store.disconnected = [first.id]
+        await finish(second, in: store)
+
+        XCTAssertEqual(store.snapshots.map(\.id), [second.id])
+        XCTAssertNil(archive.load()[first.id])
+        XCTAssertNotNil(archive.load()[second.id])
+    }
+
+    func testReconnectingDoesNotAcceptThePreviousConnectionsResponse() async {
+        let started = expectation(description: "Old request started")
+        let provider = Probe(id: "a", started: started)
+        let (store, archive) = makeStore([provider])
+        store.refreshNow()
+        await fulfillment(of: [started], timeout: 2)
+
+        store.disconnected = [provider.id]
+        store.disconnected = []
+        await finish(provider, in: store)
+
+        XCTAssertTrue(store.snapshots.isEmpty)
+        XCTAssertNil(archive.load()[provider.id])
+
+        // Only the first request is suspended: the next connection can refresh
+        // normally, so rejecting the old response must not leave it locked out.
+        await store.refresh()
+        XCTAssertEqual(provider.calls, 2)
+        XCTAssertEqual(store.snapshots.map(\.id), [provider.id])
+        XCTAssertNotNil(archive.load()[provider.id])
+    }
+
+    func testDisconnectDiscardsASingleProviderRefreshAndClearsItsSpinner() async {
+        let started = expectation(description: "Single request started")
+        let provider = Probe(id: "a", started: started)
+        let (store, archive) = makeStore([provider])
+        store.refresh(providerID: provider.id)
+        await fulfillment(of: [started], timeout: 2)
+
+        store.disconnected = [provider.id]
+        // Its automatically scheduled full refresh has no enabled providers.
+        // Await it before releasing the single-provider response.
+        await waitForRefreshToFinish(store)
+        provider.resolve()
+        await waitForResponseProcessing()
+
+        XCTAssertTrue(store.snapshots.isEmpty)
+        XCTAssertNil(archive.load()[provider.id])
+        XCTAssertTrue(store.refreshing.isEmpty)
+    }
+
+    func testSignOutInvalidatesAResponseBeforeThePreferenceBindingArrives() async {
+        let started = expectation(description: "Request started")
+        let provider = Probe(id: "a", started: started)
+        let (store, archive) = makeStore([provider])
+        store.refreshNow()
+        await fulfillment(of: [started], timeout: 2)
+
+        store.signOut(providerID: provider.id)
+        await finish(provider, in: store)
+
+        XCTAssertTrue(store.snapshots.isEmpty)
+        XCTAssertNil(archive.load()[provider.id])
+    }
+
+    func testSignOutClearsASingleProviderSpinnerEvenWhenItsResponseIsDiscarded() async {
+        let started = expectation(description: "Single request started")
+        let provider = Probe(id: "a", started: started)
+        let (store, archive) = makeStore([provider])
+        store.refresh(providerID: provider.id)
+        await fulfillment(of: [started], timeout: 2)
+
+        store.signOut(providerID: provider.id)
+        await finish(provider, in: store)
+
+        XCTAssertTrue(store.snapshots.isEmpty)
+        XCTAssertNil(archive.load()[provider.id])
+        XCTAssertTrue(store.refreshing.isEmpty)
+    }
+
+    private func finish(_ provider: Probe, in store: UsageStore,
+                        error: UsageProviderError? = nil) async {
+        let finished = expectation(description: "Refresh finished")
+        let subscription = store.$refreshing.dropFirst().filter(\.isEmpty).prefix(1)
+            .sink { _ in finished.fulfill() }
+        provider.resolve(error: error)
+        await fulfillment(of: [finished], timeout: 2)
+        withExtendedLifetime(subscription) {}
+    }
+
+    private func waitForRefreshToFinish(_ store: UsageStore) async {
+        let finished = expectation(description: "Scheduled refresh finished")
+        let subscription = store.$refreshing.dropFirst().filter(\.isEmpty).prefix(1)
+            .sink { _ in finished.fulfill() }
+        await fulfillment(of: [finished], timeout: 2)
+        withExtendedLifetime(subscription) {}
+    }
+
+    private func waitForResponseProcessing() async {
+        // A short bounded wait also covers the existing 380ms single-cell
+        // spinner delay when this regression is run against the old code.
+        try? await Task.sleep(nanoseconds: 500_000_000)
+    }
+}
+
+/// Suspends its first fetch until the test releases it; later fetches return
+/// immediately. No network, real account files, or keychain reads are involved.
+private final class Probe: UsageProvider, @unchecked Sendable {
+    let id: String
+    let displayName = "Probe"
+    let glyph = ProviderGlyph.claude
+    private let started: XCTestExpectation?
+    private let lock = NSLock()
+    private var pending: CheckedContinuation<ProviderSnapshot, Error>?
+    private var fetchCount = 0
+    private var accountCount = 0
+
+    init(id: String, started: XCTestExpectation? = nil) {
+        self.id = id
+        self.started = started
+    }
+
+    var calls: Int { lock.withLock { fetchCount } }
+    var accountReads: Int { lock.withLock { accountCount } }
+
+    func account() -> ProviderAccount? {
+        lock.withLock { accountCount += 1 }
+        return ProviderAccount(label: "Test account", plan: nil, source: "Probe", manageURL: nil)
+    }
+
+    func fetchSnapshot() async throws -> ProviderSnapshot {
+        let first = lock.withLock { fetchCount += 1; return fetchCount == 1 }
+        if first, let started {
+            return try await withCheckedThrowingContinuation { continuation in
+                lock.withLock { pending = continuation }
+                started.fulfill()
+            }
+        }
+        return reading()
+    }
+
+    func resolve(error: UsageProviderError? = nil) {
+        let continuation = lock.withLock {
+            let continuation = pending
+            pending = nil
+            return continuation
+        }
+        if let error { continuation?.resume(throwing: error) }
+        else { continuation?.resume(returning: reading()) }
+    }
+
+    private func reading() -> ProviderSnapshot {
+        ProviderSnapshot(id: id, displayName: displayName, glyph: glyph,
+                         fidelity: .official, status: .ok,
+                         windows: [LimitWindow(id: "session", label: "Session", usedFraction: 0.42)])
+    }
+}


### PR DESCRIPTION
Turning a provider off could still read its account when Settings opened. If a refresh was already running, its late response could also restore the removed ring and re-save the forgotten usage reading.

This change makes the disconnected state apply to account summaries and to every stage of a usage refresh:

- Keep disconnected providers listed in Settings without calling `account()`.
- Invalidate outstanding responses when the connection changes or sign-out begins, including a quick off/on toggle.
- Skip providers disconnected while queued behind another request; discard late successes and failures before updating the archive or access-refusal state.
- Recheck accumulated results before publishing a full refresh, and clear the single-provider spinner when a result is discarded.

Already-sent requests may finish; their results are discarded. The provider endpoints and polling intervals are unchanged.

Validation:

- Added 9 regression tests using controlled fake providers and isolated UserDefaults suites, without live credentials or network requests.
- Ran the first 8 regression cases against unchanged v1.4.0 (`60bafc2`): all 8 failed, reproducing the defects. All 9 pass with the fix.
- Full suite: 555 tests passed on Apple silicon, macOS 26.6.2.
- `git diff --check` passed.

The full suite was run with the existing XcodeGen scheme and local signing overrides because the current project requires the maintainer's certificate (already addressed separately by #8):

```sh
xcodegen generate
xcodebuild -project Codenotch.xcodeproj -scheme Codenotch \
  -destination 'platform=macOS,arch=arm64' -configuration Debug \
  -derivedDataPath build/DerivedData CODE_SIGN_IDENTITY=- DEVELOPMENT_TEAM= test
```
