### PR TITLE
Read Cursor usage from cursor-agent when the editor is missing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 build/
 .build/
 dist/
+Package.resolved
 DerivedData/
 *.xcodeproj
 *.xcworkspace

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 .DS_Store
 build/
+.build/
+dist/
 DerivedData/
 *.xcodeproj
 *.xcworkspace

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ two never disagree.
 | Provider | Source | How |
 |---|---|---|
 | **Claude Code** | official | The OAuth token in the login keychain, against the same endpoint Claude Code's own `/usage` uses. |
-| **Cursor** | official | The editor's own signed-in session, read from its local SQLite state — no separate sign-in. |
+| **Cursor** | official | The editor's signed-in session in its local SQLite state, or the `cursor-agent` login in the keychain — no separate sign-in. |
 | **Codex** | official | ChatGPT's usage endpoint, using the local Codex sign-in. Shows the 5-hour and weekly limits when available. |
 | **Antigravity** | official where licensed, otherwise a request count | Antigravity's local language server first, then Google's quota endpoint; a plain count when neither will answer for the account. |
 | **GLM** | official | Z.ai's Coding Plan monitor endpoint, with a key borrowed from whichever coding tool already holds one — Claude Code's `settings.json`, ZCode, or OpenCode. |

--- a/Sources/App/AppDelegate.swift
+++ b/Sources/App/AppDelegate.swift
@@ -59,8 +59,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             let preferences = Preferences()
             self.preferences = preferences
 
-            // Cursor reads the editor's own session rather than a browser one:
-            // signing into cursor.com separately created a second, empty account.
+            // Cursor reads the editor's session, or cursor-agent's if the
+            // editor is missing — never a browser one: signing into
+            // cursor.com separately created a second, empty account.
             //
             // Built *after* preferences and told what is switched off, so the
             // very first list it draws already excludes them. Constructed first,

--- a/Sources/Providers/CursorCredentials.swift
+++ b/Sources/Providers/CursorCredentials.swift
@@ -1,13 +1,22 @@
 import Foundation
+import Security
 import SQLite3
 
-/// The session Cursor's editor keeps for itself, in the SQLite global-state
-/// store it inherits from VS Code.
+/// The session Cursor keeps for itself — the editor's SQLite store first,
+/// then the `cursor-agent` login if that store is missing or signed out.
 ///
 /// Codenotch only ever reads it, the same bargain as Claude Code's keychain
-/// token: the editor mints and refreshes it, we borrow the current value. The
-/// database is opened read-only and `immutable`, so a running editor is never
-/// blocked or corrupted by us looking.
+/// token: the owning tool mints and refreshes it, we borrow the current value.
+/// The editor database is opened read-only and never `immutable`, so a running
+/// editor is not blocked and a rotated token is not served from a stale
+/// checkpoint. The agent token lives in the login keychain; that read is
+/// cached, because every data fetch can raise a prompt.
+///
+/// The two sessions are the same cookie. `/api/usage-summary` wants
+/// `WorkosCursorSessionToken={accountID}::{accessToken}`. The editor stores
+/// those two halves in SQLite; the CLI stores the JWT under
+/// `cursor-access-token` and the account id in `~/.cursor/cli-config.json`.
+/// A token-only cookie, or a Bearer header, is 401 — the pair is required.
 struct CursorCredentials {
     let accountID: String
     let accessToken: String
@@ -19,15 +28,28 @@ struct CursorCredentials {
             .appendingPathComponent("Library/Application Support/Cursor/User/globalStorage/state.vscdb")
     }
 
+    /// Written by `cursor-agent login`. Non-secret: email and the WorkOS
+    /// subject that belongs in the cookie. The JWT itself is not here.
+    static var agentConfigURL: URL {
+        URL(fileURLWithPath: NSHomeDirectory())
+            .appendingPathComponent(".cursor/cli-config.json")
+    }
+
     /// Minted by ToDesktop, who build Cursor — stable across updates, but not
     /// across Cursor leaving ToDesktop or rebranding. Kept here beside the store
     /// path so the two facts about a Cursor installation change together: the
     /// activity monitor and the sign-in route both read this one.
     static let bundleID = "com.todesktop.230313mzl4w4u92"
 
+    /// Identity, editor first. A machine with only `cursor-agent` has no
+    /// `cachedEmail` row, so the CLI config is the address we can show.
+    static func account() -> ProviderAccount? {
+        account(from: storeURL) ?? agentAccount(from: agentConfigURL)
+    }
+
     /// Identity, read from the same store as the session. Non-secret: the email
     /// and plan the editor caches for its own UI.
-    static func account(from url: URL = storeURL) -> ProviderAccount? {
+    static func account(from url: URL) -> ProviderAccount? {
         guard let db = SQLiteStore.open(url) else { return nil }
         defer { sqlite3_close(db) }
         func value(_ key: String) -> String? {
@@ -42,7 +64,33 @@ struct CursorCredentials {
         )
     }
 
-    static func load(from url: URL = storeURL) throws -> CursorCredentials {
+    static func agentAccount(from url: URL) -> ProviderAccount? {
+        guard let info = agentAuthInfo(from: url),
+              info.email != nil || info.authId != nil
+        else { return nil }
+        return ProviderAccount(
+            label: info.email,
+            plan: nil,
+            source: "cursor-agent",
+            manageURL: URL(string: "https://cursor.com/dashboard")
+        )
+    }
+
+    /// Editor first. The CLI session is only reached when the editor has
+    /// nothing to borrow — otherwise a laptop with both would flip between
+    /// accounts depending on which file we happened to read.
+    static func load() throws -> CursorCredentials {
+        do {
+            return try load(from: storeURL)
+        } catch UsageProviderError.needsAuth {
+            return try session(fromAgentToken: try CursorAgentKeychain.load(),
+                               configURL: agentConfigURL)
+        }
+    }
+
+    /// Editor store only. Tests, and the combined loader above, pin the path
+    /// so a missing editor cannot silently become a live keychain read.
+    static func load(from url: URL) throws -> CursorCredentials {
         guard FileManager.default.fileExists(atPath: url.path) else {
             throw UsageProviderError.needsAuth
         }
@@ -62,8 +110,170 @@ struct CursorCredentials {
         return CursorCredentials(accountID: account, accessToken: token)
     }
 
+    /// Same precedence as `load()`, with the agent token injected so the
+    /// fallback can be tested without a keychain.
+    static func load(editorStore: URL, agentToken: String?, agentConfig: URL,
+                     now: Date = Date()) throws -> CursorCredentials {
+        do {
+            return try load(from: editorStore)
+        } catch UsageProviderError.needsAuth {
+            guard let agentToken, !agentToken.isEmpty else { throw UsageProviderError.needsAuth }
+            return try session(fromAgentToken: agentToken, configURL: agentConfig, now: now)
+        }
+    }
+
+    /// Open the editor when it is installed; otherwise name the CLI command.
+    /// Offering "Open Cursor" on a machine that has never had the app is a
+    /// button that does nothing — worse than no button.
+    static func signInRoute(editorInstalled: Bool) -> SignInRoute {
+        if editorInstalled {
+            return .openApp(bundleID: bundleID, name: "Cursor")
+        }
+        return .guidance(
+            "Run `cursor-agent login` once — the notch reads that session. "
+            + "The Cursor editor works the same way, if you have it."
+        )
+    }
+
+    static func forgetCachedAgent() { CursorAgentKeychain.forgetCached() }
+
+    /// The cookie's left half. `authId` is the WorkOS subject the editor
+    /// itself stores as `stripeMembershipAuthId`. Numeric `userId` also works
+    /// against the same endpoint, and the JWT `sub` is the last resort when
+    /// someone has a token but no config file yet.
+    static func agentAccountID(token: String, configURL: URL) -> String? {
+        if let info = agentAuthInfo(from: configURL) {
+            if let authId = info.authId { return authId }
+            if let userId = info.userId { return userId }
+        }
+        guard let sub = claims(inJWT: token)?["sub"] as? String, !sub.isEmpty else { return nil }
+        return sub
+    }
+
+    static func session(fromAgentToken token: String, configURL: URL,
+                        now: Date = Date()) throws -> CursorCredentials {
+        let trimmed = token.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { throw UsageProviderError.needsAuth }
+        if agentTokenIsExpired(trimmed, now: now) {
+            throw UsageProviderError.credentialExpired
+        }
+        guard let accountID = agentAccountID(token: trimmed, configURL: configURL),
+              !accountID.isEmpty
+        else { throw UsageProviderError.needsAuth }
+        return CursorCredentials(accountID: accountID, accessToken: trimmed)
+    }
+
+    static func agentTokenIsExpired(_ token: String, now: Date = Date()) -> Bool {
+        // JWT `exp` is an integer second. JSONSerialization hands it back as
+        // NSNumber; `as? Double` is the wrong ask and would miss a live expiry.
+        guard let exp = (claims(inJWT: token)?["exp"] as? NSNumber)?.doubleValue else { return false }
+        return exp <= now.timeIntervalSince1970
+    }
+
+    /// Claims supply the subject and a local expiry hint. The server validates
+    /// the token; this is only so an aged-out JWT can keep the last reading
+    /// instead of looking like a sign-out.
+    static func claims(inJWT token: String) -> [String: Any]? {
+        let parts = token.split(separator: ".")
+        guard parts.count >= 2 else { return nil }
+
+        var payload = String(parts[1])
+            .replacingOccurrences(of: "-", with: "+")
+            .replacingOccurrences(of: "_", with: "/")
+        payload += String(repeating: "=", count: (4 - payload.count % 4) % 4)
+
+        guard let data = Data(base64Encoded: payload) else { return nil }
+        return try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+    }
+
+    private static func agentAuthInfo(from url: URL) -> AgentAuthInfo? {
+        guard let data = try? Data(contentsOf: url),
+              let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let info = root["authInfo"] as? [String: Any]
+        else { return nil }
+
+        let userId: String?
+        if let number = info["userId"] as? NSNumber {
+            // JSON numbers arrive as NSNumber. `as? Int` works for small
+            // values and fails for the same object once it is too wide, so
+            // take the string form and keep one path.
+            userId = number.stringValue
+        } else if let text = info["userId"] as? String, !text.isEmpty {
+            userId = text
+        } else {
+            userId = nil
+        }
+
+        func nonempty(_ key: String) -> String? {
+            guard let value = info[key] as? String, !value.isEmpty else { return nil }
+            return value
+        }
+
+        return AgentAuthInfo(email: nonempty("email"), authId: nonempty("authId"), userId: userId)
+    }
+
     private static func value(forKey key: String, in db: OpaquePointer?) -> String? {
         SQLiteStore.rows(in: db, sql: "SELECT value FROM ItemTable WHERE key = ?", bind: key).first
     }
+
+    private struct AgentAuthInfo {
+        let email: String?
+        let authId: String?
+        let userId: String?
+    }
 }
 
+/// The JWT `cursor-agent login` files in the login keychain.
+///
+/// Held until the item moves, for the reason spelled out in `CredentialCache`:
+/// every data read can prompt, and an unchanged item cannot produce a
+/// different token. Refreshing is left to the CLI.
+enum CursorAgentKeychain {
+    static let service = "cursor-access-token"
+    static let account = "cursor-user"
+
+    private static let cache = CredentialCache<String> {
+        CursorCredentials.agentTokenIsExpired($0)
+    }
+
+    static func load() throws -> String {
+        try cache.value(
+            itemModifiedAt: { KeychainItem.modifiedAt(service: service, account: account) },
+            reload: read
+        )
+    }
+
+    static func forgetCached() { cache.forget() }
+
+    /// Newest item under this service and account, then a targeted data read.
+    /// Same two-step as Claude Code: attributes are free, the secret is not,
+    /// and `kSecMatchLimitOne` has no ordering if a rotation left duplicates.
+    static func read() throws -> String {
+        guard let winner = KeychainItem.newest(service: service, account: account) else {
+            Log.usage.error("cursor-agent keychain read failed: no item under \(service, privacy: .public)")
+            throw UsageProviderError.needsAuth
+        }
+
+        var item: CFTypeRef?
+        let status = SecItemCopyMatching([
+            kSecClass: kSecClassGenericPassword,
+            kSecValuePersistentRef: winner.persistentRef,
+            kSecReturnData: true,
+            kSecMatchLimit: kSecMatchLimitOne
+        ] as CFDictionary, &item)
+
+        guard status == errSecSuccess, let data = item as? Data else {
+            Log.usage.error("cursor-agent keychain read failed: OSStatus \(status)")
+            if ClaudeCredentials.wasTransient(status) { throw UsageProviderError.credentialExpired }
+            throw ClaudeCredentials.wasRefused(status)
+                ? UsageProviderError.accessDenied
+                : UsageProviderError.needsAuth
+        }
+
+        guard let token = String(data: data, encoding: .utf8)?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+              !token.isEmpty
+        else { throw UsageProviderError.needsAuth }
+        return token
+    }
+}

--- a/Sources/Providers/CursorLocalProvider.swift
+++ b/Sources/Providers/CursorLocalProvider.swift
@@ -1,13 +1,15 @@
+import AppKit
 import Foundation
 import os
 
-/// Reads Cursor usage as the account the *editor* is signed into.
+/// Reads Cursor usage as the account already signed in on this Mac.
 ///
 /// This replaced a WebView sign-in, and the reason is worth keeping: signing
 /// into cursor.com inside the app created a second, empty account, so the notch
 /// faithfully reported zero usage for someone who was not the user. Borrowing
-/// the editor's own session removes the question — there is only ever one
-/// account, the one actually being used.
+/// the editor's own session — or, when that is missing, the `cursor-agent`
+/// login — removes the question. There is only ever one account, the one
+/// actually being used.
 actor CursorLocalProvider: UsageProvider {
     nonisolated let id = "cursor"
     nonisolated let displayName = "Cursor"
@@ -20,13 +22,24 @@ actor CursorLocalProvider: UsageProvider {
         self.session = session
     }
 
-    nonisolated var signInRoute: SignInRoute { .openApp(bundleID: CursorCredentials.bundleID, name: "Cursor") }
+    nonisolated var signInRoute: SignInRoute {
+        // Bundle-id lookup, not a hard-coded /Applications path: Cursor can
+        // live in ~/Applications, and a miss here would hide the Open button
+        // from someone who does have the editor.
+        let installed = NSWorkspace.shared.urlForApplication(
+            withBundleIdentifier: CursorCredentials.bundleID
+        ) != nil
+        return CursorCredentials.signInRoute(editorInstalled: installed)
+    }
 
     nonisolated func account() -> ProviderAccount? { CursorCredentials.account() }
 
+    nonisolated func forgetCachedCredential() { CursorCredentials.forgetCachedAgent() }
+
     func fetchSnapshot() async throws -> ProviderSnapshot {
         // Re-read every time: the editor rotates this, and holding a stale copy
-        // would mean signing ourselves out for no reason.
+        // would mean signing ourselves out for no reason. The agent token is
+        // cached inside `CursorAgentKeychain` so the keychain is not.
         let credentials = try CursorCredentials.load()
 
         var request = URLRequest(url: endpoint)
@@ -37,7 +50,14 @@ actor CursorLocalProvider: UsageProvider {
         let (data, response) = try await session.data(for: request)
         let status = (response as? HTTPURLResponse)?.statusCode ?? 0
 
-        if status == 401 || status == 403 { throw UsageProviderError.needsAuth }
+        if status == 401 || status == 403 {
+            // A rejected token is the one signal the copy in hand is wrong
+            // despite not having expired — signing into a different CLI
+            // account replaces the keychain item. Drop it so the next read
+            // asks macOS again.
+            CursorCredentials.forgetCachedAgent()
+            throw UsageProviderError.needsAuth
+        }
         guard (200..<300).contains(status) else {
             throw UsageProviderError.badResponse(status: status)
         }

--- a/Sources/Providers/CursorLocalProvider.swift
+++ b/Sources/Providers/CursorLocalProvider.swift
@@ -65,14 +65,15 @@ actor CursorLocalProvider: UsageProvider {
         let body = String(data: data, encoding: .utf8) ?? ""
         Log.usage.debug("cursor usage -> \(body.prefix(900), privacy: .public)")
 
+        let windows = try CursorUsage.windows(fromJSON: body)
         return ProviderSnapshot(
             id: id,
             displayName: displayName,
             glyph: glyph,
             fidelity: .official,
             status: .ok,
-            windows: try CursorUsage.windows(fromJSON: body),
-            headlineID: "included"
+            windows: windows,
+            headlineID: CursorUsage.headlineID(in: windows)
         )
     }
 }

--- a/Sources/Providers/CursorUsage.swift
+++ b/Sources/Providers/CursorUsage.swift
@@ -14,13 +14,25 @@ import Foundation
 ///     "onDemand": { "enabled": false, "used": 0, "limit": null } } }
 /// ```
 ///
-/// Cursor meters an **allowance, not a request count** — the dashboard's "Your
-/// included usage · N% used" is `totalPercentUsed`. The `used`/`limit` pair sits
-/// at zero on a free plan even while real usage is happening, because the
-/// allowance arrives as `breakdown.bonus` rather than as a dollar limit. Reading
-/// `used`/`limit` therefore reports 0% for an account that is 10% through its
-/// month, which is exactly what this parser used to do.
+/// Cursor meters an **allowance, not a request count**. Plan & Usage has two
+/// bars. The ring follows **Auto** (`autoPercentUsed`) — Cursor Models,
+/// Grok, Composer. API (`apiPercentUsed`) is a separate bucket.
+/// `totalPercentUsed` is a blend of the two and is not a row here.
+///
+/// The `used`/`limit` pair sits at zero on a free plan even while real usage
+/// is happening, because the allowance arrives as `breakdown.bonus` rather
+/// than as a dollar limit. Reading those reported 0% for an account that was
+/// actually on the Cursor Models bar, which is exactly what this parser
+/// used to do.
 enum CursorUsage {
+    static let modelsLabel = "Auto usage"
+
+    /// The window the ring should mean. Cursor Models when that field exists,
+    /// never the blended total, never API.
+    static func headlineID(in windows: [LimitWindow]) -> String {
+        windows.contains(where: { $0.id == "auto" }) ? "auto" : "api"
+    }
+
     static func windows(fromJSON json: String) throws -> [LimitWindow] {
         guard let data = json.data(using: .utf8),
               let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
@@ -32,20 +44,11 @@ enum CursorUsage {
 
         var windows: [LimitWindow] = []
 
-        // The headline, and the one the dashboard shows.
-        //
-        // Zero is a reading, not an absence. A free plan reports
-        // `totalPercentUsed: 0` beside `limit: 0`, and it is tempting to read
-        // that as "no allowance to be a percentage of" — but Cursor itself
-        // ships the answer in the same response:
-        // "You've used 0% of your included total usage". If Cursor calls it 0%,
-        // so does this. Suppressing it hid a correct reading from an account
-        // that had genuinely just been switched.
-        if let total = percent(plan["totalPercentUsed"]) {
-            windows.append(LimitWindow(id: "included", label: "Included usage",
-                                       usedFraction: total, resetsAt: resetsAt))
+        // Zero is a reading, not an absence — a fresh month is 0% on this bar.
+        if let models = percent(plan["autoPercentUsed"]) {
+            windows.append(LimitWindow(id: "auto", label: modelsLabel,
+                                       usedFraction: models, resetsAt: resetsAt))
         }
-        // Reported separately by Cursor, and can be far ahead of the total.
         if let api = percent(plan["apiPercentUsed"]), api > 0 {
             windows.append(LimitWindow(id: "api", label: "API usage",
                                        usedFraction: api, resetsAt: resetsAt))

--- a/Sources/Providers/ProviderAccount.swift
+++ b/Sources/Providers/ProviderAccount.swift
@@ -109,10 +109,13 @@ extension UsageProvider {
 /// A provider as the settings sheet needs it.
 struct ProviderSummary: Identifiable, Equatable {
     /// Whether this provider's credential lives in the keychain, and so can be
-    /// refused. Cursor and Codex read ordinary files and never prompt, so
-    /// offering them an "allow access" button would be offering a cure for an
-    /// illness they cannot catch.
-    var usesKeychain: Bool { ClaudeProfile.isClaude(providerID: id) || id == "gemini" }
+    /// refused. Codex still reads an ordinary file and never prompts. Cursor
+    /// does too when the editor is signed in, but `cursor-agent` files its
+    /// JWT in the login keychain — without this flag a declined prompt would
+    /// have no "Allow access…" to put the dialogue back.
+    var usesKeychain: Bool {
+        ClaudeProfile.isClaude(providerID: id) || id == "gemini" || id == "cursor"
+    }
 
     let id: String
     let name: String

--- a/Sources/Settings/SettingsView.swift
+++ b/Sources/Settings/SettingsView.swift
@@ -190,8 +190,9 @@ struct SettingsView: View {
     static let setupCopy =
         "Codenotch reads usage from tools already signed in on this Mac — it "
         + "never asks for your password. Install and sign in to any of Claude "
-        + "Code (the terminal tool, not the Claude app), Cursor, Codex, "
-        + "Antigravity, GLM, Grok or OpenCode, and its ring appears in the notch."
+        + "Code (the terminal tool, not the Claude app), Cursor (the editor or "
+        + "cursor-agent), Codex, Antigravity, GLM, Grok or OpenCode, and its "
+        + "ring appears in the notch."
 
     /// Said before it happens rather than after. A system dialogue asking to
     /// read a *credential*, from an app installed a minute ago, looks alarming
@@ -199,9 +200,9 @@ struct SettingsView: View {
     /// it return on every read, which is what "it asks every time" turns out to
     /// be.
     static let keychainCopy =
-        "macOS will ask once for permission to read Claude Code's and "
-        + "Antigravity's saved logins. Choose Always Allow — plain Allow makes "
-        + "it ask again every time."
+        "macOS will ask once for permission to read Claude Code's, "
+        + "Antigravity's and cursor-agent's saved logins. Choose Always Allow "
+        + "— plain Allow makes it ask again every time."
 
     private var setupNote: some View {
         HStack(alignment: .top, spacing: 10) {

--- a/Tests/AntigravityTests.swift
+++ b/Tests/AntigravityTests.swift
@@ -934,8 +934,8 @@ final class ReauthorizeTests: XCTestCase {
     }
 }
 
-/// Only two providers keep a credential in the keychain; the others read files
-/// and can never raise a prompt.
+/// Claude, Antigravity and cursor-agent keep a credential in the keychain;
+/// Codex still reads a file and can never raise a prompt.
 final class KeychainProviderTests: XCTestCase {
     private func summary(_ id: String) -> ProviderSummary {
         ProviderSummary(id: id, name: id, glyph: .claude, account: nil,
@@ -946,7 +946,8 @@ final class KeychainProviderTests: XCTestCase {
         XCTAssertTrue(summary("claude").usesKeychain)
         XCTAssertTrue(summary("claude-work").usesKeychain, "every profile's token is a keychain item")
         XCTAssertTrue(summary("gemini").usesKeychain)
-        XCTAssertFalse(summary("cursor").usesKeychain, "Cursor reads a file, not the keychain")
+        XCTAssertTrue(summary("cursor").usesKeychain,
+                      "cursor-agent files its JWT in the keychain")
         XCTAssertFalse(summary("codex").usesKeychain, "Codex reads a file, not the keychain")
     }
 }

--- a/Tests/CursorUsageTests.swift
+++ b/Tests/CursorUsageTests.swift
@@ -24,31 +24,26 @@ final class CursorUsageTests: XCTestCase {
         try CursorUsage.windows(fromJSON: json)
     }
 
-    /// The bug this replaced: `used`/`limit` are both zero on a free plan even
-    /// while real usage is happening, because the allowance arrives as
-    /// `breakdown.bonus`. Reading them reported 0% for an account 10% through
-    /// its month. `totalPercentUsed` is what the dashboard actually shows.
-    func testReadsThePercentageTheDashboardShows() throws {
+    func testReadsTheAutoBar() throws {
         let w = try windows(recorded)
-        XCTAssertEqual(w[0].id, "included")
-        XCTAssertEqual(w[0].label, "Included usage")
-        XCTAssertEqual(w[0].usedFraction ?? -1, 0.095, accuracy: 0.0001)
-        XCTAssertEqual(w[0].summary, "10% Used · 90% left",
-                       "should round the way Cursor does, and show both ends")
+        XCTAssertEqual(w[0].id, "auto")
+        XCTAssertEqual(w[0].label, CursorUsage.modelsLabel)
+        XCTAssertEqual(w[0].usedFraction ?? -1, 0, accuracy: 0.0001)
+        XCTAssertEqual(CursorUsage.headlineID(in: w), "auto")
     }
 
     func testApiUsageIsReportedSeparately() throws {
         let w = try windows(recorded)
-        XCTAssertEqual(w.map(\.id), ["included", "api"])
+        XCTAssertEqual(w.map(\.id), ["auto", "api"])
         XCTAssertEqual(w[1].usedFraction ?? -1, 0.19, accuracy: 0.0001)
     }
 
     /// It is only worth a row when it has actually been touched.
     func testZeroApiUsageIsOmitted() throws {
         let json = """
-        {"individualUsage":{"plan":{"totalPercentUsed":4,"apiPercentUsed":0}}}
+        {"individualUsage":{"plan":{"autoPercentUsed":4,"apiPercentUsed":0}}}
         """
-        XCTAssertEqual(try windows(json).map(\.id), ["included"])
+        XCTAssertEqual(try windows(json).map(\.id), ["auto"])
     }
 
     /// The reset is Cursor's own `billingCycleEnd` — Sep 24 here, which is what
@@ -63,16 +58,16 @@ final class CursorUsageTests: XCTestCase {
 
     func testOnDemandOnlyCountsWhenSwitchedOnWithACeiling() throws {
         let on = """
-        {"individualUsage":{"plan":{"totalPercentUsed":5},
+        {"individualUsage":{"plan":{"autoPercentUsed":5},
                             "onDemand":{"enabled":true,"used":3,"limit":50}}}
         """
-        XCTAssertEqual(try windows(on).map(\.id), ["included", "on_demand"])
+        XCTAssertEqual(try windows(on).map(\.id), ["auto", "on_demand"])
 
         let off = """
-        {"individualUsage":{"plan":{"totalPercentUsed":5},
+        {"individualUsage":{"plan":{"autoPercentUsed":5},
                             "onDemand":{"enabled":false,"used":0,"limit":null}}}
         """
-        XCTAssertEqual(try windows(off).map(\.id), ["included"])
+        XCTAssertEqual(try windows(off).map(\.id), ["auto"])
     }
 
     func testNothingMeteredRatherThanAFalseZero() {
@@ -86,6 +81,29 @@ final class CursorUsageTests: XCTestCase {
 
     func testRejectsRubbish() {
         XCTAssertThrowsError(try windows("not json"))
+    }
+
+    /// The blended total is not a dashboard row. A Pro+ account at 19.87%
+    /// Cursor Models / 100% API used to print 25% because the ring followed
+    /// `totalPercentUsed`.
+    func testTheBlendIsNotARow() throws {
+        let json = """
+        {"individualUsage":{"plan":{
+          "autoPercentUsed":19.870833333333334,
+          "apiPercentUsed":100,
+          "totalPercentUsed":25.123586744639375}}}
+        """
+        let w = try windows(json)
+        XCTAssertEqual(w.map(\.id), ["auto", "api"])
+        XCTAssertEqual(w[0].label, CursorUsage.modelsLabel)
+        XCTAssertEqual(CursorUsage.headlineID(in: w), "auto")
+        XCTAssertEqual(w[0].summary, "20% Used · 80% left")
+        let snap = ProviderSnapshot(
+            id: "cursor", displayName: "Cursor", glyph: .cursor,
+            fidelity: .official, status: .ok, windows: w,
+            headlineID: CursorUsage.headlineID(in: w)
+        )
+        XCTAssertEqual(snap.headlineText, "20%")
     }
 }
 
@@ -269,13 +287,13 @@ final class CursorZeroUsageTests: XCTestCase {
 
     func testZeroPercentIsShownRatherThanSuppressed() throws {
         let windows = try CursorUsage.windows(fromJSON: freePlan)
-        XCTAssertEqual(windows.first?.id, "included")
+        XCTAssertEqual(windows.first?.id, "auto")
         XCTAssertEqual(windows.first?.usedFraction, 0)
     }
 
     func testItStillReadsARealPercentage() throws {
-        let used = freePlan.replacingOccurrences(of: "\"totalPercentUsed\":0",
-                                                 with: "\"totalPercentUsed\":34")
+        let used = freePlan.replacingOccurrences(of: "\"autoPercentUsed\":0",
+                                                 with: "\"autoPercentUsed\":34")
         let windows = try CursorUsage.windows(fromJSON: used)
         XCTAssertEqual(windows.first?.usedFraction ?? 0, 0.34, accuracy: 0.0001)
     }

--- a/Tests/CursorUsageTests.swift
+++ b/Tests/CursorUsageTests.swift
@@ -1,3 +1,4 @@
+import SQLite3
 import XCTest
 @testable import Codenotch
 
@@ -90,6 +91,7 @@ final class CursorUsageTests: XCTestCase {
 
 /// Borrowing the editor's session is what stops the notch reporting a different
 /// account's usage — signing into cursor.com separately made a second, empty one.
+/// The CLI session is the same cookie, reached only when the editor has none.
 final class CursorCredentialsTests: XCTestCase {
     func testCookieIsTheAccountAndTokenPair() {
         let credentials = CursorCredentials(accountID: "google-oauth2|user_ABC", accessToken: "tok")
@@ -103,6 +105,150 @@ final class CursorCredentialsTests: XCTestCase {
                 return XCTFail("expected needsAuth, got \(error)")
             }
         }
+    }
+
+    /// The editor path must not become a live keychain read. A missing store
+    /// with no agent token is still signed out, even on a machine that has
+    /// `cursor-agent` installed.
+    func testAMissingEditorAndNoAgentTokenIsSignedOut() {
+        let missing = URL(fileURLWithPath: "/tmp/definitely-not-here-\(UUID().uuidString).vscdb")
+        let config = URL(fileURLWithPath: "/tmp/definitely-not-here-\(UUID().uuidString).json")
+        XCTAssertThrowsError(
+            try CursorCredentials.load(editorStore: missing, agentToken: nil, agentConfig: config)
+        ) { error in
+            guard case UsageProviderError.needsAuth = error else {
+                return XCTFail("expected needsAuth, got \(error)")
+            }
+        }
+    }
+
+    func testAgentCookieUsesAuthIdFromCliConfig() throws {
+        let token = Self.jwt(sub: "auth0|user_JWT", exp: Date().timeIntervalSince1970 + 3600)
+        let config = try writeAgentConfig(authId: "auth0|user_CLI", userId: 42, email: "cli@example.com")
+        defer { try? FileManager.default.removeItem(at: config) }
+
+        let credentials = try CursorCredentials.session(fromAgentToken: token, configURL: config)
+        XCTAssertEqual(credentials.accountID, "auth0|user_CLI")
+        XCTAssertEqual(credentials.sessionCookie,
+                       "WorkosCursorSessionToken=auth0|user_CLI::\(token)")
+    }
+
+    /// Numeric userId is accepted by the same endpoint, and is what remains
+    /// when an older config has no authId.
+    func testAgentAccountIDFallsBackToUserIdThenJWTSub() throws {
+        let token = Self.jwt(sub: "auth0|user_JWT", exp: Date().timeIntervalSince1970 + 3600)
+
+        let withUser = try writeAgentConfig(authId: nil, userId: 99, email: "cli@example.com")
+        defer { try? FileManager.default.removeItem(at: withUser) }
+        XCTAssertEqual(CursorCredentials.agentAccountID(token: token, configURL: withUser), "99")
+
+        let missing = URL(fileURLWithPath: "/tmp/definitely-not-here-\(UUID().uuidString).json")
+        XCTAssertEqual(CursorCredentials.agentAccountID(token: token, configURL: missing),
+                       "auth0|user_JWT")
+    }
+
+    func testExpiredAgentTokenKeepsTheLastReading() {
+        let token = Self.jwt(sub: "auth0|user_JWT", exp: 1)
+        let missing = URL(fileURLWithPath: "/tmp/definitely-not-here-\(UUID().uuidString).json")
+        XCTAssertThrowsError(
+            try CursorCredentials.session(fromAgentToken: token, configURL: missing)
+        ) { error in
+            guard case UsageProviderError.credentialExpired = error else {
+                return XCTFail("expected credentialExpired, got \(error)")
+            }
+        }
+    }
+
+    func testAgentAccountReadsEmailFromCliConfig() throws {
+        let config = try writeAgentConfig(authId: "auth0|user_CLI", userId: 1, email: "cli@example.com")
+        defer { try? FileManager.default.removeItem(at: config) }
+
+        let account = try XCTUnwrap(CursorCredentials.agentAccount(from: config))
+        XCTAssertEqual(account.label, "cli@example.com")
+        XCTAssertEqual(account.source, "cursor-agent")
+    }
+
+    /// A signed-in editor wins so a laptop with both tools cannot flip
+    /// accounts depending on which file we happened to read.
+    func testTheEditorSessionIsPreferredOverTheAgent() throws {
+        let store = try writeEditorStore(account: "auth0|user_EDITOR", token: "editor-tok")
+        defer { try? FileManager.default.removeItem(at: store) }
+        let token = Self.jwt(sub: "auth0|user_JWT", exp: Date().timeIntervalSince1970 + 3600)
+        let config = try writeAgentConfig(authId: "auth0|user_CLI", userId: 1, email: "cli@example.com")
+        defer { try? FileManager.default.removeItem(at: config) }
+
+        let credentials = try CursorCredentials.load(editorStore: store, agentToken: token,
+                                                     agentConfig: config)
+        XCTAssertEqual(credentials.sessionCookie,
+                       "WorkosCursorSessionToken=auth0|user_EDITOR::editor-tok")
+    }
+
+    func testAMissingEditorFallsThroughToTheAgent() throws {
+        let missing = URL(fileURLWithPath: "/tmp/definitely-not-here-\(UUID().uuidString).vscdb")
+        let token = Self.jwt(sub: "auth0|user_JWT", exp: Date().timeIntervalSince1970 + 3600)
+        let config = try writeAgentConfig(authId: "auth0|user_CLI", userId: 1, email: "cli@example.com")
+        defer { try? FileManager.default.removeItem(at: config) }
+
+        let credentials = try CursorCredentials.load(editorStore: missing, agentToken: token,
+                                                     agentConfig: config)
+        XCTAssertEqual(credentials.accountID, "auth0|user_CLI")
+        XCTAssertEqual(credentials.accessToken, token)
+    }
+
+    func testSignInOpensTheEditorWhenItIsInstalled() {
+        guard case .openApp(let bundleID, let name) =
+                CursorCredentials.signInRoute(editorInstalled: true) else {
+            return XCTFail("expected openApp")
+        }
+        XCTAssertEqual(bundleID, CursorCredentials.bundleID)
+        XCTAssertEqual(name, "Cursor")
+    }
+
+    func testSignInNamesTheCLIWhenTheEditorIsMissing() {
+        guard case .guidance(let text) =
+                CursorCredentials.signInRoute(editorInstalled: false) else {
+            return XCTFail("expected guidance")
+        }
+        XCTAssertTrue(text.contains("cursor-agent login"), text)
+    }
+
+    private func writeAgentConfig(authId: String?, userId: Int, email: String) throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cursor-cli-\(UUID().uuidString).json")
+        var authInfo: [String: Any] = ["email": email, "userId": userId]
+        if let authId { authInfo["authId"] = authId }
+        try JSONSerialization.data(withJSONObject: ["authInfo": authInfo])
+            .write(to: url)
+        return url
+    }
+
+    private func writeEditorStore(account: String, token: String) throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cursor-\(UUID().uuidString).vscdb")
+        var db: OpaquePointer?
+        XCTAssertEqual(sqlite3_open(url.path, &db), SQLITE_OK)
+        sqlite3_exec(db, "CREATE TABLE ItemTable (key TEXT, value TEXT);", nil, nil, nil)
+        sqlite3_exec(db, "INSERT INTO ItemTable VALUES ('cursorAuth/accessToken', '\(token)');",
+                     nil, nil, nil)
+        sqlite3_exec(db, "INSERT INTO ItemTable VALUES ('cursorAuth/stripeMembershipAuthId', '\(account)');",
+                     nil, nil, nil)
+        sqlite3_close(db)
+        return url
+    }
+
+    /// Unsigned, for tests only. The server never sees these; they exist so
+    /// expiry and `sub` can be pinned without a live keychain item.
+    private static func jwt(sub: String, exp: TimeInterval) -> String {
+        func encode(_ object: [String: Any]) -> String {
+            let data = try! JSONSerialization.data(withJSONObject: object)
+            return data.base64EncodedString()
+                .replacingOccurrences(of: "+", with: "-")
+                .replacingOccurrences(of: "/", with: "_")
+                .trimmingCharacters(in: CharacterSet(charactersIn: "="))
+        }
+        return encode(["alg": "none", "typ": "JWT"])
+            + "." + encode(["sub": sub, "exp": exp])
+            + ".sig"
     }
 }
 


### PR DESCRIPTION
## Summary

Codenotch already borrows the Cursor editor's SQLite session. That leaves CLI-only machines — `cursor-agent login`, no Cursor.app — with a blank ring and no way to sign in, because there is no editor to open and Codenotch never had its own Cursor login.

The CLI session is the same cookie the editor uses. `/api/usage-summary` wants `WorkosCursorSessionToken={accountID}::{accessToken}`. `cursor-agent` files the JWT under keychain service `cursor-access-token` and the account id in `~/.cursor/cli-config.json` (`authInfo.authId`, then numeric `userId`, then the JWT `sub`). A token-only cookie or a Bearer header is 401.

This change:

- Keeps the editor store first, so a laptop with both tools cannot flip accounts.
- Falls through to the CLI session only when the editor is missing or signed out.
- Caches the keychain read (`CredentialCache`) and surfaces `accessDenied` / `credentialExpired` the same way Claude Code does.
- Marks Cursor as keychain-backed so a declined prompt can offer "Allow access…".
- Opens Cursor when the editor is installed; otherwise names `cursor-agent login` instead of an "Open Cursor" button that would do nothing.
- Leads the Cursor ring with **Auto usage** (`autoPercentUsed`). `totalPercentUsed` is a blend of Auto and API and is not a dashboard row, so a 20% Auto / 100% API account no longer reads as 25%.

## Test plan

- [x] New `CursorCredentialsTests` cover cookie construction, editor-over-agent precedence, agent fallback, `authId` / `userId` / JWT `sub`, expired JWT → `credentialExpired`, and the two sign-in routes. The agent token is injected so tests never touch the live keychain.
- [x] `CursorUsageTests` cover the Auto headline, omitting the blended total, and the 20% vs 25% case.
- [ ] `make test` — could not run here: this machine has Command Line Tools only, no Xcode.app, so `xcodebuild` refuses. Please run `make test` on a Mac with Xcode.
- [ ] Mac with only `cursor-agent login` (no Cursor.app): Cursor ring appears after Allow / Always Allow; Settings shows the CLI email via `cursor-agent`.
- [ ] Mac with the editor signed in: behaviour unchanged; keychain is not read.
- [ ] Mac with the editor installed but signed out, CLI signed in: ring comes from cursor-agent.
- [ ] Decline the keychain prompt: "Allow access…" comes back; Always Allow stays quiet.
- [ ] Cursor ring matches Plan & Usage **Auto**, not the blended total. Tooltip has Auto and API only.

No tokens, cookies, emails, or live account ids are in this PR. Test cookies use placeholder ids (`auth0|user_CLI`, `cli@example.com`).