### PR TITLE
Let the user order the provider rings

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ them, and its ring appears. Switching a provider off in Settings stops its
 credential being read at all and forgets the readings taken from it; it does
 not sign you out of the tool that owns the account, and the row says so.
 
+Settings lists the connected providers in the order the notch draws them, and
+you can drag one by its handle to move it. The order is remembered across
+launches. A provider you switch back on joins the end of that list rather than
+reclaiming an older position, so nothing you cannot currently see jumps ahead
+of something you placed deliberately.
+
 It also answers **"is it still working?"** — a thin arc spins inside a
 provider's ring while a session is busy, and becomes a pulsing amber ring when
 one is blocked waiting on you. Hover for every live session by name, where it

--- a/Sources/App/AppDelegate.swift
+++ b/Sources/App/AppDelegate.swift
@@ -72,7 +72,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                     + [CursorLocalProvider(), CodexLocalProvider(), AntigravityProvider(),
                        GLMProvider(), GrokLocalProvider(), OpenCodeProvider()]
                     + webProviders,
-                disconnected: preferences.disconnectedProviders
+                disconnected: preferences.disconnectedProviders,
+                // Passed at construction, not left to the sink below, for the
+                // same reason `disconnected` is: the sink delivers a run loop
+                // turn later, so without this every launch draws the built-in
+                // order for a frame and then visibly shuffles.
+                order: preferences.providerOrder
             )
 
             // The stored edge goes in before the panel is ever put up. The
@@ -149,6 +154,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             preferences.$disconnectedProviders
                 .receive(on: RunLoop.main)
                 .sink { [weak store] in store?.disconnected = $0 }
+                .store(in: &cancellables)
+
+            preferences.$providerOrder
+                .receive(on: RunLoop.main)
+                .sink { [weak store] in store?.order = $0 }
                 .store(in: &cancellables)
 
             store.$snapshots

--- a/Sources/Model/ProviderOrder.swift
+++ b/Sources/Model/ProviderOrder.swift
@@ -1,0 +1,57 @@
+import Foundation
+
+/// The rule that turns a remembered order into a real one.
+///
+/// The awkward part is not applying an order, it is that the set of providers is
+/// not fixed: Claude Code contributes one per `~/.claude-<slug>` found at launch,
+/// so an id can appear on a Mac that has never seen it and vanish from one that
+/// has. A stored order is a preference to reconcile, never an authority.
+enum ProviderOrder {
+    /// `items` in the user's order, then everything the order has never seen, in
+    /// the order it arrived in.
+    ///
+    /// Idempotent, which is what lets the store re-apply it to an already-sorted
+    /// `snapshots` without the rings shuffling.
+    static func arrange<T>(_ items: [T], by order: [String], id: (T) -> String) -> [T] {
+        guard !order.isEmpty else { return items }
+
+        var remaining = items
+        var arranged: [T] = []
+        for providerID in order {
+            // A stored id no provider claims is the ordinary case, not
+            // corruption: a `~/.claude-work` that is not on this Mac today.
+            guard let index = remaining.firstIndex(where: { id($0) == providerID })
+            else { continue }
+            arranged.append(remaining.remove(at: index))
+        }
+        // Appended rather than dropped: a provider added by a new version has to
+        // turn up somewhere, and the end is the one position that is never a lie
+        // about what the user chose.
+        return arranged + remaining
+    }
+
+    /// Where a provider goes when it is switched back on: after the ones already
+    /// connected, rather than back to wherever it used to sit.
+    ///
+    /// Restoring its old place would make off/on a perfect round trip, which is
+    /// tempting — but it lets a row that was not on screen outrank one the user
+    /// deliberately dragged to the top while it was away. Landing at the end is
+    /// never a surprise, and it is one drag to fix.
+    static func joiningConnected(_ id: String, in order: [String],
+                                 isConnected: (String) -> Bool) -> [String] {
+        var rest = order.filter { $0 != id }
+        // Nothing connected at all makes it the first, not the last.
+        let insertAt = rest.lastIndex(where: isConnected).map { $0 + 1 } ?? 0
+        rest.insert(id, at: insertAt)
+        return rest
+    }
+
+    /// The order to remember, given the order now on screen.
+    ///
+    /// Ids that are remembered but not visible are kept, at the end: a Claude
+    /// profile whose directory is not on this Mac today must not lose its place
+    /// because an unrelated row moved.
+    static func remember(_ visible: [String], keeping remembered: [String]) -> [String] {
+        visible + remembered.filter { !visible.contains($0) }
+    }
+}

--- a/Sources/Model/UsageStore.swift
+++ b/Sources/Model/UsageStore.swift
@@ -39,6 +39,29 @@ final class UsageStore: ObservableObject {
         }
     }
 
+    /// The order the user has put the rings in, as provider ids.
+    ///
+    /// Held here rather than at each consumer because there are two consumers —
+    /// the notch reads `snapshots`, settings reads `providerSummaries` — and
+    /// they have to agree. Sorting each of them separately makes that agreement
+    /// something two call sites have to keep remembering.
+    @Published var order: [String] = [] {
+        didSet {
+            guard order != oldValue else { return }
+            // Reordered in place, not refetched. The user has just dragged a
+            // row and the rings have to follow now; re-reading every credential
+            // to answer a question about layout would spend Claude's
+            // rate-limit budget on nothing.
+            snapshots = ProviderOrder.arrange(snapshots, by: order, id: \.id)
+        }
+    }
+
+    /// `providers` in the user's order. Every read of `providers` that ends up
+    /// on screen goes through this.
+    private var orderedProviders: [UsageProvider] {
+        ProviderOrder.arrange(providers, by: order, id: \.id)
+    }
+
     /// Whether any provider is actively being used right now. Your usage cannot
     /// move while nothing is running, so polling hard through a quiet afternoon
     /// spends rate-limit budget to re-read a number that has not changed.
@@ -74,7 +97,8 @@ final class UsageStore: ObservableObject {
         idleRefreshInterval: TimeInterval = 5 * 60,
         staleAfter: TimeInterval = 15 * 60,
         archive: UsageArchive = UsageArchive(),
-        disconnected: Set<String> = []
+        disconnected: Set<String> = [],
+        order: [String] = []
     ) {
         self.providers = providers
         self.refreshInterval = refreshInterval
@@ -90,6 +114,10 @@ final class UsageStore: ObservableObject {
         // `lastGood` is still empty, so it wrote an empty archive and destroyed
         // every remembered reading on any launch with a provider switched off.
         _disconnected = Published(initialValue: disconnected)
+        // Through the wrapper's storage for the same reason `_disconnected` is:
+        // a plain assignment runs the `didSet`, which sorts a `snapshots` that
+        // does not exist yet and is then immediately thrown away below.
+        _order = Published(initialValue: order)
         lastGood = archive.load()
         // Pruned here as well as in `didSet`, because `didSet` cannot be relied
         // on to run: it guards against a no-op change, and the value the
@@ -103,7 +131,7 @@ final class UsageStore: ObservableObject {
         // Filtered here, not only in `didSet`. The store is built before the
         // preference reaches it, so an unfiltered first pass draws every
         // switched-off provider for as long as it takes the binding to arrive.
-        snapshots = providers.filter { !disconnected.contains($0.id) }.map { provider in
+        snapshots = orderedProviders.filter { !disconnected.contains($0.id) }.map { provider in
             guard let remembered = lastGood[provider.id] else { return Self.placeholder(provider) }
             var snapshot = remembered.snapshot
             snapshot.status = .stale(since: remembered.fetchedAt)
@@ -113,7 +141,7 @@ final class UsageStore: ObservableObject {
 
     /// Enough to list the providers in settings without exposing them.
     var providerSummaries: [ProviderSummary] {
-        providers.map { provider in
+        orderedProviders.map { provider in
             ProviderSummary(id: provider.id, name: provider.displayName,
                             glyph: provider.glyph,
                             account: disconnected.contains(provider.id) ? nil : provider.account(),
@@ -186,7 +214,7 @@ final class UsageStore: ObservableObject {
     }
 
     func refresh() async {
-        let live = providers.filter { !disconnected.contains($0.id) }
+        let live = orderedProviders.filter { !disconnected.contains($0.id) }
         let versions = connectionVersions
         refreshing = Set(live.map(\.id))
         defer { refreshing = [] }

--- a/Sources/Settings/Preferences.swift
+++ b/Sources/Settings/Preferences.swift
@@ -16,6 +16,21 @@ final class Preferences: ObservableObject {
         didSet { defaults.set(Array(disconnectedProviders), forKey: Keys.disconnected) }
     }
 
+    /// The order the user has dragged the rings into, as provider ids.
+    ///
+    /// Stored as the ids actually placed rather than as every id known at the
+    /// time: providers are discovered at launch — Claude Code contributes one
+    /// per `~/.claude-<slug>` — so an exhaustive list written today is wrong
+    /// the moment a profile appears. `ProviderOrder` reconciles the two,
+    /// forgivingly in both directions.
+    ///
+    /// Empty means never chosen, which is not the same as having chosen the
+    /// order the app ships with: keeping them distinct is what lets a later
+    /// version change the built-in order for everyone who never had an opinion.
+    @Published var providerOrder: [String] {
+        didSet { defaults.set(providerOrder, forKey: Keys.order) }
+    }
+
     /// How much of itself the notch shows at rest.
     @Published var notchVisibility: NotchVisibility {
         didSet { defaults.set(notchVisibility.rawValue, forKey: Keys.visibility) }
@@ -60,6 +75,7 @@ final class Preferences: ObservableObject {
         static let presence = "appPresence"
         static let edge = "notchEdge"
         static let lastSeenVersion = "lastSeenVersion"
+        static let order = "providerOrder"
     }
 
     /// True the very first time this copy runs, and never again.
@@ -116,6 +132,9 @@ final class Preferences: ObservableObject {
         // Absent means nothing has been shown yet, which is true of a fresh
         // install — so the current release reads as new to it.
         self.lastSeenVersion = defaults.string(forKey: Keys.lastSeenVersion)
+        // Absent means never chosen, so the rings keep the order the app ships
+        // with until someone drags one.
+        self.providerOrder = defaults.stringArray(forKey: Keys.order) ?? []
         // Read from the system rather than from our own store: the user can turn
         // this off in System Settings, and a remembered `true` would then be a lie.
         self.launchAtLogin = Self.isRegisteredForLogin
@@ -131,6 +150,16 @@ final class Preferences: ObservableObject {
         } else {
             disconnectedProviders.insert(providerID)
         }
+    }
+
+    /// Record a new order, keeping the ids that are not on this Mac today.
+    ///
+    /// Settings can only show what was discovered at launch, so writing its
+    /// list verbatim would quietly forget where a Claude profile sat the moment
+    /// its directory was moved away — and put it back at the end when it
+    /// returned, for something the user never did.
+    func setProviderOrder(_ ids: [String]) {
+        providerOrder = ProviderOrder.remember(ids, keeping: providerOrder)
     }
 
     /// Forget everything this app has stored and quit.

--- a/Sources/Settings/SettingsView.swift
+++ b/Sources/Settings/SettingsView.swift
@@ -1,4 +1,5 @@
 import AppKit
+import CoreTransferable
 import SwiftUI
 
 /// The settings sheet, reached from the orb below the notch.
@@ -9,6 +10,17 @@ struct SettingsView: View {
     /// another app, so the user is always coming *back* here to see it — which
     /// makes returning focus the exact moment the old value is wrong.
     @State private var accounts: [ProviderSummary] = []
+    /// The provider being dragged right now.
+    ///
+    /// Held here rather than read off the drop, because the rows have to move
+    /// *during* the drag and `dropDestination` only hands over its payload once
+    /// the pointer is released. See `DragState` for why it is a reference.
+    @State private var drag = DragState()
+    /// Bumped on every drop, purely to make the rows' cursor rects re-evaluate.
+    ///
+    /// A re-render per drop, which is a discrete action and cheap — unlike the
+    /// per-drag state this replaced.
+    @State private var cursorRefresh = 0
     /// Switching off has to reach the store's archive, not just the preference
     /// — see `UsageStore.signOut(providerID:)`.
     let signOut: (String) -> Void
@@ -29,12 +41,33 @@ struct SettingsView: View {
         // uses for this: each section is a titled, rounded group, so the
         // structure is visible all at once instead of navigated to.
         Form {
-            Section("Integrations") {
+            // Split in two, because ordering only means anything for the
+            // first group: a provider switched off has no ring in the notch,
+            // so dragging it was arranging something that is not on screen.
+            Section("Connected") {
                 if needsSetup { setupNote }
-                ForEach(accounts) {
-                    AccountRow(provider: $0, preferences: preferences,
+                ForEach(connected) { account in
+                    AccountRow(provider: account, preferences: preferences,
                                signOut: signOut, signIn: signIn,
-                               switchAccount: switchAccount, retry: retry)
+                               switchAccount: switchAccount, retry: retry,
+                               isOrderable: true,
+                               drag: drag,
+                               cursorRefresh: cursorRefresh,
+                               onDrop: { cursorRefresh += 1 },
+                               takePlaceOf: { move($0, onto: account.id) },
+                               didConnect: { connect(account.id) })
+                }
+                if connected.isEmpty {
+                    Text("Nothing is connected, so the notch has no rings to draw.")
+                        .font(.caption)
+                        .foregroundStyle(.tertiary)
+                        .fixedSize(horizontal: false, vertical: true)
+                } else {
+                    Text("The notch draws these in this order. Drag one by its "
+                         + "handle to move it.")
+                        .font(.caption)
+                        .foregroundStyle(.tertiary)
+                        .fixedSize(horizontal: false, vertical: true)
                 }
                 // Beside the switches it explains, not stranded at the end of
                 // the page.
@@ -47,6 +80,31 @@ struct SettingsView: View {
                     .font(.caption)
                     .foregroundStyle(.tertiary)
                     .fixedSize(horizontal: false, vertical: true)
+            }
+
+            // Absent rather than empty when everything is on: a titled, empty
+            // group reads as something having failed to load.
+            if !notConnected.isEmpty {
+                Section("Not connected") {
+                    ForEach(notConnected) { account in
+                        AccountRow(provider: account, preferences: preferences,
+                                   signOut: signOut, signIn: signIn,
+                                   switchAccount: switchAccount, retry: retry,
+                                   isOrderable: false,
+                                   drag: drag,
+                                   cursorRefresh: cursorRefresh,
+                                   onDrop: {},
+                                   takePlaceOf: { _ in false },
+                                   didConnect: { connect(account.id) })
+                    }
+                    // Says what switching one back on will do, which is the
+                    // only question this group raises.
+                    Text("These have no ring to place. Switch one on and it "
+                         + "joins the end of the list above.")
+                        .font(.caption)
+                        .foregroundStyle(.tertiary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
             }
 
             // One section, because they are one question: what Codenotch
@@ -136,6 +194,9 @@ struct SettingsView: View {
             }
         }
         .formStyle(.grouped)
+        // A row switched off jumps from one group to the other. Scoped to that
+        // one value so nothing else on the page inherits an animation.
+        .animation(.snappy(duration: 0.25), value: preferences.disconnectedProviders)
         // Outside the form, so it stays put at the foot of the window rather
         // than scrolling away below the last section — a credit that has to be
         // hunted for is not really a credit.
@@ -177,6 +238,19 @@ struct SettingsView: View {
     /// four account rows push everything below them a long way down.
     static let height: CGFloat = 560
 
+    /// The rows the notch actually draws, in the order it draws them.
+    ///
+    /// Filtered out of `accounts` rather than kept as a list of its own, so the
+    /// stored order stays one list: a provider switched off keeps its place in
+    /// it, and switching it back on returns it there instead of to the end.
+    private var connected: [ProviderSummary] {
+        accounts.filter { preferences.isConnected($0.id) }
+    }
+
+    private var notConnected: [ProviderSummary] {
+        accounts.filter { !preferences.isConnected($0.id) }
+    }
+
     /// Nothing to read from anywhere. On a first launch that is the normal
     /// state, and it is the only moment the sheet has something to explain.
     private var needsSetup: Bool {
@@ -202,6 +276,47 @@ struct SettingsView: View {
         "macOS will ask once for permission to read Claude Code's and "
         + "Antigravity's saved logins. Choose Always Allow — plain Allow makes "
         + "it ask again every time."
+
+    /// A provider has just been switched on: put it after the ones already
+    /// connected.
+    ///
+    /// Done here rather than in `Preferences` because the full list of
+    /// providers lives here — `providerOrder` is empty until someone drags
+    /// something, and "the end of the connected ones" cannot be expressed
+    /// against an order that does not exist yet.
+    private func connect(_ providerID: String) {
+        let ids = ProviderOrder.joiningConnected(providerID,
+                                                 in: accounts.map(\.id),
+                                                 isConnected: preferences.isConnected)
+        accounts = ProviderOrder.arrange(accounts, by: ids, id: \.id)
+        preferences.setProviderOrder(ids)
+    }
+
+    /// Put the dragged provider where the one under the pointer sits, while the
+    /// drag is still in the air.
+    ///
+    /// Written through the preference on every crossing rather than batched
+    /// until the drop: a drag released outside the window fires no drop at all,
+    /// and a list left visibly reordered but unsaved would disagree with the
+    /// notch until the window was next opened.
+    ///
+    /// Returns whether both ids are ours — anything dragged in from another app
+    /// is a string too.
+    @discardableResult
+    private func move(_ movedID: String, onto targetID: String) -> Bool {
+        guard let from = accounts.firstIndex(where: { $0.id == movedID }),
+              let to = accounts.firstIndex(where: { $0.id == targetID })
+        else { return false }
+        guard from != to else { return true }
+
+        var reordered = accounts
+        reordered.insert(reordered.remove(at: from), at: to)
+        accounts = reordered
+        // Every row, connected or not — the order is a fact about the list, and
+        // a provider switched off today still has a place to come back to.
+        preferences.setProviderOrder(accounts.map(\.id))
+        return true
+    }
 
     private var setupNote: some View {
         HStack(alignment: .top, spacing: 10) {
@@ -230,6 +345,47 @@ struct SettingsView: View {
 
 }
 
+/// A grab cursor AppKit can be forced to re-evaluate on the spot.
+///
+/// `.pointerStyle` rides the pointer-tracking system, which AppKit consults only
+/// on a mouse move — so a drag ending with the pointer held still leaves an
+/// arrow on the grip. `invalidateCursorRects(for:)` is the escape hatch the
+/// pointer system lacks, and owning a cursor rect is what puts it within reach.
+private struct GrabCursor: NSViewRepresentable {
+    /// Bumped by the parent on each drop. Its only purpose is to make
+    /// `updateNSView` run, which is where the rects are invalidated — the value
+    /// itself is never read.
+    let refreshToken: Int
+
+    func makeNSView(context: Context) -> CursorRectView { CursorRectView() }
+
+    func updateNSView(_ view: CursorRectView, context: Context) {
+        // The pointer is sitting on a grip whose cursor AppKit reset to an arrow
+        // when the drag ended, and it will not ask again on its own. This asks.
+        view.window?.invalidateCursorRects(for: view)
+    }
+
+    /// A transparent view whose whole job is to declare "an open hand belongs
+    /// here", so `resetCursorRects` — which AppKit calls on its own and on every
+    /// `invalidateCursorRects` — has something to re-establish.
+    final class CursorRectView: NSView {
+        override func resetCursorRects() {
+            addCursorRect(bounds, cursor: .openHand)
+        }
+    }
+}
+
+/// What is being dragged, shared by every row without any of them observing it.
+///
+/// A class on purpose. As `@State`/`@Binding` this was SwiftUI state, so setting
+/// it re-rendered every row twice per drag — once to start, once to finish — and
+/// the second rebuild arrived after the drop and reset the pointer. A plain
+/// reference is read the same way and changes nothing on screen.
+@MainActor
+final class DragState {
+    var id: String?
+}
+
 /// One provider: whether Codenotch reads it, whose account that is, and where
 /// to go if there is nothing to read.
 private struct AccountRow: View {
@@ -239,6 +395,29 @@ private struct AccountRow: View {
     let signIn: (String) -> Bool
     let switchAccount: (String) -> Bool
     let retry: (String) -> Void
+    /// Whether this row has a place in the notch to argue about. A provider
+    /// switched off draws no ring, so there is nothing for a drag to arrange.
+    let isOrderable: Bool
+    /// The provider in flight, shared with every other row: this one has to
+    /// know what is being dragged the moment the pointer arrives, not once it
+    /// is released.
+    let drag: DragState
+    /// Changes on every drop; handed straight to `GrabCursor`, which uses the
+    /// change itself rather than the value.
+    let cursorRefresh: Int
+    /// Tells the list a drop landed, so the cursor rects get re-evaluated while
+    /// the pointer is still standing on the grip.
+    let onDrop: () -> Void
+    /// Move the dragged provider into this row's place. False when the id is
+    /// not one of ours.
+    let takePlaceOf: (String) -> Bool
+    /// Called after this row is switched on, so the list can decide where it
+    /// now belongs. The row itself cannot: it can see only itself.
+    let didConnect: () -> Void
+
+    /// The handle only appears under the pointer, so a row at rest stays as
+    /// quiet as it was before there was anything to drag.
+    @State private var isHovering = false
 
     private var isConnected: Bool { preferences.isConnected(provider.id) }
 
@@ -250,11 +429,63 @@ private struct AccountRow: View {
             // Everything on this row is a single line, so centring is what makes
             // the mark, the name, the button and the switch sit on one axis.
             HStack(alignment: .center, spacing: 10) {
-                ProviderGlyphView(glyph: provider.glyph, size: 16)
-                    .foregroundStyle(isConnected ? .primary : .tertiary)
+                // Grip, mark and name are one grab area: a 12pt square is a
+                // blank to hit, and none of the three do anything else. The
+                // buttons and the switch stay out — a drag would compete.
+                HStack(spacing: 10) {
+                    if isOrderable { handle }
 
-                Text(provider.name)
-                    .foregroundStyle(isConnected ? .primary : .secondary)
+                    ProviderGlyphView(glyph: provider.glyph, size: 16)
+                        .foregroundStyle(isConnected ? .primary : .tertiary)
+
+                    Text(provider.name)
+                        .foregroundStyle(isConnected ? .primary : .secondary)
+                }
+                // Without this only the drawn pixels are grabbable, and the
+                // gaps between the three of them are not.
+                .contentShape(Rectangle())
+                // `onDrag` rather than `draggable`, for its one advantage: it
+                // runs a closure when the drag *starts*. Every other row needs
+                // to know what is coming before it can make room for it, and
+                // `dropDestination` does not hand over its payload until the
+                // drop.
+                .onDrag {
+                    // A row with no ring has nothing to place. Handing back an
+                    // empty provider is how `onDrag` declines a drag.
+                    guard isOrderable else { return NSItemProvider() }
+                    drag.id = provider.id
+                    return NSItemProvider(object: provider.id as NSString)
+                } preview: {
+                    // The name alone, not the row: dragging the switch, the
+                    // buttons and two lines of explanation across the window is
+                    // a lot of translucent furniture to move a ring one place
+                    // up.
+                    HStack(spacing: 6) {
+                        ProviderGlyphView(glyph: provider.glyph, size: 12)
+                        Text(provider.name)
+                    }
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 4)
+                }
+                .help(isOrderable
+                      ? "Drag to reorder. The notch draws the rings in this order."
+                      : "Switch this on to give it a ring in the notch.")
+                // Two mechanisms, neither of which covers both halves.
+                // `pointerStyle` draws the hand on an ordinary hover but cannot
+                // re-evaluate under a pointer that has not moved, which is the
+                // state a finished drag leaves behind; the cursor rect exists
+                // only so `invalidateCursorRects` can force that.
+                //
+                // It must sit *over* the content — behind it, SwiftUI's own
+                // pointer regions win and the rect is never consulted at all —
+                // and it must not take hits, or it swallows the drag.
+                .pointerStyle(isOrderable ? .grabIdle : nil)
+                .overlay {
+                    if isOrderable {
+                        GrabCursor(refreshToken: cursorRefresh)
+                            .allowsHitTesting(false)
+                    }
+                }
 
                 Spacer(minLength: 8)
 
@@ -298,10 +529,58 @@ private struct AccountRow: View {
                           : "Switch on to sign in and read \(provider.name) again.")
             }
 
+            // 48 = the handle, the glyph and the two gaps before the name, so
+            // the detail still starts under the first letter of the name.
             detail
                 .font(.caption)
-                .padding(.leading, 26)
+                .padding(.leading, 48)
         }
+        // The whole row is the drop target, handle or not: a 12pt strip is a
+        // hard thing to hit, and there is no ambiguity about which row the
+        // pointer is over.
+        .contentShape(Rectangle())
+        .onHover { isHovering = $0 }
+        .dropDestination(for: String.self) { ids, _ in
+            defer { drag.id = nil }
+            guard isOrderable else { return false }
+            // AppKit resets the cursor when a drag session ends and will not ask
+            // what belongs here again until the mouse next moves — so releasing
+            // the button and holding still left an arrow on a grip that was
+            // perfectly grabbable. Setting a cursor by hand loses that race
+            // whatever the timing, because the reset lands last; asking AppKit
+            // to re-evaluate the rects does not race it at all.
+            onDrop()
+            // The list already settled on the way in. This only answers whether
+            // what was released was ever ours.
+            guard let moved = ids.first else { return false }
+            return takePlaceOf(moved)
+        } isTargeted: { entered in
+            // The rearrangement happens here, not on the drop: the pointer
+            // crossing into this row is the whole gesture, and the rows sliding
+            // out of the way is what says where the ring will land.
+            guard isOrderable, entered, let moved = drag.id, moved != provider.id
+            else { return }
+            withAnimation(.snappy(duration: 0.22)) { _ = takePlaceOf(moved) }
+        }
+    }
+
+    /// The affordance only. The drag itself is on the whole group around it,
+    /// because this is far too small a thing to have to hit.
+    private var handle: some View {
+        Image(systemName: "line.3.horizontal")
+            .font(.system(size: 11, weight: .medium))
+            .foregroundStyle(.secondary)
+            // Always drawn, only dimmer at rest. It used to be invisible until
+            // hovered, and hover is exactly the state a drag leaves stale: the
+            // reorder moves the row out from under a pointer that has not
+            // itself moved, so no further hover event arrives and the grip
+            // stayed gone until the pointer left the row and came back. Dimming
+            // cannot fail that way — the worst a stale `isHovering` costs now
+            // is a little emphasis.
+            .opacity(isHovering ? 1 : 0.4)
+            // Tall enough to be part of a real target rather than a 13pt strip
+            // floating in the middle of the row.
+            .frame(width: 12, height: 22)
     }
 
     @ViewBuilder
@@ -420,6 +699,10 @@ private struct AccountRow: View {
             set: { wantsOn in
                 if wantsOn {
                     preferences.setConnected(true, for: provider.id)
+                    // After the switch, not before: where it belongs depends on
+                    // which providers are connected, and this one has only just
+                    // become one of them.
+                    didConnect()
                     // Nothing to open for Claude Code — but then there is no
                     // account either, so `detail` is already showing what to do.
                     _ = signIn(provider.id)

--- a/TASKS.md
+++ b/TASKS.md
@@ -548,7 +548,11 @@ and the tooltip header is dated.
       rather than from our own store — the user can turn it off in System
       Settings, and a remembered `true` would then be a lie
 - [x] Right-click menu: Keep open, Refresh now, Sign in…, Quit
-- [ ] Drag-to-reorder providers
+- [x] Drag-to-reorder providers. Stored as the ids the user actually placed,
+      not as an index per provider: the set is not fixed — Claude Code
+      contributes one per `~/.claude-<slug>` — so anything the stored order has
+      never seen is appended rather than dropped, and an id whose directory is
+      gone keeps its place instead of being pruned
 - [ ] Plan ceilings, auto-hide
 
 ### Accounts in settings

--- a/Tests/NotchLayoutTests.swift
+++ b/Tests/NotchLayoutTests.swift
@@ -411,6 +411,16 @@ final class PreferencesTests: XCTestCase {
         return Preferences(defaults: defaults)
     }
 
+    /// The defaults themselves, for the cases that need two `Preferences` over
+    /// the same store to stand in for a relaunch.
+    private func scratchDefaults() -> UserDefaults {
+        let name = "PreferencesTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: name)!
+        defaults.removePersistentDomain(forName: name)
+        addTeardownBlock { defaults.removePersistentDomain(forName: name) }
+        return defaults
+    }
+
     func testTheFirstLaunchIsAnnouncedExactlyOnce() {
         let name = "PreferencesTests.\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: name)!
@@ -455,6 +465,33 @@ final class PreferencesTests: XCTestCase {
 
         XCTAssertFalse(Preferences(defaults: defaults).isConnected("cursor"))
     }
+
+    // MARK: - Order
+
+    func testNoStoredOrderMeansNeverChosen() {
+        XCTAssertTrue(Preferences(defaults: scratchDefaults()).providerOrder.isEmpty)
+    }
+
+    func testTheOrderSurvivesARelaunch() {
+        let defaults = scratchDefaults()
+
+        Preferences(defaults: defaults).setProviderOrder(["codex", "claude", "cursor"])
+
+        XCTAssertEqual(Preferences(defaults: defaults).providerOrder,
+                       ["codex", "claude", "cursor"])
+    }
+
+    func testAnAbsentProfileKeepsItsPlaceAcrossAMove() {
+        let preferences = Preferences(defaults: scratchDefaults())
+        preferences.setProviderOrder(["claude", "claude-work", "cursor"])
+
+        // Settings can only show what was discovered at launch, and
+        // `~/.claude-work` is not on this Mac today.
+        preferences.setProviderOrder(["cursor", "claude"])
+
+        XCTAssertEqual(preferences.providerOrder, ["cursor", "claude", "claude-work"])
+    }
+
 }
 
 /// Settings shows whose account each reading comes from. Not decoration: the app

--- a/Tests/ProviderDisconnectionTests.swift
+++ b/Tests/ProviderDisconnectionTests.swift
@@ -4,13 +4,15 @@ import XCTest
 
 @MainActor
 final class ProviderDisconnectionTests: XCTestCase {
-    private func makeStore(_ providers: [UsageProvider], disconnected: Set<String> = [])
+    private func makeStore(_ providers: [UsageProvider], disconnected: Set<String> = [],
+                           order: [String] = [])
         -> (UsageStore, UsageArchive) {
         let name = "ProviderDisconnectionTests.\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: name)!
         addTeardownBlock { defaults.removePersistentDomain(forName: name) }
         let archive = UsageArchive(defaults: defaults)
-        return (UsageStore(providers: providers, archive: archive, disconnected: disconnected), archive)
+        return (UsageStore(providers: providers, archive: archive,
+                           disconnected: disconnected, order: order), archive)
     }
 
     func testSettingsDoesNotReadADisconnectedAccount() {
@@ -181,6 +183,62 @@ final class ProviderDisconnectionTests: XCTestCase {
         // A short bounded wait also covers the existing 380ms single-cell
         // spinner delay when this regression is run against the old code.
         try? await Task.sleep(nanoseconds: 500_000_000)
+    }
+
+    // MARK: - Order
+
+    private let providers = [Probe(id: "claude"), Probe(id: "cursor"), Probe(id: "codex")]
+
+    /// The one assertion that fails the moment anyone goes back to sorting at
+    /// one consumer instead of at the store.
+    func testTheNotchAndTheSettingsListOpenInTheSameOrder() {
+        let (store, _) = makeStore(providers, order: ["codex", "claude"])
+
+        XCTAssertEqual(store.snapshots.map(\.id), ["codex", "claude", "cursor"])
+        XCTAssertEqual(store.providerSummaries.map(\.id), ["codex", "claude", "cursor"])
+    }
+
+    func testARefreshKeepsTheOrder() async {
+        let (store, _) = makeStore(providers, order: ["codex", "claude"])
+
+        await store.refresh()
+
+        XCTAssertEqual(store.snapshots.map(\.id), ["codex", "claude", "cursor"])
+    }
+
+    /// Dragging a row is a question about layout. Answering it by re-reading
+    /// every credential would spend Claude's rate-limit budget on nothing.
+    func testReorderingMovesTheRingsWithoutRefetching() async {
+        let (store, _) = makeStore(providers)
+        await store.refresh()
+        let before = providers.map(\.calls)
+
+        store.order = ["codex", "cursor", "claude"]
+
+        XCTAssertEqual(store.snapshots.map(\.id), ["codex", "cursor", "claude"])
+        XCTAssertEqual(providers.map(\.calls), before, "reordering refetched a provider")
+    }
+
+    /// Settings splits the rows into connected and not, and the second group is
+    /// built by filtering the first list rather than by keeping a list of its
+    /// own. That only works because a switched-off provider still has a place
+    /// in the summaries — it is missing from the notch, never from the order.
+    func testASwitchedOffProviderKeepsItsPlaceInTheSettingsList() {
+        let (store, _) = makeStore(providers,
+                              disconnected: ["cursor"],
+                              order: ["codex", "cursor", "claude"])
+
+        XCTAssertEqual(store.providerSummaries.map(\.id), ["codex", "cursor", "claude"])
+    }
+
+    /// A provider switched off is not in the notch at all, so its place in the
+    /// order must simply be skipped rather than leaving a gap.
+    func testADisconnectedProviderDoesNotLeaveAGap() {
+        let (store, _) = makeStore(providers,
+                              disconnected: ["cursor"],
+                              order: ["codex", "cursor", "claude"])
+
+        XCTAssertEqual(store.snapshots.map(\.id), ["codex", "claude"])
     }
 }
 

--- a/Tests/ProviderOrderTests.swift
+++ b/Tests/ProviderOrderTests.swift
@@ -1,0 +1,113 @@
+import XCTest
+@testable import Codenotch
+
+/// The order the rings sit in is the user's, and it has to survive a provider
+/// set that changes underneath it — Claude Code contributes one provider per
+/// `~/.claude-<slug>` found at launch, so an id can turn up on a Mac that has
+/// never seen it and disappear from one that has.
+final class ProviderOrderTests: XCTestCase {
+
+    private func arrange(_ ids: [String], by order: [String]) -> [String] {
+        ProviderOrder.arrange(ids, by: order, id: { $0 })
+    }
+
+    /// Never chosen is not the same as having chosen the order the app ships
+    /// with — which is what lets a later version change that order for everyone
+    /// who has no opinion.
+    func testAnEmptyOrderLeavesTheBuiltInOrderAlone() {
+        XCTAssertEqual(arrange(["claude", "cursor", "codex"], by: []),
+                       ["claude", "cursor", "codex"])
+    }
+
+    func testProvidersFollowTheStoredOrder() {
+        XCTAssertEqual(arrange(["claude", "cursor", "codex"], by: ["codex", "claude", "cursor"]),
+                       ["codex", "claude", "cursor"])
+    }
+
+    /// The regression that matters. A provider added by a new version, or a
+    /// profile directory created this morning, is in nobody's stored order —
+    /// and a strict sort would silently hide it.
+    func testAProviderTheOrderHasNeverSeenStillAppears() {
+        let arranged = arrange(["claude", "cursor", "opencode"], by: ["cursor", "claude"])
+        XCTAssertEqual(arranged, ["cursor", "claude", "opencode"])
+        XCTAssertEqual(arranged.count, 3, "a provider the stored order predates must not vanish")
+    }
+
+    /// A `~/.claude-work` that is not on this Mac today. Ordinary, not
+    /// corruption — and it must not shift anything else.
+    func testAStoredIDWithNoProviderIsIgnored() {
+        XCTAssertEqual(arrange(["claude", "cursor"], by: ["cursor", "claude-work", "claude"]),
+                       ["cursor", "claude"])
+    }
+
+    /// What `UsageStore.order` relies on when it re-applies the order to an
+    /// already-sorted `snapshots`: the rings must not shuffle.
+    func testArrangingTwiceChangesNothing() {
+        let order = ["codex", "claude"]
+        let once = arrange(["claude", "cursor", "codex"], by: order)
+        XCTAssertEqual(arrange(once, by: order), once)
+    }
+
+    /// Settings can only show what was discovered at launch, so writing its list
+    /// verbatim would forget where an absent profile sat.
+    func testAProfileNotOnThisMacKeepsItsPlace() {
+        XCTAssertEqual(
+            ProviderOrder.remember(["cursor", "claude"], keeping: ["claude", "cursor", "claude-work"]),
+            ["cursor", "claude", "claude-work"]
+        )
+    }
+
+    func testRememberDoesNotDuplicateAnIDItAlreadyHas() {
+        XCTAssertEqual(ProviderOrder.remember(["claude", "cursor"], keeping: ["claude"]),
+                       ["claude", "cursor"])
+    }
+
+    // MARK: - Coming back on
+
+    private func on(_ ids: String...) -> (String) -> Bool {
+        { ids.contains($0) }
+    }
+
+    /// The rule: after the ones already connected, not back where it used to
+    /// sit. `glm` was first, and does not get to be first again.
+    func testAReconnectedProviderJoinsTheEndOfTheConnectedOnes() {
+        XCTAssertEqual(
+            ProviderOrder.joiningConnected("glm",
+                                           in: ["glm", "claude", "codex", "gemini"],
+                                           isConnected: on("claude", "codex")),
+            ["claude", "codex", "glm", "gemini"]
+        )
+    }
+
+    /// "The end of the connected ones" with none connected is the top, not the
+    /// bottom — the first thing switched on has nothing to queue behind.
+    func testTheFirstProviderSwitchedOnGoesToTheTop() {
+        XCTAssertEqual(
+            ProviderOrder.joiningConnected("codex",
+                                           in: ["claude", "codex", "cursor"],
+                                           isConnected: on()),
+            ["codex", "claude", "cursor"]
+        )
+    }
+
+    /// It joins the connected block, not the switched-off one it was sitting
+    /// in — even when that means moving up past other switched-off rows.
+    func testItDoesNotSettleAmongTheOtherSwitchedOffOnes() {
+        XCTAssertEqual(
+            ProviderOrder.joiningConnected("opencode",
+                                           in: ["claude", "glm", "gemini", "opencode"],
+                                           isConnected: on("claude")),
+            ["claude", "opencode", "glm", "gemini"]
+        )
+    }
+
+    /// Arriving must not reshuffle the arrangement it is arriving into.
+    func testTheConnectedOrderIsUndisturbed() {
+        let after = ProviderOrder.joiningConnected("glm",
+                                                   in: ["glm", "codex", "claude", "cursor"],
+                                                   isConnected: on("codex", "claude", "cursor"))
+
+        XCTAssertEqual(after.filter { $0 != "glm" }, ["codex", "claude", "cursor"])
+        XCTAssertEqual(after.last, "glm")
+    }
+}


### PR DESCRIPTION
`TASKS.md` has carried `- [ ] Drag-to-reorder providers` under M5 since the
milestone was written. This implements it.

The order the notch draws was a hardcoded array literal in `AppDelegate`, so
someone who lives in Codex reads past three rings they do not care about every
time they glance at the strip.

## What changed

Settings splits **Integrations** into **Connected** and **Not connected**, and a
connected row can be dragged by its handle. Ordering only means something for the
first group — a provider switched off draws no ring, so dragging it was arranging
something that is not on screen.

<img width="85" alt="The notch, rings in the chosen order" src="https://github.com/user-attachments/assets/c41f9462-1165-45c8-aba4-90b4defd8390" />

*The strip, drawn in the order set below.*

<img width="459" alt="Settings — Connected" src="https://github.com/user-attachments/assets/74dbedec-2831-48d2-9a6e-8ea4909124f5" />

*Connected rows carry a handle. Account addresses redacted for the screenshot.*

<img width="500" alt="Settings — Not connected" src="https://github.com/user-attachments/assets/cda95c69-9f8f-4b90-9c8f-043a9e82e691" />

*Switched-off providers have no handle — nothing to place.*

## Design decisions worth reviewing

**Stored as ids, not as a `sortIndex`.** This diverges from the design spec
deliberately. The provider set is not fixed — Claude Code contributes one per
`~/.claude-<slug>` found at launch — so an index is a number about a list that no
longer exists. `ProviderOrder` reconciles a stored order against the live
registry in both directions: an id the order has never seen is **appended rather
than dropped** (a provider added by a new version must not silently vanish), and
a stored id whose provider is gone **keeps its place rather than being pruned**
(a `~/.claude-work` that is not on this Mac today). The archive already carries a
`perplexity` entry from a provider that no longer exists, so ids outliving their
provider is a shape this repo already has.

**Applied in `UsageStore`, not at each consumer.** There are two consumers — the
notch reads `snapshots`, Settings reads `providerSummaries` — and they have to
agree by construction rather than by two call sites remembering to.

**Reordering never refetches.** Dragging a row is a question about layout;
answering it by re-reading every credential would spend Claude's rate-limit
budget on nothing. `order.didSet` re-sorts what the store already holds. Pinned
by `testReorderingMovesTheRingsWithoutRefetching`.

**A provider switched back on joins the end of the connected list** rather than
reclaiming an older position. Restoring its old place would make off/on a perfect
round trip, which is tempting — but it lets a row that was not on screen outrank
one the user deliberately dragged to the top while it was away.

**An empty stored order means "never chosen"**, kept distinct from "chose the
current default", so an existing install updates into the order it already had
and nobody wakes up to moved rings.

## Implementation notes

`ForEach.onMove` does nothing inside a `Form` on macOS — it is honoured by
`List`, and on iOS a `Form` *is* a `List` underneath, which is why it compiles
and looks like it should work. Converting the sheet to a `List` to get it would
restyle all four sections, so the drag uses `.onDrag`/`.dropDestination`, which
are plain view modifiers.

The rows rearrange **during** the drag rather than settling once on release.
`dropDestination` does not hand over its payload until the drop, so the dragged
id is captured at drag start and held in a plain reference (`DragState`) that no
row observes — as SwiftUI state it re-rendered every row twice per gesture.

`GrabCursor` is the one piece that looks like overkill and is not. AppKit resets
the cursor when a drag session ends and does not re-evaluate until the mouse next
moves, so releasing the button and holding still left an arrow on a grip that was
perfectly grabbable. `.pointerStyle` rides the same mechanism and inherits the
limitation; `invalidateCursorRects(for:)` is the only lever that forces a
re-evaluation under a stationary pointer. It must sit *over* the content —
behind it, SwiftUI's own pointer regions win and the rect is never consulted.

## Tests

19 new tests, placed in the existing classes closest to each concern per
CONTRIBUTING: the pure rule in a new `ProviderOrderTests`, store plumbing in
`ProviderDisconnectionTests`, persistence in `PreferencesTests`.

`571 tests, 1 failure` — the failure is `ResetCopyTests.testAbsoluteTimeUsesAColon`,
which is **pre-existing and unrelated**: it asserts the formatted reset time
contains no `.`, and a Spanish-locale machine renders `11:32 p.m.`. It fails on
`main` without this branch. Everything else is green.

## Not included

- The Settings window is still a fixed 560pt, so **Not connected** needs a
  scroll to reach. Left alone rather than changing the window's shape inside a
  feature PR.
- `CODENOTCH_DEMO=1` keeps the fixture order; it bypasses the store entirely.
