### PR TITLE
Name the model-scoped weekly window after its model

### DIFF
--- a/Sources/Providers/ClaudeOAuthProvider.swift
+++ b/Sources/Providers/ClaudeOAuthProvider.swift
@@ -241,6 +241,44 @@ struct UsageResponse: Decodable {
         let kind: String
         let percent: Double
         let resetsAt: Date?
+        /// What the window is scoped to, where it is scoped to anything.
+        ///
+        /// The model-specific weekly window comes back as `weekly_scoped` for
+        /// *every* model, so the kind alone can only ever say "Scoped". The
+        /// model it actually meters is named here and nowhere else — which is
+        /// also why this is read rather than the model being hardcoded: the
+        /// window follows whichever model the plan scopes, and has already been
+        /// Opus once.
+        let scope: Scope?
+
+        /// The window's own name: the model where the response names one, the
+        /// kind's own wording otherwise.
+        var windowLabel: String {
+            let named = scope?.model?.displayName?.trimmingCharacters(in: .whitespaces)
+            if let named, !named.isEmpty { return named }
+            return UsageResponse.label(forKind: kind)
+        }
+
+        private enum CodingKeys: String, CodingKey {
+            case kind, percent, resetsAt, scope
+        }
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            kind = try container.decode(String.self, forKey: .kind)
+            percent = try container.decode(Double.self, forKey: .percent)
+            resetsAt = try container.decodeIfPresent(Date.self, forKey: .resetsAt)
+            // Tolerated rather than required. Everything above is the reading
+            // itself and must decode; the scope is only a nicer name for it, so
+            // a shape change here falls back to the kind's wording instead of
+            // costing the whole response.
+            scope = try? container.decodeIfPresent(Scope.self, forKey: .scope)
+        }
+    }
+
+    struct Scope: Decodable {
+        struct Model: Decodable { let displayName: String? }
+        let model: Model?
     }
     struct Window: Decodable {
         let utilization: Double
@@ -259,7 +297,7 @@ struct UsageResponse: Decodable {
             guard let resetsAt = limit.resetsAt else { return nil }
             return LimitWindow(
                 id: limit.kind,
-                label: UsageResponse.label(forKind: limit.kind),
+                label: limit.windowLabel,
                 usedFraction: limit.percent / 100,
                 resetsAt: resetsAt
             )
@@ -292,6 +330,9 @@ struct UsageResponse: Decodable {
         case "weekly_all":    return "All models"
         case "weekly_opus":   return "Opus"
         case "weekly_sonnet": return "Sonnet"
+        // Only reached when the response names no model for the window, which
+        // is the one case where there is nothing better to call it.
+        case "weekly_scoped", "scoped": return "Scoped"
         default:
             return kind
                 .replacingOccurrences(of: "weekly_", with: "")

--- a/Tests/UsageResponseTests.swift
+++ b/Tests/UsageResponseTests.swift
@@ -82,6 +82,47 @@ final class UsageResponseTests: XCTestCase {
         XCTAssertEqual(windows.map(\.label), ["Current session", "All models"])
     }
 
+    /// The model-scoped weekly window reads "Scoped", because that is all its
+    /// kind says. The model it meters is named in the entry's own scope, and is
+    /// what the tooltip row should show — the same name Claude Code's own
+    /// `/usage` gives that window.
+    func testTheScopedWindowIsNamedAfterItsModel() throws {
+        let json = """
+        { "limits": [
+            { "kind": "session", "percent": 52, "resets_at": "2026-08-28T09:50:00.316290+00:00",
+              "scope": null },
+            { "kind": "weekly_scoped", "percent": 61,
+              "resets_at": "2026-09-02T17:00:00.316321+00:00",
+              "scope": { "model": { "display_name": "Fable", "id": "claude-fable-5-1" } } } ] }
+        """
+        let windows = try decode(json).limitWindows()
+        XCTAssertEqual(windows.map(\.label), ["Current session", "Fable"])
+        // The id stays the API's own kind: it keys the archive and the cell.
+        XCTAssertEqual(windows.map(\.id), ["session", "weekly_scoped"])
+    }
+
+    /// Named by the kind when the response names no model — honest, if terse.
+    func testAnUnscopedModelWindowFallsBackToTheKind() throws {
+        let json = """
+        { "limits": [ { "kind": "weekly_scoped", "percent": 61,
+                        "resets_at": "2026-09-02T17:00:00.316321+00:00", "scope": null } ] }
+        """
+        XCTAssertEqual(try decode(json).limitWindows().map(\.label), ["Scoped"])
+    }
+
+    /// The scope is a nicer name for a reading, not the reading. If its shape
+    /// changes the percentage still has to arrive.
+    func testAMalformedScopeDoesNotCostTheReading() throws {
+        let json = """
+        { "limits": [ { "kind": "weekly_scoped", "percent": 61,
+                        "resets_at": "2026-09-02T17:00:00.316321+00:00",
+                        "scope": "fable" } ] }
+        """
+        let windows = try decode(json).limitWindows()
+        XCTAssertEqual(windows.first?.usedFraction ?? -1, 0.61, accuracy: 0.0001)
+        XCTAssertEqual(windows.first?.label, "Scoped")
+    }
+
     func testUnknownKindsGetAReadableLabel() {
         XCTAssertEqual(UsageResponse.label(forKind: "weekly_opus"), "Opus")
         XCTAssertEqual(UsageResponse.label(forKind: "weekly_cowork"), "Cowork")


### PR DESCRIPTION
## What

Claude's model-specific weekly window comes back with `kind` = `weekly_scoped` whatever the model it meters, so `UsageResponse.label(forKind:)` can only ever turn it into **"Scoped"** — the mechanism's name rather than the model's. Every account that has this window gets that row; Claude Code's own `/usage` names the model there.

The model is already in the entry, under its own `scope`, which `Limit` decoded as nothing:

```json
{ "kind": "weekly_scoped", "percent": 61,
  "resets_at": "2026-09-02T17:00:00.316321+00:00",
  "scope": { "model": { "display_name": "Fable", "id": "…" } } }
```

The `"scope": null` in the existing `live` fixture is the same field on a window that isn't scoped to anything.

## The change

- `Limit` decodes `scope.model.display_name`, and a new `windowLabel` prefers it, falling back to `label(forKind:)`. The window's `id` stays the API's own kind, so nothing keyed on it moves.
- Read rather than hardcoded on purpose: this window has already been Opus once and follows whichever model a plan scopes, so a hardcoded "Fable" would go quietly stale at the next plan change.
- The scope decodes **leniently** (`try?` around it). It is a nicer name for a reading, not the reading — a shape change there should cost the label and nothing else, rather than failing the whole response and blanking a ring that is otherwise being reported correctly. That follows the adapter rule in CONTRIBUTING.md: degrade visibly, never lose the number you had.
- `weekly_scoped` gets an explicit case in `label(forKind:)`, reached only when the response names no model, so the fallback is a chosen word rather than whatever the underscore-stripping happens to produce.

## Tests

Three, in `UsageResponseTests` (the class that already pins this response shape):

- the scoped window is labelled after its model;
- with `"scope": null` it falls back to the kind's wording;
- with a **string** where the scope object belongs, the 61% still arrives and only the label falls back.

`make test` passes — 555 tests, 0 failures, on macOS 27 / Xcode 26.6.

## How it was verified

The response shape above was observed on a real account that has this window; the fix itself is verified against fixtures, not against a live call, since the endpoint needs that account's own token. If you'd rather name the fallback differently than "Scoped", or prefer the label to keep the kind and put the model in the tooltip's second line instead, say so and I'll rework it.
