### PR TITLE
feat: read usage without the keychain, and attach the release dmg

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,13 @@ DEST    := platform=macOS,arch=arm64
 # changes nothing: project.yml's stable identity is what keeps a keychain
 # "Always Allow" grant alive across rebuilds, and forcing ad-hoc there would
 # throw that away and bring the prompt back on every `make run`.
-ifeq (,$(shell security find-identity -v -p codesigning 2>/dev/null | grep -c "Developer ID Application"))
+#
+# Compared against `0`, not against empty: `grep -c` prints a count on every
+# run and only sets its exit status, so the empty-string test this started as
+# was never true and the ad-hoc fallback never applied. A contributor with no
+# certificate got `No signing certificate "Developer ID Application" found`
+# from `make build` — the very thing this block exists to prevent.
+ifeq (0,$(shell security find-identity -v -p codesigning 2>/dev/null | grep -c "Developer ID Application"))
 DEV_SIGN := CODE_SIGN_IDENTITY="-" DEVELOPMENT_TEAM="" CODE_SIGN_STYLE=Automatic
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ APP_NAME    := Codenotch
 NOTARY_PROFILE := UsageNotch
 DMG := $(RELEASE_DIR)/$(APP_NAME).dmg
 
-.PHONY: archive dmg notarize release verify-release
+.PHONY: archive dmg notarize release verify-release publish
 
 # Release configuration, exported with the Developer ID identity. `xcodebuild
 # archive` + `-exportArchive` rather than a plain build: it re-signs the bundle
@@ -156,6 +156,25 @@ appcast: $(DMG)
 
 release: notarize verify-release appcast
 	@echo "Notarized: $(DMG)"
+
+# The GitHub release page is where someone who has never installed the app
+# looks first; the appcast feed is only ever read by copies already running.
+# The same notarized dmg belongs in both, and until it was in both the release
+# pages carried no assets at all — leaving a full Xcode install as the only way
+# to try the app.
+#
+# Deliberately not part of `release`: every other target here is local, and
+# this one writes to the remote. Run it once `make release` has finished and
+# the tag exists.
+VERSION := $(shell awk -F'"' '/MARKETING_VERSION:/ {print $$2}' project.yml)
+TAG     ?= v$(VERSION)
+
+publish: $(DMG)
+	@test -n "$(VERSION)" || (echo "No MARKETING_VERSION in project.yml" && exit 1)
+	@# --clobber so re-running after a rebuild replaces the asset instead of
+	@# failing on the name already being taken.
+	gh release upload $(TAG) $(DMG) --clobber
+	@echo "Attached $(DMG) to $(TAG)."
 
 # What Gatekeeper on a customer's Mac will check. `spctl` accepting the app is
 # the actual proof that the download will open without a right-click.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ two never disagree.
 
 | Provider | Source | How |
 |---|---|---|
-| **Claude Code** | official | The OAuth token in the login keychain, against the same endpoint Claude Code's own `/usage` uses. |
+| **Claude Code** | official | Claude Code's own `/usage`, asked of the installed `claude`. Falls back to the OAuth token in the login keychain, against the endpoint that command uses, when Claude Code isn't installed. |
 | **Cursor** | official | The editor's own signed-in session, read from its local SQLite state — no separate sign-in. |
 | **Codex** | official | ChatGPT's usage endpoint, using the local Codex sign-in. Shows the 5-hour and weekly limits when available. |
 | **Antigravity** | official where licensed, otherwise a request count | Antigravity's local language server first, then Google's quota endpoint; a plain count when neither will answer for the account. |
@@ -105,12 +105,16 @@ those can change without notice. Every adapter's response shape is pinned by
 tests, and every failure degrades to a visible status (`stale`, `needsAuth`,
 `error`) rather than an invented number.
 
-**Keychain:** the app is signed with a stable Developer ID identity so the
-one-time "Always Allow" grant on Claude Code's and Antigravity's keychain
-items survives rebuilds. The secret itself is read only when the owning app
-has actually changed it — checked via the item's modification date, which
-isn't behind the same access prompt as the credential — so a valid grant does
-not mean a prompt on every poll.
+**Keychain:** Claude's readings do not use it where Claude Code is installed.
+Claude Code files a *new* keychain item on every token rotation, and the new
+item's access list does not carry this app, so an "Always Allow" granted
+against the old one stops working about an hour later — asking `claude` itself
+avoids the question entirely. Where the keychain is still the source (no
+Claude Code on the machine, or Antigravity), the app is signed with a stable
+Developer ID identity so a grant survives rebuilds, and the secret is read
+only when the owning app has actually changed it — checked via the item's
+modification date, which isn't behind the same access prompt as the
+credential — so a valid grant does not mean a prompt on every poll.
 
 **Rate limits:** Claude's endpoint returns 429 if polled too hard, with an
 unhelpful `Retry-After: 0`. The back-off treats that as a floor-raiser only —

--- a/Sources/Providers/AntigravityCredentials.swift
+++ b/Sources/Providers/AntigravityCredentials.swift
@@ -21,6 +21,16 @@ struct AntigravityCredentials {
 
     static func forgetCached() { cache.forget() }
 
+    /// Whatever a previous fetch already read, without asking macOS again.
+    static var held: AntigravityCredentials? { cache.held }
+
+    /// Whether Antigravity has filed a credential at all, judged from the
+    /// item's attributes rather than its contents — those are not behind the
+    /// access prompt the secret is, so this can be asked freely.
+    static func isSignedIn() -> Bool {
+        KeychainItem.modifiedAt(service: service, account: account) != nil
+    }
+
     /// Antigravity stores through Go's `keyring` package, which base64-encodes
     /// the payload behind this marker rather than writing raw JSON the way
     /// Claude Code does. Decoding it is not optional: without stripping the

--- a/Sources/Providers/AntigravityProvider.swift
+++ b/Sources/Providers/AntigravityProvider.swift
@@ -42,8 +42,17 @@ actor AntigravityProvider: UsageProvider {
     /// rather than degraded.
     private var everBridged = false
 
-    init(session: URLSession = .shared) {
+    /// How the language server is asked, when a test needs to say. Production
+    /// leaves this nil and goes through `localQuota()`, which spawns `ps` and
+    /// `lsof` to find a port that only exists while Antigravity is running —
+    /// nothing a test can arrange, and the ordering this fixes is exactly what
+    /// would otherwise go uncovered.
+    private let localQuotaOverride: (@Sendable () async -> [LimitWindow]?)?
+
+    init(session: URLSession = .shared,
+         localQuota: (@Sendable () async -> [LimitWindow]?)? = nil) {
         self.session = session
+        self.localQuotaOverride = localQuota
         self.localSession = URLSession(configuration: .ephemeral,
                                        delegate: LocalhostTrust(),
                                        delegateQueue: nil)
@@ -56,16 +65,48 @@ actor AntigravityProvider: UsageProvider {
     nonisolated func forgetCachedCredential() { AntigravityCredentials.forgetCached() }
 
     nonisolated func account() -> ProviderAccount? {
-        guard let credentials = try? AntigravityCredentials.load() else { return nil }
+        // Presence, not contents. This row is rebuilt every time the settings
+        // window renders, and reading the secret to print a plan name made
+        // opening Settings raise the keychain dialogue — the same interruption
+        // the readings themselves now avoid. The item's attributes answer
+        // "is there an account" without being behind that prompt.
+        guard AntigravityCredentials.isSignedIn() else { return nil }
+        // Named only when a fetch has already had to read the token, which is
+        // exactly when Antigravity is not running to be asked instead. A blank
+        // plan is a smaller loss than a dialogue nobody asked for.
+        let held = AntigravityCredentials.held
         return ProviderAccount(
             label: nil,   // the token carries no address
-            plan: credentials.authMethod == "consumer" ? "Personal" : credentials.authMethod,
+            plan: held.map { $0.authMethod == "consumer" ? "Personal" : $0.authMethod },
             source: "Antigravity",
             manageURL: URL(string: "https://antigravity.google")
         )
     }
 
     func fetchSnapshot() async throws -> ProviderSnapshot {
+        // Antigravity's own language server first, before anything is asked of
+        // the keychain. It already holds the credential and the client identity
+        // Google insists on, and answers with the same figure Antigravity's own
+        // panel shows — so where it is running, the token is not needed at all.
+        //
+        // It used to be asked third, after a keychain read and a round trip to
+        // `:loadCodeAssist`. That made the reading depend on a dialogue it did
+        // not need: someone who dismissed the keychain prompt got `accessDenied`
+        // and an empty ring, while the server that would have answered sat
+        // running on the same machine, never asked.
+        if let windows = await localQuota(), !windows.isEmpty {
+            everBridged = true
+            return ProviderSnapshot(id: id, displayName: displayName, glyph: glyph,
+                                    fidelity: .official, status: .ok, windows: windows,
+                                    headlineID: "gemini-weekly")
+        }
+
+        // Antigravity has answered before and is not answering now: it has been
+        // closed or restarted. Keep the last percentage, dimmed and dated,
+        // rather than swapping in a count — and still without a prompt, which
+        // asking for the token here would have caused.
+        if everBridged { throw UsageProviderError.credentialExpired }
+
         let credentials = try AntigravityCredentials.load()
         // Expired is not signed out: Antigravity refreshes this on its own the
         // next time it runs, and the last reading is still true, just old.
@@ -83,7 +124,11 @@ actor AntigravityProvider: UsageProvider {
         )
         request.timeoutInterval = 15
 
-        let (data, response) = try await session.data(for: request)
+        // The body is not read. `:loadCodeAssist` answers with tiers and no
+        // numbers — no used, no limit, no reset — so the only thing this call
+        // still contributes is its status code, which separates "signed out"
+        // from "something else went wrong" before the quota endpoint is tried.
+        let (_, response) = try await session.data(for: request)
         let status = (response as? HTTPURLResponse)?.statusCode ?? 0
 
         if status == 401 {
@@ -99,23 +144,6 @@ actor AntigravityProvider: UsageProvider {
             throw UsageProviderError.rateLimited(retryAfter: retry ?? 0)
         }
         guard status == 200 else { throw UsageProviderError.badResponse(status: status) }
-
-        let tier = Self.tier(in: data)
-
-        // Antigravity's own language server first: it holds the client identity
-        // Google insists on, and answers with the same figure the app's own
-        // usage panel shows.
-        if let windows = await localQuota(), !windows.isEmpty {
-            everBridged = true
-            return ProviderSnapshot(id: id, displayName: displayName, glyph: glyph,
-                                    fidelity: .official, status: .ok, windows: windows,
-                                    headlineID: "gemini-weekly")
-        }
-
-        // Antigravity has answered before and is not answering now: keep the
-        // last percentage, dimmed and dated, rather than swapping in a count.
-        // `credentialExpired` is the store's word for "still true, just old".
-        if everBridged { throw UsageProviderError.credentialExpired }
 
         // Then Google directly, which answers for a licensed account.
         if let windows = try await quota(token: credentials.accessToken), !windows.isEmpty {
@@ -154,6 +182,7 @@ actor AntigravityProvider: UsageProvider {
     /// closed is the ordinary case, not a fault, and the caller has an honest
     /// answer to fall back to.
     private func localQuota() async -> [LimitWindow]? {
+        if let localQuotaOverride { return await localQuotaOverride() }
         if let bridge, let windows = try? await AntigravityBridge.quota(
             from: bridge, session: localSession
         ), !windows.isEmpty {

--- a/Sources/Providers/ClaudeOAuthProvider.swift
+++ b/Sources/Providers/ClaudeOAuthProvider.swift
@@ -1,8 +1,16 @@
 import Foundation
 import os
 
-/// Reads the same usage endpoint Claude Code's own `/usage` uses, with the
-/// OAuth token from the keychain.
+/// One Claude account's limits, read from whichever source can answer without
+/// interrupting anyone.
+///
+/// Two sources, in order. `claude "/usage"` is asked first where the binary is
+/// installed: it reports the same figures off a credential Claude Code already
+/// holds, and needs no keychain access from this app — which matters because
+/// Claude Code files a new keychain item on every token rotation, so a grant
+/// the user gives against the old item is good for about an hour. Where that
+/// fails or Claude Code is not installed, the usage endpoint is called directly
+/// with the OAuth token from the keychain, exactly as before.
 ///
 /// One instance per `ClaudeProfile`: a work login kept under `~/.claude-work`
 /// has its own token, its own limits and its own ring, and this reads exactly
@@ -39,10 +47,28 @@ actor ClaudeOAuthProvider: UsageProvider {
     /// `ClaudeKeychain`; a test substitutes a fake credential source instead.
     private let loadCredentials: @Sendable () throws -> ClaudeCredentials
 
+    /// How the CLI is asked, or nil where Claude Code is not installed. Nil is
+    /// resolved once at init rather than per refresh: the answer only changes
+    /// when someone installs or removes Claude Code, and the app is relaunched
+    /// either way.
+    nonisolated private let cli: ClaudeUsageCLI?
+    /// A subprocess is far more expensive than an HTTP call, and `UsageStore`
+    /// polls every 60s while a session is busy. The windows barely move in a
+    /// minute, so the last answer is reused in between.
+    private let cliRefreshInterval: TimeInterval
+    private var lastCLIWindows: (windows: [LimitWindow], at: Date)?
+    /// Stamped on every spawn, successful or not. Without it a Claude Code that
+    /// is installed but signed out costs a process on every tick, forever.
+    private var lastCLIAttempt: Date?
+
     init(profile: ClaudeProfile = .default(),
          session: URLSession = .shared,
          archive: UsageArchive = UsageArchive(),
-         loadCredentials: (@Sendable () throws -> ClaudeCredentials)? = nil) {
+         loadCredentials: (@Sendable () throws -> ClaudeCredentials)? = nil,
+         cli: ClaudeUsageCLI? = ClaudeUsageCLI.locate(),
+         cliRefreshInterval: TimeInterval = 5 * 60) {
+        self.cli = cli
+        self.cliRefreshInterval = cliRefreshInterval
         self.profile = profile
         self.id = profile.id
         self.displayName = profile.displayName
@@ -57,6 +83,21 @@ actor ClaudeOAuthProvider: UsageProvider {
     }
 
     func fetchSnapshot() async throws -> ProviderSnapshot {
+        // Ahead of the back-off check on purpose. That deadline is the
+        // endpoint's, and the CLI does not share the endpoint's rate limit —
+        // there is no reason for a 429 on one to darken a ring the other can
+        // still fill.
+        if let windows = await cliWindows() {
+            return ProviderSnapshot(
+                id: id,
+                displayName: displayName,
+                glyph: glyph,
+                fidelity: .official,
+                status: .ok,
+                windows: windows,
+                headlineID: "session"
+            )
+        }
         if let retryNoEarlierThan, retryNoEarlierThan > Date() {
             let remaining = retryNoEarlierThan.timeIntervalSinceNow
             Log.usage.debug("skipping fetch, backing off for \(remaining, format: .fixed(precision: 0))s")
@@ -89,6 +130,39 @@ actor ClaudeOAuthProvider: UsageProvider {
                 Log.usage.notice("rate limited (\(self.consecutiveRateLimits)x), next attempt in \(retryAfter, format: .fixed(precision: 0))s")
             }
             throw error
+        }
+    }
+
+    /// What `claude "/usage"` last said, or nil to mean "use the token path".
+    ///
+    /// Deliberately cannot throw. Every way the CLI can fail — not installed,
+    /// signed out, wording changed, wedged and killed — is a reason to ask the
+    /// endpoint instead, not a reason to fail the refresh. The endpoint's
+    /// errors are also the ones `UsageStore` knows how to word, and a status
+    /// invented here would be a second vocabulary saying the same things.
+    private func cliWindows() async -> [LimitWindow]? {
+        guard let cli else { return nil }
+        let now = Date()
+
+        // A cached answer is only reused inside the interval. Past it the
+        // reading is stale, and handing it back as `.ok` would be claiming a
+        // freshness it does not have.
+        if let last = lastCLIWindows, now.timeIntervalSince(last.at) < cliRefreshInterval {
+            return last.windows
+        }
+        if let lastCLIAttempt, now.timeIntervalSince(lastCLIAttempt) < cliRefreshInterval {
+            return nil
+        }
+        lastCLIAttempt = now
+
+        do {
+            let windows = try await cli.read(profile: profile, now: now)
+            lastCLIWindows = (windows, now)
+            Log.usage.debug("\(self.id, privacy: .public): read \(windows.count) windows from claude /usage")
+            return windows
+        } catch {
+            Log.usage.debug("\(self.id, privacy: .public): claude /usage did not answer, falling back to the token")
+            return nil
         }
     }
 
@@ -194,24 +268,42 @@ actor ClaudeOAuthProvider: UsageProvider {
         return max(0, date.timeIntervalSinceNow)
     }
 
-    /// Read straight from the keychain item rather than from the cached token,
-    /// so the settings row reflects what the next fetch will actually use.
     nonisolated var signInRoute: SignInRoute {
         // Names the command for a profile, because that is the only way to
         // reach it: plain `claude` signs the default one in, not this.
-        .guidance("Run `\(profile.signInCommand)` once — it signs in and refreshes "
-                  + "the token this reads. Use /login there to change account.")
+        .guidance("Run `\(profile.signInCommand)` once — it signs in and is what "
+                  + "these readings come from. Use /login there to change account.")
     }
 
     nonisolated func forgetCachedCredential() { keychain.forgetCached() }
 
     nonisolated func account() -> ProviderAccount? {
+        let manageURL = URL(string: "https://claude.ai/settings/usage")
+
+        // Settings must not be the thing that raises a keychain prompt. Where
+        // the CLI can answer, the readings never touch the token, and opening
+        // Settings to see whose account a ring is for would have been the one
+        // thing that did — the exact interruption this provider now avoids.
+        //
+        // The trade is the plan name for the address, and the address is the
+        // more useful half: it says *which* account, which is the only question
+        // two Claude rings ever raise, and the token could never answer it.
+        if cli != nil {
+            guard let address = profile.signedInAddress() else { return nil }
+            return ProviderAccount(
+                label: address,
+                plan: nil,   // Claude Code's own config does not name the plan
+                source: profile.sourceName,
+                manageURL: manageURL
+            )
+        }
+
         guard let credentials = try? keychain.load() else { return nil }
         return ProviderAccount(
-            label: nil,   // the credential carries no address
+            label: profile.signedInAddress(),
             plan: credentials.subscriptionType,
             source: profile.sourceName,
-            manageURL: URL(string: "https://claude.ai/settings/usage")
+            manageURL: manageURL
         )
     }
 
@@ -301,7 +393,9 @@ struct UsageResponse: Decodable {
     }
 
     /// Session first, then the weekly windows — the order the frame shows.
-    private static func displayOrder(_ a: LimitWindow, _ b: LimitWindow) -> Bool {
+    /// Shared with `ClaudeUsageCLI`, which reads the same windows off the CLI
+    /// and must hand them over in the same order.
+    static func displayOrder(_ a: LimitWindow, _ b: LimitWindow) -> Bool {
         func rank(_ id: String) -> Int {
             if id == "session" { return 0 }
             if id == "weekly_all" { return 1 }

--- a/Sources/Providers/ClaudeProfile.swift
+++ b/Sources/Providers/ClaudeProfile.swift
@@ -117,6 +117,37 @@ struct ClaudeProfile: Equatable, Hashable {
     /// Where Claude Code writes one file per running process.
     var sessionsDirectory: URL { configDirectory.appendingPathComponent("sessions") }
 
+    /// Claude Code's own settings file, which carries the signed-in address.
+    ///
+    /// The default profile keeps it *beside* the directory, at `~/.claude.json`;
+    /// a profile reached through `CLAUDE_CONFIG_DIR` keeps it *inside* its own
+    /// directory. Reading the wrong one shows the personal account against the
+    /// work ring, so the distinction matters more than it looks.
+    var accountFileURL: URL {
+        slug == nil
+            ? configDirectory.deletingLastPathComponent().appendingPathComponent(".claude.json")
+            : configDirectory.appendingPathComponent(".claude.json")
+    }
+
+    /// Who is signed in, read from that file.
+    ///
+    /// Worth having because the keychain token does not carry an address, so
+    /// until now the settings row could not say *which* account a ring was for
+    /// — the one question two Claude rings actually raise. It is also readable
+    /// without a keychain prompt, which is the whole point of asking here.
+    func signedInAddress() -> String? {
+        struct Config: Decodable {
+            struct Account: Decodable { let emailAddress: String? }
+            let oauthAccount: Account?
+        }
+        guard let data = try? Data(contentsOf: accountFileURL),
+              let config = try? JSONDecoder().decode(Config.self, from: data),
+              let address = config.oauthAccount?.emailAddress,
+              !address.isEmpty
+        else { return nil }
+        return address
+    }
+
     /// The keychain service the OAuth token is filed under.
     ///
     /// The default directory uses the bare name. Any other `CLAUDE_CONFIG_DIR`

--- a/Sources/Providers/ClaudeUsageCLI.swift
+++ b/Sources/Providers/ClaudeUsageCLI.swift
@@ -226,8 +226,20 @@ struct ClaudeUsageCLI: Sendable {
         let formatter = DateFormatter()
         formatter.locale = Locale(identifier: "en_US_POSIX")
         formatter.timeZone = zone
-        formatter.dateFormat = "MMM d 'at' h:mma"
-        guard let parsed = formatter.date(from: stamp) else { return nil }
+
+        // Two spellings, because the minutes are dropped when they are zero:
+        // `Sep 7 at 2:59pm`, but `Sep 7 at 3pm` on the hour. A single
+        // `h:mma` pattern reads the first and rejects the second, which is a
+        // window that loses its reset time for one hour in sixty — long
+        // enough to look like a bug and short enough to miss in a fixture.
+        guard let parsed = ["MMM d 'at' h:mma", "MMM d 'at' ha"]
+            .lazy
+            .compactMap({ format -> Date? in
+                formatter.dateFormat = format
+                return formatter.date(from: stamp)
+            })
+            .first
+        else { return nil }
 
         var calendar = Calendar(identifier: .gregorian)
         calendar.timeZone = zone

--- a/Sources/Providers/ClaudeUsageCLI.swift
+++ b/Sources/Providers/ClaudeUsageCLI.swift
@@ -1,0 +1,242 @@
+import Foundation
+
+/// Claude Code's own `/usage`, asked of the binary rather than of the endpoint
+/// behind it.
+///
+/// The token path works, but it cannot stop asking: Claude Code files a *new*
+/// keychain item on every rotation, and the new item's access list does not
+/// carry this app. So a grant the user gives is only ever good until the next
+/// rotation, and the password dialogue comes back roughly hourly for a reading
+/// nobody asked to be interrupted for.
+///
+/// `claude "/usage"` answers with the same figures, off a credential the CLI
+/// already holds, and needs no keychain access from this app at all. It costs a
+/// subprocess, so it is throttled by its caller — see
+/// `ClaudeOAuthProvider.cliRefreshInterval`.
+struct ClaudeUsageCLI: Sendable {
+    /// Where the binary was found.
+    let binary: URL
+    /// How its output is obtained. Injected for the same reason the provider's
+    /// credential source is: a test that actually spawned Claude Code would
+    /// need a login and a network to be deterministic, and the part worth
+    /// testing — what the text means — is downstream of this.
+    let output: @Sendable (ClaudeProfile) throws -> String
+
+    init(binary: URL, output: @escaping @Sendable (ClaudeProfile) throws -> String) {
+        self.binary = binary
+        self.output = output
+    }
+
+    /// Long enough for a cold Node start on a busy machine, short enough that a
+    /// wedged process cannot hold a refresh open. A timeout kills the process.
+    static let timeout: TimeInterval = 20
+
+    // MARK: - Finding the binary
+
+    /// Every path Claude Code installs itself to, newest installer first.
+    ///
+    /// `which` is no help here: the app is launched from Finder, so it inherits
+    /// a `PATH` of `/usr/bin:/bin:/usr/sbin:/sbin` and none of these are on it.
+    private static let searchPaths = [
+        ".local/bin/claude",     // the native installer
+        ".claude/local/claude",  // the migrate-from-npm layout
+        ".bun/bin/claude"
+    ]
+
+    /// Relative to the filesystem root rather than absolute, so a test can point
+    /// the whole search at a temporary directory. Left absolute, `locate` would
+    /// find the machine's own Claude Code however carefully a test set its home
+    /// up, and would pass or fail depending on what the developer has installed.
+    private static let systemPaths = [
+        "opt/homebrew/bin/claude",
+        "usr/local/bin/claude"
+    ]
+
+    /// Nil means Claude Code is not installed in any of the places it installs
+    /// itself, and the caller should use the token path instead.
+    static func locate(home: URL = ClaudeProfile.homeDirectory,
+                       root: URL = URL(fileURLWithPath: "/"),
+                       fileManager: FileManager = .default) -> ClaudeUsageCLI? {
+        let candidates = searchPaths.map { home.appendingPathComponent($0) }
+            + systemPaths.map { root.appendingPathComponent($0) }
+        guard let found = candidates.first(where: {
+            fileManager.isExecutableFile(atPath: $0.path)
+        }) else { return nil }
+        return ClaudeUsageCLI(binary: found) { try run(binary: found, profile: $0) }
+    }
+
+    // MARK: - Asking it
+
+    /// Runs `/usage` for one profile and returns what it reported.
+    ///
+    /// Runs off the cooperative pool: reading a pipe to exhaustion blocks the
+    /// thread it is on, and the caller is an actor whose other work — the
+    /// token path this falls back to — would be stuck behind it.
+    func read(profile: ClaudeProfile, now: Date = Date()) async throws -> [LimitWindow] {
+        let text = try await withCheckedThrowingContinuation { continuation in
+            DispatchQueue.global(qos: .utility).async {
+                continuation.resume(with: Result { try self.output(profile) })
+            }
+        }
+        return try Self.parse(text, now: now)
+    }
+
+    private static func run(binary: URL, profile: ClaudeProfile) throws -> String {
+        // A directory of its own, so a session artifact written on the way past
+        // lands somewhere disposable rather than in whatever directory the app
+        // happened to be launched from.
+        let scratch = FileManager.default.temporaryDirectory
+            .appendingPathComponent("codenotch-usage-\(UUID().uuidString)", isDirectory: true)
+        try? FileManager.default.createDirectory(at: scratch, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: scratch) }
+
+        var environment = ProcessInfo.processInfo.environment
+        // Only for a named profile. Pointing the variable at `~/.claude`
+        // explicitly is not the same as leaving it unset — Claude Code reads
+        // `.claude.json` from beside the home directory when it is unset and
+        // from inside the config directory when it is set, so setting it for
+        // the default profile would send it looking in the wrong place.
+        if profile.slug != nil {
+            environment["CLAUDE_CONFIG_DIR"] = profile.configDirectory.path
+        }
+        environment["PWD"] = scratch.path
+
+        let process = Process()
+        process.executableURL = binary
+        process.arguments = ["/usage"]
+        process.currentDirectoryURL = scratch
+        process.environment = environment
+        // Never a terminal. Left inheriting the app's stdin, `claude` waits for
+        // input that will never come and the timeout is the only thing that
+        // ends it.
+        process.standardInput = FileHandle.nullDevice
+        let output = Pipe()
+        process.standardOutput = output
+        process.standardError = Pipe()
+
+        try process.run()
+
+        let watchdog = DispatchWorkItem {
+            if process.isRunning { process.terminate() }
+        }
+        DispatchQueue.global(qos: .utility)
+            .asyncAfter(deadline: .now() + Self.timeout, execute: watchdog)
+        defer { watchdog.cancel() }
+
+        let data = output.fileHandleForReading.readDataToEndOfFile()
+        process.waitUntilExit()
+
+        guard process.terminationStatus == 0 else {
+            Log.usage.debug("claude /usage exited \(process.terminationStatus)")
+            // A non-zero exit is Claude Code declining to answer, which in
+            // practice means it has no login of its own. Not an error worth
+            // showing — the caller falls back to the token path, which can say
+            // something more precise about why.
+            throw UsageProviderError.needsAuth
+        }
+        guard let text = String(data: data, encoding: .utf8), !text.isEmpty else {
+            throw UsageProviderError.badResponse(status: 0)
+        }
+        return text
+    }
+
+    // MARK: - Reading what it said
+
+    /// The lines `/usage` leads with, e.g.
+    ///
+    ///     Current session: 38% used · resets Sep 7 at 2:59pm (Asia/Jakarta)
+    ///     Current week (all models): 4% used · resets Sep 14 at 5:59am (Asia/Jakarta)
+    ///
+    /// Everything below them is prose about what drove the usage, and is
+    /// ignored — it is approximate by its own admission, and none of it is a
+    /// limit.
+    private static let line = try! NSRegularExpression(
+        pattern: #"^Current (?:(session)|week \(([^)]+)\)):\s*(\d+)%\s*used(?:\s*·\s*resets\s*(.+?))?\s*$"#,
+        options: [.anchorsMatchLines]
+    )
+
+    static func parse(_ text: String, now: Date = Date()) throws -> [LimitWindow] {
+        let range = NSRange(text.startIndex..., in: text)
+        var windows: [LimitWindow] = []
+
+        for match in line.matches(in: text, range: range) {
+            func group(_ index: Int) -> String? {
+                guard let r = Range(match.range(at: index), in: text) else { return nil }
+                return String(text[r])
+            }
+            guard let percent = group(3).flatMap(Double.init) else { continue }
+
+            let kind = group(1) != nil ? "session" : Self.kind(forWeek: group(2) ?? "")
+            guard !windows.contains(where: { $0.id == kind }) else { continue }
+
+            windows.append(LimitWindow(
+                id: kind,
+                // The same labels the endpoint path produces, so a reading
+                // archived under one source still matches when the other takes
+                // over — the archive keys on the window id and the tooltip
+                // shows the label, and two spellings would read as two windows.
+                label: UsageResponse.label(forKind: kind),
+                usedFraction: percent / 100,
+                // Kept even when the date is unparseable. `resetsAt` is
+                // optional by design, and losing a percentage that parsed
+                // perfectly well because the wording of a date changed is the
+                // worse failure of the two.
+                resetsAt: group(4).flatMap { Self.resetDate(from: $0, now: now) }
+            ))
+        }
+
+        // Without the session window there is no headline, and the caller asks
+        // for one by id. Better to fall back to the token path than to draw a
+        // ring with a hole in it.
+        guard windows.contains(where: { $0.id == "session" }) else {
+            throw UsageProviderError.badResponse(status: 0)
+        }
+        return windows.sorted(by: UsageResponse.displayOrder)
+    }
+
+    /// `all models` → `weekly_all`, `Opus` → `weekly_opus`. The endpoint's own
+    /// vocabulary, so `UsageResponse.label(forKind:)` can name both.
+    private static func kind(forWeek text: String) -> String {
+        let name = text.lowercased() == "all models"
+            ? "all"
+            : text.lowercased().replacingOccurrences(of: " ", with: "_")
+        return "weekly_\(name)"
+    }
+
+    /// `Sep 7 at 2:59pm (Asia/Jakarta)` → a `Date`.
+    ///
+    /// No year is printed, so one is chosen: the candidate nearest `now`, over
+    /// last year, this year and next. Anything else gets New Year's Eve wrong
+    /// in one direction or the other — a window resetting on Jan 2, read on
+    /// Dec 31, is next year's, and `Dec 31` read on `Jan 2` is last year's.
+    static func resetDate(from text: String, now: Date) -> Date? {
+        var stamp = text.trimmingCharacters(in: .whitespaces)
+        var zone = TimeZone.current
+
+        // The zone comes last, in brackets, and has to come off before the
+        // am/pm fix below — `America/...` carries an "am" of its own.
+        if let open = stamp.lastIndex(of: "("), stamp.hasSuffix(")") {
+            let name = String(stamp[stamp.index(after: open)...].dropLast())
+            zone = TimeZone(identifier: name) ?? zone
+            stamp = String(stamp[..<open]).trimmingCharacters(in: .whitespaces)
+        }
+        stamp = stamp.replacingOccurrences(of: "am", with: "AM")
+            .replacingOccurrences(of: "pm", with: "PM")
+
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = zone
+        formatter.dateFormat = "MMM d 'at' h:mma"
+        guard let parsed = formatter.date(from: stamp) else { return nil }
+
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = zone
+        var parts = calendar.dateComponents([.month, .day, .hour, .minute], from: parsed)
+        let thisYear = calendar.component(.year, from: now)
+
+        return [thisYear - 1, thisYear, thisYear + 1].compactMap { year -> Date? in
+            parts.year = year
+            return calendar.date(from: parts)
+        }.min { abs($0.timeIntervalSince(now)) < abs($1.timeIntervalSince(now)) }
+    }
+}

--- a/Sources/Providers/CredentialCache.swift
+++ b/Sources/Providers/CredentialCache.swift
@@ -118,6 +118,17 @@ final class CredentialCache<Credential>: @unchecked Sendable {
         }
     }
 
+    /// What is already in hand, and nothing more.
+    ///
+    /// For a caller that would like the credential's details but must not be
+    /// the reason a dialogue appears. The settings row is exactly that: it is
+    /// rebuilt every time the window renders, and it has no business asking
+    /// macOS for a secret in order to print a plan name.
+    var held: Credential? {
+        lock.lock(); defer { lock.unlock() }
+        return stored
+    }
+
     /// Drop what is held, so the next read goes to the keychain for real.
     ///
     /// Called when the server rejects the credential — that is the one signal

--- a/Tests/AntigravityTests.swift
+++ b/Tests/AntigravityTests.swift
@@ -1033,3 +1033,112 @@ final class KeychainDuplicateTests: XCTestCase {
         XCTAssertEqual(winner?.persistentRef, Data("usable".utf8))
     }
 }
+
+/// Which source Antigravity's ring is drawn from, and in what order.
+///
+/// The language server holds the credential and the client identity already,
+/// so it needs nothing from the keychain. Asking it third — after a keychain
+/// read and a round trip to Google — meant that dismissing the keychain prompt
+/// produced an empty ring while the server that would have answered sat running
+/// on the same machine, never asked.
+final class AntigravitySourceOrderTests: XCTestCase {
+
+    override func tearDown() {
+        GoogleStub.reset()
+        super.tearDown()
+    }
+
+    /// The whole point: a language server that answers ends the fetch before
+    /// anything is asked of macOS or of Google.
+    ///
+    /// The request count is the assertion that carries it. `:loadCodeAssist` is
+    /// sent immediately after the credential is read, so zero requests means
+    /// the credential was never read either — which is not otherwise
+    /// observable, the keychain read being a static call with nothing to
+    /// substitute.
+    func testAnAnsweringBridgeEndsTheFetchBeforeTheKeychain() async throws {
+        let windows = [LimitWindow(id: "gemini-weekly", label: "Weekly", usedFraction: 0.2)]
+        let provider = AntigravityProvider(session: GoogleStub.session(),
+                                           localQuota: { windows })
+
+        let snapshot = try await provider.fetchSnapshot()
+
+        XCTAssertEqual(snapshot.windows.map(\.id), ["gemini-weekly"])
+        XCTAssertEqual(snapshot.fidelity, .official)
+        XCTAssertEqual(GoogleStub.requestCount, 0,
+                       "Google was called even though the language server answered")
+    }
+
+    /// Once the server has answered, its going away means Antigravity was
+    /// closed — keep the last reading dated rather than going back to the
+    /// keychain for a number the token cannot produce anyway.
+    func testOnceBridgedItDoesNotFallBackToTheToken() async throws {
+        let answers = Answers([[LimitWindow(id: "gemini-weekly", label: "Weekly", usedFraction: 0.2)], nil])
+        let provider = AntigravityProvider(session: GoogleStub.session(),
+                                           localQuota: { answers.next() })
+
+        _ = try await provider.fetchSnapshot()
+        GoogleStub.reset()
+
+        do {
+            _ = try await provider.fetchSnapshot()
+            XCTFail("expected credentialExpired")
+        } catch UsageProviderError.credentialExpired {
+            XCTAssertEqual(GoogleStub.requestCount, 0,
+                           "it went back to the token after the bridge had answered once")
+        } catch {
+            XCTFail("expected credentialExpired, got \(error)")
+        }
+    }
+}
+
+/// Hands out canned bridge answers in order, so one test can watch Antigravity
+/// answer and then go away.
+private final class Answers: @unchecked Sendable {
+    private let lock = NSLock()
+    private var queued: [[LimitWindow]?]
+
+    init(_ queued: [[LimitWindow]?]) { self.queued = queued }
+
+    func next() -> [LimitWindow]? {
+        lock.lock(); defer { lock.unlock() }
+        return queued.isEmpty ? nil : queued.removeFirst()
+    }
+}
+
+/// Counts what actually reached Google. Nothing should, while the language
+/// server is answering.
+private final class GoogleStub: URLProtocol {
+    private static let lock = NSLock()
+    private static var served = 0
+
+    static func reset() {
+        lock.lock(); served = 0; lock.unlock()
+    }
+
+    static var requestCount: Int {
+        lock.lock(); defer { lock.unlock() }
+        return served
+    }
+
+    static func session() -> URLSession {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [GoogleStub.self]
+        return URLSession(configuration: configuration)
+    }
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        Self.lock.lock(); Self.served += 1; Self.lock.unlock()
+        // 403 is what a personal account genuinely gets here, and it ends the
+        // fetch without another round trip.
+        let response = HTTPURLResponse(url: request.url!, statusCode: 403,
+                                       httpVersion: nil, headerFields: nil)!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+}

--- a/Tests/ClaudeOAuthProviderTests.swift
+++ b/Tests/ClaudeOAuthProviderTests.swift
@@ -87,16 +87,103 @@ final class ClaudeOAuthProviderTests: XCTestCase {
     {"limits":[{"kind":"session","percent":42,"resets_at":"2099-01-01T00:00:00Z"}]}
     """.utf8)
 
-    private func makeProvider(source: CredentialSource) -> ClaudeOAuthProvider {
+    private func makeProvider(source: CredentialSource,
+                              cli: ClaudeUsageCLI? = nil,
+                              cliRefreshInterval: TimeInterval = 5 * 60) -> ClaudeOAuthProvider {
         // A private defaults suite per test: the archive persists the 429 back-off
         // deadline, and a leaked one would silently skip fetches in the next test.
         let name = "ClaudeOAuthProviderTests.\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: name)!
         defaults.removePersistentDomain(forName: name)
 
+        // No CLI, because these are the token path's tests. Left to find one,
+        // the provider would answer off `claude "/usage"` on a machine that has
+        // Claude Code installed and off the endpoint on one that does not, and
+        // every assertion below about retries and back-off would depend on the
+        // developer's own setup rather than on the code.
         return ClaudeOAuthProvider(session: StubEndpoint.session(),
                                    archive: UsageArchive(defaults: defaults),
-                                   loadCredentials: { try source.read() })
+                                   loadCredentials: { try source.read() },
+                                   cli: cli,
+                                   cliRefreshInterval: cliRefreshInterval)
+    }
+
+    // MARK: - The CLI path
+
+    /// The point of the whole thing: when `claude "/usage"` answers, nothing
+    /// asks macOS for a credential and nothing calls the endpoint.
+    ///
+    /// Counting is the only way to know. A provider that read the keychain and
+    /// then threw the result away would return exactly the same snapshot, and
+    /// the keychain prompt this exists to avoid would still have appeared.
+    func testAWorkingCLIMeansNoKeychainReadAndNoRequest() async throws {
+        StubEndpoint.reset([.init(status: 200, body: Self.usagePayload)])
+        let source = CredentialSource(readable: true)
+        let provider = makeProvider(source: source, cli: Self.cli(answering: Self.cliUsage))
+
+        let snapshot = try await provider.fetchSnapshot()
+
+        XCTAssertEqual(snapshot.windows.map(\.id), ["session", "weekly_all"])
+        XCTAssertEqual(source.reads, 0, "the keychain was read even though the CLI answered")
+        XCTAssertEqual(StubEndpoint.requestCount, 0, "the endpoint was called even though the CLI answered")
+    }
+
+    /// A CLI that cannot answer is a reason to ask the endpoint, never a reason
+    /// to fail the refresh — otherwise installing Claude Code and signing out
+    /// of it would take the ring down on a machine whose token is fine.
+    func testAFailingCLIFallsBackToTheToken() async throws {
+        StubEndpoint.reset([.init(status: 200, body: Self.usagePayload)])
+        let source = CredentialSource(readable: true)
+        let provider = makeProvider(source: source,
+                                    cli: Self.cli(answering: "Please run /login first"))
+
+        let snapshot = try await provider.fetchSnapshot()
+
+        XCTAssertEqual(snapshot.windows.first?.id, "session")
+        XCTAssertEqual(source.reads, 1, "the token path was not reached")
+        XCTAssertEqual(StubEndpoint.requestCount, 1)
+    }
+
+    /// `UsageStore` polls every 60s while a session is busy, and each ask is a
+    /// subprocess. The windows do not move enough in a minute to be worth one.
+    func testTheCLIIsNotSpawnedOnEveryTick() async throws {
+        let spawns = Counter()
+        let provider = makeProvider(source: CredentialSource(readable: true),
+                                    cli: Self.cli { spawns.increment(); return Self.cliUsage })
+
+        _ = try await provider.fetchSnapshot()
+        _ = try await provider.fetchSnapshot()
+        _ = try await provider.fetchSnapshot()
+
+        XCTAssertEqual(spawns.value, 1, "the CLI was spawned again inside its own interval")
+    }
+
+    /// And it is asked again once the interval has passed, or the ring would
+    /// show one reading for the rest of the session.
+    func testTheCLIIsAskedAgainOnceTheIntervalPasses() async throws {
+        let spawns = Counter()
+        let provider = makeProvider(source: CredentialSource(readable: true),
+                                    cli: Self.cli { spawns.increment(); return Self.cliUsage },
+                                    cliRefreshInterval: 0)
+
+        _ = try await provider.fetchSnapshot()
+        _ = try await provider.fetchSnapshot()
+
+        XCTAssertEqual(spawns.value, 2)
+    }
+
+    private static let cliUsage = """
+    Current session: 38% used · resets Sep 7 at 2:59pm (Asia/Jakarta)
+    Current week (all models): 4% used · resets Sep 14 at 5:59am (Asia/Jakarta)
+    """
+
+    private static func cli(answering text: String) -> ClaudeUsageCLI {
+        cli { text }
+    }
+
+    private static func cli(_ answer: @escaping @Sendable () -> String) -> ClaudeUsageCLI {
+        // The path is never run — `output` is what the provider reaches.
+        ClaudeUsageCLI(binary: URL(fileURLWithPath: "/nonexistent/claude")) { _ in answer() }
     }
 
     private func assertNeedsAuth(from provider: ClaudeOAuthProvider,
@@ -110,6 +197,22 @@ final class ClaudeOAuthProviderTests: XCTestCase {
         } catch {
             XCTFail("expected needsAuth, got \(error)", file: file, line: line)
         }
+    }
+}
+
+/// How many times the CLI was actually asked. "Did it spawn again?" is the
+/// question the throttle exists to answer, and only a count answers it.
+private final class Counter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var count = 0
+
+    func increment() {
+        lock.lock(); count += 1; lock.unlock()
+    }
+
+    var value: Int {
+        lock.lock(); defer { lock.unlock() }
+        return count
     }
 }
 

--- a/Tests/ClaudeProfileTests.swift
+++ b/Tests/ClaudeProfileTests.swift
@@ -188,10 +188,16 @@ final class ClaudeProfileTests: XCTestCase {
         let home = URL(fileURLWithPath: "/Users/vinz")
         let store = UsageStore(
             providers: [
-                ClaudeOAuthProvider(profile: .default(home: home), archive: UsageArchive(defaults: defaults)),
+                // `cli: nil` throughout: this is about two profiles being two
+                // cells, and finding the machine's own Claude Code would make
+                // it about what the developer has installed.
+                ClaudeOAuthProvider(profile: .default(home: home),
+                                    archive: UsageArchive(defaults: defaults),
+                                    cli: nil),
                 ClaudeOAuthProvider(profile: ClaudeProfile(slug: "work",
                                                            configDirectory: home.appendingPathComponent(".claude-work")),
-                                    archive: UsageArchive(defaults: defaults))
+                                    archive: UsageArchive(defaults: defaults),
+                                    cli: nil)
             ],
             archive: UsageArchive(defaults: defaults)
         )

--- a/Tests/ClaudeUsageCLITests.swift
+++ b/Tests/ClaudeUsageCLITests.swift
@@ -122,6 +122,37 @@ final class ClaudeUsageCLITests: XCTestCase {
         XCTAssertEqual(reset, date("2026-12-31T03:00:00Z"))
     }
 
+    /// On the hour the minutes are dropped: `3pm`, not `3:00pm`. Reading only
+    /// the `h:mm` spelling left the window with no reset for one hour in
+    /// sixty — which is how this was found, by looking at the notch rather
+    /// than at the tests.
+    func testATimeOnTheHourHasNoMinutesToRead() {
+        let reset = ClaudeUsageCLI.resetDate(from: "Sep 7 at 3pm (Asia/Jakarta)",
+                                             now: date("2026-09-07T06:00:00Z"))
+
+        // 3pm in Jakarta is 08:00 UTC.
+        XCTAssertEqual(reset, date("2026-09-07T08:00:00Z"))
+    }
+
+    /// The whole line, not just the date fragment — a window on the hour has
+    /// to arrive with its reset intact.
+    func testAWindowResettingOnTheHourKeepsItsResetDate() throws {
+        let text = "Current session: 72% used · resets Sep 7 at 3pm (Asia/Jakarta)"
+
+        let windows = try ClaudeUsageCLI.parse(text, now: date("2026-09-07T06:00:00Z"))
+
+        XCTAssertEqual(windows[0].resetsAt, date("2026-09-07T08:00:00Z"))
+    }
+
+    /// Midnight is the other end of the same spelling.
+    func testMidnightIsReadAsMidnight() {
+        let reset = ClaudeUsageCLI.resetDate(from: "Sep 8 at 12am (Asia/Jakarta)",
+                                             now: date("2026-09-07T06:00:00Z"))
+
+        // Midnight in Jakarta is 17:00 UTC the day before.
+        XCTAssertEqual(reset, date("2026-09-07T17:00:00Z"))
+    }
+
     /// `America/...` carries an "am" of its own, so the zone has to come off
     /// before the lower-case meridiem is fixed up for the formatter.
     func testAZoneNameContainingAMDoesNotCorruptTheTime() {

--- a/Tests/ClaudeUsageCLITests.swift
+++ b/Tests/ClaudeUsageCLITests.swift
@@ -1,0 +1,177 @@
+import XCTest
+@testable import Codenotch
+
+/// `claude "/usage"` is asked before the keychain, because Claude Code files a
+/// new keychain item on every token rotation and a grant against the old one
+/// stops working about an hour later. These pin what its output means.
+final class ClaudeUsageCLITests: XCTestCase {
+    /// A real answer, trimmed of the prose below the limits. Everything after
+    /// the two limit lines is Claude Code describing what drove the usage; it
+    /// is approximate by its own admission and carries no limit.
+    private let live = """
+    You are currently using your subscription to power your Claude Code usage
+
+    Current session: 38% used · resets Sep 7 at 2:59pm (Asia/Jakarta)
+    Current week (all models): 4% used · resets Sep 14 at 5:59am (Asia/Jakarta)
+
+    What's contributing to your limits usage?
+    Approximate, based on local sessions on this machine — does not include other devices.
+
+    Last 24h · 268 requests · 3 sessions
+      37% of your usage was at >150k context
+      Top skills: /jira-tools 1%
+    """
+
+    private func date(_ iso: String) -> Date {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        return formatter.date(from: iso)!
+    }
+
+    // MARK: - What the output means
+
+    func testItReadsBothWindowsOffARealAnswer() throws {
+        let windows = try ClaudeUsageCLI.parse(live, now: date("2026-09-07T06:00:00Z"))
+
+        XCTAssertEqual(windows.map(\.id), ["session", "weekly_all"])
+        XCTAssertEqual(windows.map(\.label), ["Current session", "All models"])
+    }
+
+    /// The one number the ring is drawn from.
+    func testAPercentageBecomesAFraction() throws {
+        let windows = try ClaudeUsageCLI.parse(live, now: date("2026-09-07T06:00:00Z"))
+
+        XCTAssertEqual(windows[0].usedFraction!, 0.38, accuracy: 0.0001)
+        XCTAssertEqual(windows[1].usedFraction!, 0.04, accuracy: 0.0001)
+    }
+
+    /// The prose underneath mentions percentages of its own — "37% of your
+    /// usage was at >150k context". Read as a limit, they would be nonsense.
+    func testTheProseUnderneathIsNotMistakenForALimit() throws {
+        let windows = try ClaudeUsageCLI.parse(live, now: date("2026-09-07T06:00:00Z"))
+
+        XCTAssertEqual(windows.count, 2)
+    }
+
+    /// Without the session window there is no headline, and the snapshot asks
+    /// for one by id. Falling back to the token path beats drawing a hole.
+    func testAnAnswerWithoutASessionIsRefused() {
+        let text = "Current week (all models): 4% used · resets Sep 14 at 5:59am (Asia/Jakarta)"
+
+        XCTAssertThrowsError(try ClaudeUsageCLI.parse(text, now: Date()))
+    }
+
+    func testUnrecognisedOutputIsRefusedRatherThanGuessedAt() {
+        XCTAssertThrowsError(try ClaudeUsageCLI.parse("Please run /login first", now: Date()))
+    }
+
+    /// The per-model weekly windows use the endpoint's own vocabulary, so one
+    /// table of labels serves both sources and an archived reading survives the
+    /// source changing under it.
+    func testPerModelWeeklyWindowsKeepTheEndpointsNames() throws {
+        let text = """
+        Current session: 10% used · resets Sep 7 at 2:59pm (Asia/Jakarta)
+        Current week (Opus): 12% used · resets Sep 14 at 5:59am (Asia/Jakarta)
+        """
+
+        let windows = try ClaudeUsageCLI.parse(text, now: date("2026-09-07T06:00:00Z"))
+
+        XCTAssertEqual(windows.map(\.id), ["session", "weekly_opus"])
+        XCTAssertEqual(windows[1].label, "Opus")
+        XCTAssertEqual(windows[1].label, UsageResponse.label(forKind: "weekly_opus"))
+    }
+
+    /// A percentage that parsed is worth keeping even when the date beside it
+    /// did not. `resetsAt` is optional by design, and losing the reading over
+    /// the wording of a date is the worse of the two failures.
+    func testAWindowSurvivesAnUnreadableResetDate() throws {
+        let text = "Current session: 38% used · resets whenever it feels like it"
+
+        let windows = try ClaudeUsageCLI.parse(text, now: Date())
+
+        XCTAssertEqual(windows.count, 1)
+        XCTAssertEqual(windows[0].usedFraction!, 0.38, accuracy: 0.0001)
+        XCTAssertNil(windows[0].resetsAt)
+    }
+
+    // MARK: - Reset dates
+
+    func testTheZoneInBracketsIsHonoured() throws {
+        let windows = try ClaudeUsageCLI.parse(live, now: date("2026-09-07T06:00:00Z"))
+
+        // 2:59pm in Jakarta is 07:59 UTC.
+        XCTAssertEqual(windows[0].resetsAt, date("2026-09-07T07:59:00Z"))
+    }
+
+    /// No year is printed. Read on New Year's Eve, a window resetting on Jan 2
+    /// belongs to next year — picking the current one puts the reset eleven
+    /// months in the past and the ring reads as permanently expired.
+    func testAJanuaryResetReadInDecemberBelongsToNextYear() {
+        let reset = ClaudeUsageCLI.resetDate(from: "Jan 2 at 3:00am (UTC)",
+                                             now: date("2026-12-31T12:00:00Z"))
+
+        XCTAssertEqual(reset, date("2027-01-02T03:00:00Z"))
+    }
+
+    /// And the same mistake in the other direction: a window that reset on
+    /// New Year's Eve, read on Jan 2, is last year's.
+    func testADecemberResetReadInJanuaryBelongsToLastYear() {
+        let reset = ClaudeUsageCLI.resetDate(from: "Dec 31 at 3:00am (UTC)",
+                                             now: date("2027-01-02T12:00:00Z"))
+
+        XCTAssertEqual(reset, date("2026-12-31T03:00:00Z"))
+    }
+
+    /// `America/...` carries an "am" of its own, so the zone has to come off
+    /// before the lower-case meridiem is fixed up for the formatter.
+    func testAZoneNameContainingAMDoesNotCorruptTheTime() {
+        let reset = ClaudeUsageCLI.resetDate(from: "Sep 7 at 2:59pm (America/Panama)",
+                                             now: date("2026-09-07T06:00:00Z"))
+
+        // 2:59pm in Panama (UTC-5) is 19:59 UTC.
+        XCTAssertEqual(reset, date("2026-09-07T19:59:00Z"))
+    }
+
+    // MARK: - Finding the binary
+
+    func testItFindsClaudeWhereTheInstallerPutsIt() throws {
+        let home = try makeHome(executableAt: ".local/bin/claude")
+
+        XCTAssertEqual(ClaudeUsageCLI.locate(home: home, root: home)?.binary.lastPathComponent, "claude")
+    }
+
+    /// Nil is the signal to use the token path, so a machine without Claude
+    /// Code keeps working exactly as it did.
+    func testNoBinaryMeansNoCLI() throws {
+        let home = try makeHome(executableAt: nil)
+
+        XCTAssertNil(ClaudeUsageCLI.locate(home: home, root: home))
+    }
+
+    /// A file at the right path that cannot be run is not an installation —
+    /// npm leaves one behind after an uninstall.
+    func testANonExecutableFileIsNotAnInstallation() throws {
+        let home = try makeHome(executableAt: ".local/bin/claude", executable: false)
+
+        XCTAssertNil(ClaudeUsageCLI.locate(home: home, root: home))
+    }
+
+    private func makeHome(executableAt path: String?, executable: Bool = true) throws -> URL {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ClaudeUsageCLITests.\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        addTeardownBlock { try? FileManager.default.removeItem(at: root) }
+
+        if let path {
+            let url = root.appendingPathComponent(path)
+            try FileManager.default.createDirectory(at: url.deletingLastPathComponent(),
+                                                    withIntermediateDirectories: true)
+            FileManager.default.createFile(
+                atPath: url.path,
+                contents: Data(),
+                attributes: [.posixPermissions: executable ? 0o755 : 0o644]
+            )
+        }
+        return root
+    }
+}


### PR DESCRIPTION
## Summary

- Claude Code files a **new** keychain item on every token rotation, and the new item's access list does not carry Codenotch. An "Always Allow" is therefore good until the next rotation and no longer, so the password dialogue came back roughly hourly. Both Claude and Antigravity already expose the same figures through something that needs no keychain access at all — `claude "/usage"` and Antigravity's own language server — so those are asked first, with the existing token paths kept underneath as fallbacks.
- `make build` failed on any machine without the maintainer's Developer ID certificate, contradicting CONTRIBUTING.md. The `DEV_SIGN` guard added in 4123c816 tested `grep -c` against the empty string; `grep -c` always prints a count and reports absence through its exit status, so the condition could never hold.
- Closes #18: `make release` already produced a notarized dmg and copied it into `site/` for the Sparkle feed, but nothing ever put it on the release page, so v1.4.0 and v1.5.0 carry no assets.

## Changes

**Build and release**
- `Makefile`: compare the Developer ID probe against `0` rather than the empty string, so Debug ad-hoc signing actually applies.
- `Makefile`: new `publish` target — `gh release upload $(TAG) $(DMG) --clobber`, with `TAG` defaulting to `v$(MARKETING_VERSION)` read from `project.yml`. Kept out of the `release` chain deliberately: that chain is entirely local and this writes to the remote, so it should be a decision rather than a side effect.

**Claude**
- `Sources/Providers/ClaudeUsageCLI.swift` (new): finds the `claude` binary where its installers put it, runs `/usage` in a scratch directory under a watchdog, and reads the result into `LimitWindow`s. Ids and labels come from the existing `UsageResponse.label(forKind:)` and `displayOrder`, so a reading archived under one source still matches when the other takes over.
- `ClaudeOAuthProvider` asks the CLI first and falls through to the token path on any failure — absent, signed out, wording changed, wedged and killed. A machine without Claude Code behaves exactly as it did.
- Asked ahead of the endpoint's back-off deadline: the two do not share a rate limit, so a 429 on one is no reason to darken a ring the other can still fill. Throttled to one subprocess every five minutes, since the store polls every 60s while a session is busy.
- `account()` answers from Claude Code's own config rather than the token, so opening Settings no longer prompts either. That trades the plan name for the signed-in address — the field the token could never fill, and the only question two Claude rings raise.
- Reset times are read in both spellings Claude Code uses: `2:59pm`, and `3pm` on the hour. Reading only the first left a window with no reset for one hour in sixty.

**Antigravity**
- `AntigravityProvider`: the language server moves from third to first. It already holds the credential and the client identity Google insists on; being asked after a keychain read meant that dismissing the prompt produced an empty ring while the server that would have answered sat running on the same machine, never asked.
- `account()` reads the keychain item's attributes rather than its contents to say an account exists — those are not behind the access prompt the secret is.
- The `:loadCodeAssist` body is no longer decoded on this path. Only its status code was load-bearing, and the local it was decoded into was already unused; the compiler had been saying so.

## Test plan

- [x] `make test` passes with no override and no Developer ID certificate in the keychain — which is also the proof of the signing fix. Before it, `make build` stopped at `No signing certificate "Developer ID Application" found`.
- [x] No new compiler warnings; the four that remain are all present on `main`.
- [x] Claude, end to end, with the app launched the way a user launches it — `env -i open Codenotch.app`, so it inherits launchd's environment and not a developer shell's. `lsof` recorded **no network connection from the app at all** while `ps` recorded `claude /usage` as its child. Since the token path cannot produce a reading without calling `api.anthropic.com`, that is the reading coming from the CLI and the keychain going untouched.
- [x] The figures match: the app read `session 79% / weekly 8%, resetting 15:00 and Sep 14 06:00` against `claude "/usage"` reporting `79% / 8%, resets 3pm / 6am` at the same minute.
- [x] Claude fallback: with the binary moved aside, no subprocess is spawned, nothing is logged as failed, and the ring still fills from the token path.
- [x] Reset dates are pinned across the New Year in both directions, on the hour, at midnight, and against a zone name that contains "am".
- [ ] `make publish` has **not** been run — it needs write access to this repository. Verified only as far as `make -n publish`, which expands to `gh release upload v1.5.0 build/release/Codenotch.dmg --clobber`.
- [ ] Antigravity has **not** been verified end to end. It is not installed on the machine this was written on, so its language server could not be started; that path is covered by unit tests with an injected source rather than by a real reading. The keychain fallback underneath it is unchanged.

One thing worth saying plainly: #18 also mentions needing a full Xcode to build from source. The signing half of that is fixed here — `xcodegen` and `xcodebuild` are still required, and this does not change that.

## Evidance
<img width="409" height="356" alt="Screenshot 2026-09-07 at 14 50 35" src="https://github.com/user-attachments/assets/5f7473eb-2e4d-4b8e-b6de-2cb525861e34" />

