### PR TITLE
Make `make` actually sign a Debug build without a Developer ID

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,15 +12,38 @@ PROJECT := Codenotch.xcodeproj
 SCHEME  := Codenotch
 DEST    := platform=macOS,arch=arm64
 
-# Debug ad-hoc signs itself when the maintainer's Developer ID certificate
-# isn't in the keychain, which is every machine but the maintainer's — so a
-# contributor can `make build`/`make test`/`make run` with no Apple account at
-# all, per CONTRIBUTING.md. On the maintainer's own machine this is empty and
-# changes nothing: project.yml's stable identity is what keeps a keychain
-# "Always Allow" grant alive across rebuilds, and forcing ad-hoc there would
-# throw that away and bring the prompt back on every `make run`.
-ifeq (,$(shell security find-identity -v -p codesigning 2>/dev/null | grep -c "Developer ID Application"))
+# Debug signs itself when the maintainer's Developer ID certificate isn't in
+# the keychain, which is every machine but the maintainer's — so a contributor
+# can `make build`/`make test`/`make run` with no Apple account at all, per
+# CONTRIBUTING.md. On the maintainer's own machine this is empty and changes
+# nothing: project.yml's stable identity is what keeps a keychain "Always
+# Allow" grant alive across rebuilds, and forcing another one there would throw
+# that away and bring the prompt back on every `make run`.
+#
+# `grep`, not `grep -c`: `-c` prints "0" rather than nothing when it matches
+# nothing, so `ifeq (,...)` was never true and a machine *without* the
+# certificate fell through to signing with an identity it does not have —
+# "Signing for Codenotch requires a development team", on every target.
+HAS_DEVELOPER_ID := $(shell security find-identity -v -p codesigning 2>/dev/null | grep "Developer ID Application")
+
+# A personal "Apple Development" certificate, where there is one, is preferred
+# over ad-hoc for exactly the reason the maintainer's identity is: it is
+# stable, so a keychain "Always Allow" grant survives the next rebuild, and
+# working on the credential-reading paths does not mean re-granting after every
+# build. Its team is read out of the certificate itself, since manual signing
+# will not proceed without one; with nothing parsed, ad-hoc is the fallback and
+# needs no Apple account.
+DEV_TEAM := $(shell security find-certificate -c "Apple Development" -p 2>/dev/null \
+	| openssl x509 -noout -subject 2>/dev/null \
+	| sed -n 's/.*OU *= *\([A-Z0-9]*\).*/\1/p')
+
+ifeq (,$(HAS_DEVELOPER_ID))
+ifeq (,$(DEV_TEAM))
 DEV_SIGN := CODE_SIGN_IDENTITY="-" DEVELOPMENT_TEAM="" CODE_SIGN_STYLE=Automatic
+else
+DEV_SIGN := CODE_SIGN_IDENTITY="Apple Development" CODE_SIGN_STYLE=Manual \
+	DEVELOPMENT_TEAM="$(DEV_TEAM)" PROVISIONING_PROFILE_SPECIFIER=""
+endif
 endif
 
 .PHONY: gen build test run clean


### PR DESCRIPTION
## The bug

The ad-hoc fallback added for 1.5.0 ("Contributors can now `make build`/`make test` with no Apple Developer account") never engages. It is guarded by

```make
ifeq (,$(shell security find-identity -v -p codesigning 2>/dev/null | grep -c "Developer ID Application"))
```

and `grep -c` prints `0` rather than nothing when it matches nothing — so the condition is false on **every** machine, including the ones it exists for. `DEV_SIGN` stays empty, the build falls through to `project.yml`'s manual identity and team `6WFPL8B9FB`, and anyone without that certificate gets

```
error: Signing for "Codenotch" requires selecting either a development team or
a provisioning profile.
```

from `make build`, `make test` and `make run` alike. On the maintainer's own machine nothing looks wrong, because there the fallback is supposed to stay empty.

## The change

Dropping `-c` is the whole fix — `grep` alone prints nothing when it matches nothing, which is what `ifeq (,…)` is testing for.

The ladder above it is one step wider, and separable if you'd rather not have it: where the machine has a personal **Apple Development** certificate, that is now preferred over ad-hoc, for exactly the reason `project.yml` pins a stable identity on yours. The keychain ACL that guards Claude Code's and Antigravity's credentials keys on the signing identity, and an ad-hoc identity is new on every build — so "Always Allow" is forgotten and the prompt comes back after every `make run`, which is painful precisely when working on the credential-reading paths. Manual signing will not proceed without a team, so the team is read out of the certificate's own subject; if either half comes back empty, ad-hoc still carries a build with no Apple account at all.

If you prefer the minimal version, say so and I'll cut this back to the one-flag change.

## Verified

On a Mac with an Apple Development certificate and **no** Developer ID:

- `make build` → signs manually against the team parsed from the certificate, **BUILD SUCCEEDED**
- `make build DEV_TEAM=` (the certificate withheld, so the ad-hoc branch runs) → **BUILD SUCCEEDED**, and the product comes out `Signature=adhoc`, `TeamIdentifier=not set`
- `make test` → 552 tests, 0 failures (macOS 27, Xcode 26.6)

Before the change, all three of those failed at the signing step on the same machine.
