### PR TITLE
Read the default profile's suffixed keychain service, not just the bare name

### DIFF
--- a/Sources/Providers/ClaudeCredentials.swift
+++ b/Sources/Providers/ClaudeCredentials.swift
@@ -42,9 +42,9 @@ struct ClaudeCredentials {
     /// authorization to read — only this second, targeted fetch of the
     /// winner's actual data does, which is why it costs the same single prompt
     /// as before, per profile.
-    static func read(service: String) throws -> ClaudeCredentials {
-        guard let winner = KeychainItem.newest(service: service) else {
-            Log.usage.error("keychain read failed: no item under \(service, privacy: .public)")
+    static func read(services: [String]) throws -> ClaudeCredentials {
+        guard let winner = KeychainItem.newest(services: services) else {
+            Log.usage.error("keychain read failed: no item under \(services.joined(separator: ", "), privacy: .public)")
             throw UsageProviderError.needsAuth
         }
 
@@ -62,7 +62,7 @@ struct ClaudeCredentials {
             // exact wrong instant — whereas -25308 (interaction not allowed) or
             // -128 (user cancelled) mean it is there and this app is not on its
             // access list. Those need very different advice, so record which.
-            Log.usage.error("keychain read of \(service, privacy: .public) failed: OSStatus \(status) (\(Self.explain(status), privacy: .public))")
+            Log.usage.error("keychain read of \(services.joined(separator: ", "), privacy: .public) failed: OSStatus \(status) (\(Self.explain(status), privacy: .public))")
             // A machine just woken from a long sleep answers -25320 — awake
             // enough to run background work, not awake enough to show a
             // dialogue even if one were needed. The credential is unaffected;
@@ -147,32 +147,34 @@ struct ClaudeCredentials {
 /// keychain item with its own access list: macOS prompts once per item, and a
 /// cache shared between them would hand the personal token to the work ring.
 final class ClaudeKeychain: @unchecked Sendable {
-    let service: String
+    let services: [String]
 
     /// Read once, then held until the token expires — see `CredentialCache`.
     /// Claude Code rotates this roughly hourly, so this is about one keychain
     /// read an hour instead of two a minute.
     private let cache = CredentialCache<ClaudeCredentials> { $0.isExpired }
 
-    init(service: String) {
-        self.service = service
+    init(services: [String]) {
+        self.services = services
     }
 
     convenience init(profile: ClaudeProfile) {
-        self.init(service: profile.keychainService)
+        self.init(services: profile.keychainServices)
     }
 
     /// The default profile's reader, shared so that every caller that predates
-    /// profiles keeps sharing one cache — and so one prompt.
-    static let `default` = ClaudeKeychain(service: ClaudeProfile.defaultKeychainService)
+    /// profiles keeps sharing one cache — and so one prompt. Uses the default
+    /// profile's full candidate list, so it finds the token whether Claude Code
+    /// filed it under the bare name or the suffixed one.
+    static let `default` = ClaudeKeychain(services: ClaudeProfile.default().keychainServices)
 
     /// Reads whatever is stored, expired or not. Judging expiry is the caller's
     /// job, because "signed out" and "the token has aged out overnight" call for
     /// different behaviour and only one of them is worth alarming anyone about.
     func load() throws -> ClaudeCredentials {
         try cache.value(
-            itemModifiedAt: { KeychainItem.modifiedAt(service: service) },
-            reload: { try ClaudeCredentials.read(service: service) }
+            itemModifiedAt: { KeychainItem.modifiedAt(services: services) },
+            reload: { try ClaudeCredentials.read(services: services) }
         )
     }
 

--- a/Sources/Providers/ClaudeProfile.swift
+++ b/Sources/Providers/ClaudeProfile.swift
@@ -117,17 +117,33 @@ struct ClaudeProfile: Equatable, Hashable {
     /// Where Claude Code writes one file per running process.
     var sessionsDirectory: URL { configDirectory.appendingPathComponent("sessions") }
 
-    /// The keychain service the OAuth token is filed under.
+    /// Every keychain service a profile's token might be filed under, in the
+    /// order to prefer them — newest wins across the lot at read time.
     ///
-    /// The default directory uses the bare name. Any other `CLAUDE_CONFIG_DIR`
-    /// gets a suffix so two profiles cannot overwrite each other's token: the
-    /// first eight hex digits of the SHA-256 of the directory's absolute path,
-    /// no trailing slash. That is Claude Code's rule, not ours — it is what
-    /// makes `Claude Code-credentials-1c731050` findable at all.
-    var keychainService: String {
-        guard slug != nil else { return Self.defaultKeychainService }
-        return "\(Self.defaultKeychainService)-\(Self.keychainSuffix(forPath: configDirectory.path))"
+    /// A profile's token is filed under the bare name plus a suffix: the first
+    /// eight hex digits of the SHA-256 of the directory's absolute path, no
+    /// trailing slash. That is Claude Code's rule, not ours. The subtlety is
+    /// *when* Claude Code applies it to the default directory: it suffixes
+    /// whenever `CLAUDE_CONFIG_DIR` is set in the shell it runs from, and a
+    /// shell that exports the variable exports it even when it points at the
+    /// default `~/.claude` — so the default profile's live token can sit under
+    /// `Claude Code-credentials-<hash of ~/.claude>` rather than the bare name.
+    /// Older Claude Code, and an unset variable, keep the bare name for the
+    /// default. Reading only the bare name therefore finds a stale, months-old
+    /// duplicate on such a machine and the ring waits for a first reading that
+    /// never comes, while a current token sits one service name away.
+    ///
+    /// So the default profile offers both, suffixed first; a named profile is
+    /// only ever written suffixed. `KeychainItem.newest(services:)` picks the
+    /// most recently written item across them.
+    var keychainServices: [String] {
+        let suffixed = "\(Self.defaultKeychainService)-\(Self.keychainSuffix(forPath: configDirectory.path))"
+        return slug == nil ? [suffixed, Self.defaultKeychainService] : [suffixed]
     }
+
+    /// The primary service — the first candidate. Retained for callers and
+    /// tests that name a single service.
+    var keychainService: String { keychainServices.first! }
 
     static let defaultKeychainService = "Claude Code-credentials"
 

--- a/Sources/Providers/KeychainItem.swift
+++ b/Sources/Providers/KeychainItem.swift
@@ -80,4 +80,20 @@ enum KeychainItem {
     static func modifiedAt(service: String, account: String? = nil) -> Date? {
         newest(service: service, account: account)?.modifiedAt
     }
+
+    /// The newest item across several services — the same "newest wins" choice
+    /// as `newest(service:)`, widened to a profile whose token may be filed
+    /// under more than one service name (see `ClaudeProfile.keychainServices`).
+    /// Enumerating each service's attributes never raises a prompt, so trying
+    /// two costs no extra dialogue over trying one.
+    static func newest(services: [String], account: String? = nil) -> Match? {
+        services
+            .compactMap { newest(service: $0, account: account) }
+            .max { ($0.modifiedAt ?? .distantPast) < ($1.modifiedAt ?? .distantPast) }
+    }
+
+    /// When the owning app last wrote the newest item across these services.
+    static func modifiedAt(services: [String], account: String? = nil) -> Date? {
+        newest(services: services, account: account)?.modifiedAt
+    }
 }

--- a/Tests/ClaudeProfileTests.swift
+++ b/Tests/ClaudeProfileTests.swift
@@ -29,7 +29,6 @@ final class ClaudeProfileTests: XCTestCase {
         XCTAssertNil(profile.slug)
         XCTAssertEqual(profile.id, "claude")
         XCTAssertEqual(profile.displayName, "Claude")
-        XCTAssertEqual(profile.keychainService, "Claude Code-credentials")
         XCTAssertEqual(profile.sessionsDirectory.path, "/Users/vinz/.claude/sessions")
         XCTAssertEqual(profile.sourceName, "Claude Code")
         XCTAssertEqual(profile.signInCommand, "claude")
@@ -60,6 +59,26 @@ final class ClaudeProfileTests: XCTestCase {
         let slashed = ClaudeProfile(slug: "work",
                                     configDirectory: URL(fileURLWithPath: "/Users/vinz/.claude-work/"))
         XCTAssertEqual(slashed.keychainService, "Claude Code-credentials-19914660")
+    }
+
+    /// The default profile offers both service names — the suffix Claude Code
+    /// uses when `CLAUDE_CONFIG_DIR` is exported (even at the default path) and
+    /// the bare name older versions use — suffixed first so a current token
+    /// wins, bare kept so a legacy login still reads. Reading only the bare
+    /// name is what left the ring stuck on "Waiting for the first reading…".
+    func testTheDefaultProfileOffersBothTheSuffixedAndBareServices() {
+        let profile = ClaudeProfile.default(home: URL(fileURLWithPath: "/Users/vinz"))
+        // `shasum -a 256` of "/Users/vinz/.claude", first eight hex digits.
+        XCTAssertEqual(profile.keychainServices,
+                       ["Claude Code-credentials-337ba600", "Claude Code-credentials"])
+    }
+
+    /// A named profile is only ever written suffixed, so it offers exactly the
+    /// one service — no bare fallback that could shadow another account.
+    func testANamedProfileOffersOnlyItsSuffixedService() {
+        let profile = ClaudeProfile(slug: "work",
+                                    configDirectory: URL(fileURLWithPath: "/Users/vinz/.claude-work"))
+        XCTAssertEqual(profile.keychainServices, ["Claude Code-credentials-19914660"])
     }
 
     func testProviderIDsAreRecognised() {


### PR DESCRIPTION
Fixes the Claude default-profile ring being stuck on **"Waiting for the first reading…"** on machines where `CLAUDE_CONFIG_DIR` is exported.

### Symptom
On my Mac the Claude usage ring never got a reading — "Waiting for the first reading…" indefinitely — while **session/idle detection worked fine**, and Codex (and others) read normally. That contrast is the tell: session detection reads `~/.claude/sessions` files, but the usage number needs the OAuth token from the keychain.

### Root cause
Claude Code files its OAuth token under the **SHA-256-suffixed** service whenever `CLAUDE_CONFIG_DIR` is set in the shell it runs from — and a shell that exports the variable exports it **even when it points at the default `~/.claude`**. So the default profile's live, hourly-rotating token was under `Claude Code-credentials-<hash of ~/.claude>`, while the bare `Claude Code-credentials` held only a stale duplicate from months earlier (before the variable was exported).

`ClaudeProfile` read only the bare name for the default profile (`slug == nil`), so it picked the expired duplicate → `GET /api/oauth/usage` returned `401` → the ring waited forever, with a valid token one service name away.

Concrete evidence on my machine: `sha256("/Users/<me>/.claude")[:8]` matched an existing keychain item `Claude Code-credentials-<hash>` whose token was current, while the bare item had expired 42 days earlier.

### Fix
Give the default profile **both** candidate services — suffixed first, bare kept as a legacy fallback — and let `KeychainItem` pick the newest item **across** them. This reuses the existing "newest wins" philosophy you already apply to rotation duplicates *within* one service, just widened across service names. Named profiles are unchanged (single suffixed service, no bare fallback that could shadow another account).

- `ClaudeProfile`: `keychainService` → `keychainServices` (`[suffixed, bare]` for the default; `[suffixed]` for named). `keychainService` retained as the first candidate for existing callers/tests.
- `KeychainItem`: add `newest(services:)` / `modifiedAt(services:)`.
- `ClaudeCredentials` / `ClaudeKeychain`: read across the candidate list; the shared default reader uses the default profile's full list.
- Tests: assert the default's two-service candidate list and the named profile's single service.

### Testing
Reasoned against the codebase and syntax-checked with `swiftc -parse`; I'm on macOS 15 so I couldn't run the full `make test` locally (Xcode 26 required). Happy to adjust naming/placement to fit your conventions.