### PR TITLE
Show provider usage in the menu bar menu

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ DEST    := platform=macOS,arch=arm64
 # changes nothing: project.yml's stable identity is what keeps a keychain
 # "Always Allow" grant alive across rebuilds, and forcing ad-hoc there would
 # throw that away and bring the prompt back on every `make run`.
-ifeq (,$(shell security find-identity -v -p codesigning 2>/dev/null | grep -c "Developer ID Application"))
+ifeq (0,$(shell security find-identity -v -p codesigning 2>/dev/null | grep -c "Developer ID Application"))
 DEV_SIGN := CODE_SIGN_IDENTITY="-" DEVELOPMENT_TEAM="" CODE_SIGN_STYLE=Automatic
 endif
 

--- a/Sources/App/AppDelegate.swift
+++ b/Sources/App/AppDelegate.swift
@@ -127,6 +127,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
             let statusItem = StatusItemController { [weak settings] in settings?.show() }
             self.statusItem = statusItem
+            statusItem.onRefreshProvider = { [weak store] id in store?.refresh(providerID: id) }
+            statusItem.onRefreshAll = { [weak store] in store?.refreshNow() }
 
             preferences.$appPresence
                 .receive(on: RunLoop.main)
@@ -153,11 +155,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
             store.$snapshots
                 .receive(on: RunLoop.main)
-                .sink { [weak controller] snapshots in
+                .sink { [weak controller, weak statusItem] snapshots in
                     withAnimation(NotchMotion.unfold) {
                         controller?.model.snapshots = snapshots
                     }
                     controller?.model.now = Date()
+                    statusItem?.snapshots = snapshots
                 }
                 .store(in: &cancellables)
             store.start()

--- a/Sources/App/StatusItemController.swift
+++ b/Sources/App/StatusItemController.swift
@@ -5,10 +5,22 @@ import AppKit
 /// It exists to be a way *into* the app, so it opens settings and offers Quit —
 /// with no Dock tile there is otherwise nothing to right-click, and an app you
 /// cannot quit is a worse problem than one you cannot see.
+///
+/// It also carries the same readings as the notch tooltips, so `NotchVisibility`
+/// hidden stays usable: with the notch off screen the menu is where the
+/// percentages, resets and stale ages live.
 @MainActor
-final class StatusItemController {
+final class StatusItemController: NSObject, NSMenuDelegate {
     private var item: NSStatusItem?
     private let onOpenSettings: () -> Void
+    /// Refetch one provider, leaving the others alone.
+    var onRefreshProvider: ((String) -> Void)?
+    /// Refetch every provider.
+    var onRefreshAll: (() -> Void)?
+
+    /// The latest readings, mirrored from the store. The menu is rebuilt from
+    /// these every time it opens, so reset countdowns and ages are fresh.
+    var snapshots: [ProviderSnapshot] = []
 
     init(onOpenSettings: @escaping () -> Void) {
         self.onOpenSettings = onOpenSettings
@@ -24,13 +36,7 @@ final class StatusItemController {
         item.button?.toolTip = "Codenotch"
 
         let menu = NSMenu()
-        menu.addItem(
-            withTitle: "Settings…", action: #selector(openSettings), keyEquivalent: ","
-        ).target = self
-        menu.addItem(.separator())
-        menu.addItem(
-            withTitle: "Quit Codenotch", action: #selector(quit), keyEquivalent: "q"
-        ).target = self
+        menu.delegate = self
         item.menu = menu
 
         self.item = item
@@ -40,6 +46,46 @@ final class StatusItemController {
         guard let item else { return }
         NSStatusBar.system.removeStatusItem(item)
         self.item = nil
+    }
+
+    // MARK: - Menu
+
+    /// Rebuilt on every open rather than on every fetch: a menu built at fetch
+    /// time would freeze "Resets in 51 min" and "20 hr ago" until the next
+    /// reading lands.
+    func menuWillOpen(_ menu: NSMenu) {
+        rebuild(menu: menu, now: Date())
+    }
+
+    /// Exposed for tests: what the menu says without needing a status item.
+    func rebuild(menu: NSMenu, now: Date) {
+        menu.removeAllItems()
+        if snapshots.isEmpty {
+            let empty = NSMenuItem(title: "Waiting for the first reading…", action: nil, keyEquivalent: "")
+            empty.isEnabled = false
+            menu.addItem(empty)
+        } else {
+            for snapshot in snapshots {
+                menu.addItem(headerItem(for: snapshot, now: now))
+                for line in Self.detailLines(for: snapshot, now: now) {
+                    let row = NSMenuItem(title: line, action: nil, keyEquivalent: "")
+                    row.isEnabled = false
+                    row.indentationLevel = 1
+                    menu.addItem(row)
+                }
+            }
+        }
+        menu.addItem(.separator())
+        menu.addItem(
+            withTitle: "Refresh all", action: #selector(refreshAll), keyEquivalent: "r"
+        ).target = self
+        menu.addItem(
+            withTitle: "Settings…", action: #selector(openSettings), keyEquivalent: ","
+        ).target = self
+        menu.addItem(.separator())
+        menu.addItem(
+            withTitle: "Quit Codenotch", action: #selector(quit), keyEquivalent: "q"
+        ).target = self
     }
 
     /// The menu bar mark: its own drawing, not the app icon shrunk down.
@@ -63,4 +109,50 @@ final class StatusItemController {
 
     @objc private func openSettings() { onOpenSettings() }
     @objc private func quit() { NSApp.terminate(nil) }
+
+    @objc private func refreshProvider(_ sender: NSMenuItem) {
+        guard let id = sender.representedObject as? String else { return }
+        onRefreshProvider?(id)
+    }
+
+    @objc private func refreshAll() { onRefreshAll?() }
+
+    /// The provider's own row: name, headline figure, and age when stale — the
+    /// same three facts the tooltip header shows. Clicking re-reads it.
+    private func headerItem(for snapshot: ProviderSnapshot, now: Date) -> NSMenuItem {
+        var title = "\(snapshot.displayName) — \(snapshot.hasReading ? snapshot.headlineText : "—")"
+        if let since = snapshot.status.staleSince, since != .distantPast {
+            title += " · \(ElapsedCopy.ago(since: since, now: now))"
+        }
+        let header = NSMenuItem(title: title, action: #selector(refreshProvider(_:)), keyEquivalent: "")
+        header.target = self
+        header.representedObject = snapshot.id
+        return header
+    }
+
+    /// Everything the tooltip says under its header: the blocked line first,
+    /// then one row per limit window, or the status message when there is
+    /// nothing metered. Pure, so the wording can be tested without a menu.
+    static func detailLines(for snapshot: ProviderSnapshot, now: Date) -> [String] {
+        let now = now
+        if let block = snapshot.block {
+            var lines = [block.summary(now: now)]
+            lines += snapshot.windows.map { windowLine(for: $0, now: now) }
+            return lines
+        }
+        if let message = snapshot.statusMessage {
+            return [message]
+        }
+        return snapshot.windows.map { windowLine(for: $0, now: now) }
+    }
+
+    /// One metered window on one line: label, percentage burned, and reset —
+    /// the same three the tooltip spreads over three lines.
+    static func windowLine(for window: LimitWindow, now: Date) -> String {
+        var line = "\(window.label): \(window.summary)"
+        if let resetsAt = window.resetsAt {
+            line += " · \(ResetCopy.text(for: resetsAt, now: now))"
+        }
+        return line
+    }
 }

--- a/Sources/Providers/CodexUsage.swift
+++ b/Sources/Providers/CodexUsage.swift
@@ -14,7 +14,7 @@ enum CodexUsage {
     }
 
     private struct Window: Decodable {
-        let limit_window_seconds: Double
+        let limit_window_seconds: Double?
         let used_percent: Double?
         let reset_at: Double?
         let reset_after_seconds: Double?
@@ -32,14 +32,15 @@ enum CodexUsage {
         for (id, window) in [("primary", response.rate_limit?.primary_window),
                              ("secondary", response.rate_limit?.secondary_window)] {
             guard let window else { continue }
-            guard let percent = window.used_percent else {
-                throw UsageProviderError.badResponse(status: 0)
-            }
+            // One malformed window must not discard the other: a null
+            // `used_percent` on the 5h window once threw the whole fetch away,
+            // hiding a perfectly good weekly window behind an error.
+            guard let percent = window.used_percent else { continue }
             let resetsAt = window.reset_at.map { Date(timeIntervalSince1970: $0) }
                 ?? window.reset_after_seconds.map { now.addingTimeInterval($0) }
             windows.append(LimitWindow(
                 id: id,
-                label: label(windowSeconds: window.limit_window_seconds, fallback: id),
+                label: label(windowSeconds: window.limit_window_seconds ?? 0, fallback: id),
                 usedFraction: percent / 100,
                 resetsAt: resetsAt
             ))

--- a/Sources/Settings/NotchVisibility.swift
+++ b/Sources/Settings/NotchVisibility.swift
@@ -32,8 +32,12 @@ enum NotchVisibility: String, CaseIterable, Identifiable {
             return "A small pill at the screen edge that opens when you reach it."
         case .hidden:
             // Said here because a hidden notch is also a hidden way back in.
-            return "Nothing on screen. Open Codenotch again from Applications "
-                 + "to bring these settings back."
+            // Names the menu bar route: with the notch off screen the readings
+            // live in the menu bar menu instead, so Hide plus App icon "Menu
+            // bar" is a working setup rather than a one-way door.
+            return "Nothing on screen. The readings stay in the menu bar menu "
+                 + "when App icon is Menu bar. Otherwise, open Codenotch again "
+                 + "from Applications to bring these settings back."
         }
     }
 }

--- a/Tests/AntigravityTests.swift
+++ b/Tests/AntigravityTests.swift
@@ -798,6 +798,98 @@ final class MenuBarIconTests: XCTestCase {
     }
 }
 
+/// The menu bar menu when the notch is hidden: the same readings as the
+/// tooltips, or Hide is a one-way door to numbers you can no longer see.
+@MainActor
+final class StatusMenuTests: XCTestCase {
+    private let now = Date(timeIntervalSince1970: 1_788_000_000)
+
+    private func snapshot(
+        id: String = "codex", name: String = "Codex",
+        status: ProviderStatus = .ok,
+        windows: [LimitWindow] = [],
+        headlineID: String? = nil,
+        block: UsageBlock? = nil
+    ) -> ProviderSnapshot {
+        ProviderSnapshot(id: id, displayName: name, glyph: .openai,
+                         fidelity: .official, status: status,
+                         windows: windows, headlineID: headlineID, block: block)
+    }
+
+    /// One window reads as one line with the same three facts the tooltip
+    /// spreads over three lines: label, percentage, reset.
+    func testAWindowReadsAsOneLineWithLabelSummaryAndReset() {
+        let line = StatusItemController.windowLine(
+            for: LimitWindow(id: "primary", label: "5h limit", usedFraction: 0.08,
+                             resetsAt: now.addingTimeInterval(51 * 60)),
+            now: now)
+        XCTAssertTrue(line.contains("5h limit"), line)
+        XCTAssertTrue(line.contains("8% Used · 92% left"), line)
+        XCTAssertTrue(line.contains("Resets in 51 min"), line)
+    }
+
+    /// A window with no reset says so by saying nothing — never invented.
+    func testAWindowWithoutAResetOmitsIt() {
+        let line = StatusItemController.windowLine(
+            for: LimitWindow(id: "primary", label: "5h limit", usedFraction: 0.08),
+            now: now)
+        XCTAssertTrue(line.contains("5h limit"), line)
+        XCTAssertFalse(line.contains("Resets"), line)
+    }
+
+    /// The blocked line leads, because it changes what you can do next while
+    /// the percentage beside it still reads comfortable.
+    func testABlockLeadsTheDetails() {
+        let details = StatusItemController.detailLines(for: snapshot(
+            status: .ok,
+            windows: [LimitWindow(id: "primary", label: "5h limit", usedFraction: 0.16)],
+            block: UsageBlock(reason: "Paused", resetsAt: now.addingTimeInterval(90 * 60))
+        ), now: now)
+        XCTAssertEqual(details.count, 2)
+        XCTAssertTrue(details[0].hasPrefix("Paused until "), details[0])
+        XCTAssertTrue(details[1].contains("5h limit"), details[1])
+    }
+
+    /// Nothing metered reads as the tooltip's own status message, not blank.
+    func testNoWindowsReadsAsTheStatusMessage() {
+        let details = StatusItemController.detailLines(
+            for: snapshot(status: .needsAuth), now: now)
+        XCTAssertEqual(details, ["Sign in to Codex to read your usage"])
+    }
+
+    /// The header carries the headline figure and the reading's age — the same
+    /// pair the tooltip header shows.
+    func testTheMenuListsEveryProviderWithRefreshAndSettings() {
+        let controller = StatusItemController(onOpenSettings: {})
+        controller.snapshots = [snapshot(
+            status: .stale(since: now.addingTimeInterval(-(20 * 3600 + 21 * 60))),
+            windows: [LimitWindow(id: "secondary", label: "Weekly limit",
+                                   usedFraction: 0.29,
+                                   resetsAt: now.addingTimeInterval(3600))],
+            headlineID: "secondary")]
+        let menu = NSMenu()
+        controller.rebuild(menu: menu, now: now)
+        let titles = menu.items.map(\.title)
+        XCTAssertTrue(titles[0].contains("Codex — 29%"), titles[0])
+        XCTAssertTrue(titles[0].contains("20 hr 21 min ago"), titles[0])
+        XCTAssertTrue(titles[1].contains("Weekly limit"), titles[1])
+        XCTAssertTrue(titles[1].contains("29% Used · 71% left"), titles[1])
+        XCTAssertTrue(titles.contains("Refresh all"))
+        XCTAssertTrue(titles.contains("Settings…"))
+        XCTAssertTrue(titles.contains("Quit Codenotch"))
+        // The header re-reads its own provider.
+        XCTAssertEqual(menu.items[0].representedObject as? String, "codex")
+    }
+
+    /// With no readings yet the menu says so instead of showing an empty list.
+    func testAnEmptyMenuSaysItIsWaiting() {
+        let controller = StatusItemController(onOpenSettings: {})
+        let menu = NSMenu()
+        controller.rebuild(menu: menu, now: now)
+        XCTAssertTrue(menu.items[0].title.contains("Waiting for the first reading"))
+    }
+}
+
 
 
 /// Declining the keychain prompt is easy to do by reflex. Until now it was

--- a/Tests/CodexUsageTests.swift
+++ b/Tests/CodexUsageTests.swift
@@ -72,6 +72,44 @@ final class CodexUsageTests: XCTestCase {
         XCTAssertEqual(result.last?.usedFraction, 0)
         XCTAssertEqual(result.last?.resetsAt, Date(timeIntervalSince1970: 1_800_000_120))
     }
+
+    /// The reported symptom: the tooltip showed only the weekly window and the
+    /// ring showed a dash. A null `used_percent` on one window threw the whole
+    /// fetch away, so a good weekly window was hidden behind the bad hourly
+    /// one. One malformed window is skipped, not fatal.
+    func testAWindowMissingUsedPercentIsSkippedRatherThanFailing() throws {
+        let result = try windows("""
+        {"rate_limit":{
+          "primary_window":{"used_percent":null,"limit_window_seconds":18000,"reset_at":1800001000},
+          "secondary_window":{"used_percent":29,"limit_window_seconds":604800,"reset_at":1800600000}}}
+        """)
+        XCTAssertEqual(result.map(\.id), ["secondary"])
+        XCTAssertEqual(result.first?.label, "Weekly limit")
+        XCTAssertEqual(result.first?.usedFraction ?? -1, 0.29, accuracy: 0.0001)
+    }
+
+    /// A window without a duration still gets a fallback label instead of
+    /// failing the decode of the whole response.
+    func testAWindowMissingItsDurationStillParses() throws {
+        let result = try windows("""
+        {"rate_limit":{
+          "primary_window":{"used_percent":8,"reset_at":1800001000},
+          "secondary_window":{"used_percent":42,"limit_window_seconds":604800,"reset_at":1800600000}}}
+        """)
+        XCTAssertEqual(result.map(\.id), ["primary", "secondary"])
+        XCTAssertEqual(result.first?.label, "Current session")
+        XCTAssertEqual(result.last?.label, "Weekly limit")
+    }
+
+    /// Both windows malformed is still an error, not an empty success — the
+    /// store turns it into "waiting", not a silent 0%.
+    func testBothWindowsMissingLeavesNothingMetered() {
+        XCTAssertThrowsError(try windows("""
+        {"rate_limit":{
+          "primary_window":{"used_percent":null,"limit_window_seconds":18000},
+          "secondary_window":null}}
+        """))
+    }
 }
 
 /// The activity signal is a heuristic — a rollout written moments ago — so what


### PR DESCRIPTION
Settings has a Hide option for the notch overall, so putting the same usage on the menu bar click feels natural: Hide plus App icon set to Menu bar becomes a working setup instead of a one-way door to numbers you can no longer see.

Outcome (screenshot to attach below):

The menu bar menu now lists every provider with the same facts as the notch tooltips — header row with headline figure and reading age (clicking it refreshes just that provider), one line per limit window (label, percentage, reset), the blocked line first when present, or the status message when nothing is metered. Menu is rebuilt on every open so countdowns and ages are fresh, followed by Refresh all, Settings…, Quit. The Hide explanation now points at the menu bar route.

[Screenshot: menu bar usage menu — drag image 1 here]

Also in this PR, two small fixes found along the way:

- Makefile: the ad-hoc signing fallback never triggered — `grep -c` prints `0`, never empty, so `ifeq (, …)` was never true and Debug builds demanded the maintainer's Developer ID cert. Now `ifeq (0, …)`.
- Codex: one window with a null `used_percent` threw the whole fetch away, hiding a good weekly window behind a bad hourly one (ring showed — with only Weekly in the tooltip). Malformed windows are now skipped; both-bad is still nothingMetered. `limit_window_seconds` is optional with a fallback label.

Tests: `make test` passes — 561 tests, 0 failures, including 6 new StatusMenuTests and 3 new Codex partial-window tests.