### PR TITLE
Allow pinning the notch to a display

### DIFF
--- a/Sources/App/AppDelegate.swift
+++ b/Sources/App/AppDelegate.swift
@@ -81,6 +81,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             // this, every launch on any other edge opens with a flash of the
             // right-hand one and then crossfades away from it.
             controller.model.edge = preferences.notchEdge
+            controller.displayPreference = preferences.displayPreference
 
             let updater = Updater()
             self.updater = updater
@@ -144,6 +145,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             preferences.$notchEdge
                 .receive(on: RunLoop.main)
                 .sink { [weak controller] in controller?.apply(edge: $0) }
+                .store(in: &cancellables)
+
+            preferences.$displayPreference
+                .receive(on: RunLoop.main)
+                .sink { [weak controller] in controller?.apply(displayPreference: $0) }
                 .store(in: &cancellables)
 
             preferences.$disconnectedProviders

--- a/Sources/Notch/NotchGeometry.swift
+++ b/Sources/Notch/NotchGeometry.swift
@@ -14,16 +14,29 @@ protocol ScreenDescribing {
     var frameValue: CGRect { get }
     var visibleFrameValue: CGRect { get }
     var hardwareNotch: HardwareNotch? { get }
+    var displayIdentifier: String? { get }
 }
 
 extension ScreenDescribing {
     /// Most displays have none, and most tests do not care.
     var hardwareNotch: HardwareNotch? { nil }
+    var displayIdentifier: String? { nil }
 }
 
 extension NSScreen: ScreenDescribing {
     var frameValue: CGRect { frame }
     var visibleFrameValue: CGRect { visibleFrame }
+
+    /// Unlike `CGDirectDisplayID`, this UUID survives display reconfiguration
+    /// and restarts, so a saved choice still names the same physical monitor.
+    var displayIdentifier: String? {
+        let screenNumber = NSDeviceDescriptionKey("NSScreenNumber")
+        guard let number = deviceDescription[screenNumber] as? NSNumber,
+              let unmanaged = CGDisplayCreateUUIDFromDisplayID(number.uint32Value)
+        else { return nil }
+        let uuid = unmanaged.takeRetainedValue()
+        return CFUUIDCreateString(nil, uuid) as String
+    }
 
     /// Measured from the two menu-bar strips *either side* of the notch, which
     /// is the only thing AppKit describes directly. `safeAreaInsets.top` gives
@@ -96,8 +109,24 @@ enum NotchGeometry {
         )
     }
 
-    /// The notch follows the screen with the menu bar.
-    static func preferredScreen(from screens: [NSScreen]) -> NSScreen? {
-        NSScreen.main ?? screens.first
+    static func preferredScreen(
+        from screens: [NSScreen],
+        preference: DisplayPreference = .followActiveWindow
+    ) -> NSScreen? {
+        preferredScreen(from: screens, preference: preference, activeScreen: NSScreen.main)
+    }
+
+    /// Kept generic so display selection can be proved without relying on the
+    /// monitors attached to the machine running the tests.
+    static func preferredScreen<Screen: ScreenDescribing>(
+        from screens: [Screen],
+        preference: DisplayPreference,
+        activeScreen: Screen?
+    ) -> Screen? {
+        if case .display(let id) = preference,
+           let selected = screens.first(where: { $0.displayIdentifier == id }) {
+            return selected
+        }
+        return activeScreen ?? screens.first
     }
 }

--- a/Sources/Notch/NotchWindowController.swift
+++ b/Sources/Notch/NotchWindowController.swift
@@ -5,6 +5,7 @@ import Combine
 @MainActor
 final class NotchWindowController {
     let model = NotchViewModel()
+    var displayPreference: DisplayPreference = .followActiveWindow
 
     /// The panel's content view, so a test can check what SwiftUI is and is not
     /// allowed to reach.
@@ -97,7 +98,9 @@ final class NotchWindowController {
     // MARK: - Placement
 
     func relocate(cellCount: Int? = nil) {
-        guard let screen = NotchGeometry.preferredScreen(from: NSScreen.screens) else { return }
+        guard let screen = NotchGeometry.preferredScreen(
+            from: NSScreen.screens, preference: displayPreference
+        ) else { return }
         model.adopt(screen: screen)
         let size = model.panelSize(cellCount: cellCount ?? model.snapshots.count)
         let frame = NotchGeometry.panelFrame(for: screen, panelSize: size, edge: model.edge)
@@ -288,7 +291,9 @@ final class NotchWindowController {
     /// Has the Dock appeared, gone away, moved or resized since we last placed
     /// the panel? Nothing notifies us, so this is asked rather than told.
     private func followUsableAreaIfItMoved() {
-        guard let screen = NotchGeometry.preferredScreen(from: NSScreen.screens) else { return }
+        guard let screen = NotchGeometry.preferredScreen(
+            from: NSScreen.screens, preference: displayPreference
+        ) else { return }
         guard screen.visibleFrame != lastVisibleFrame else { return }
         relocate()
     }
@@ -479,6 +484,12 @@ final class NotchWindowController {
                 }
             }
         }
+    }
+
+    func apply(displayPreference: DisplayPreference) {
+        guard self.displayPreference != displayPreference else { return }
+        self.displayPreference = displayPreference
+        relocate()
     }
 
     /// Half the crossing, each way. Short: it is a settings change, not a

--- a/Sources/Settings/DisplayPreference.swift
+++ b/Sources/Settings/DisplayPreference.swift
@@ -1,0 +1,20 @@
+import AppKit
+
+/// Whether the notch follows keyboard focus or stays on one physical display.
+enum DisplayPreference: Hashable {
+    case followActiveWindow
+    case display(String)
+}
+
+/// A connected display as it appears in Settings.
+struct DisplayOption: Identifiable, Equatable {
+    let id: String
+    let name: String
+
+    @MainActor
+    static var connected: [DisplayOption] {
+        NSScreen.screens.compactMap { screen in
+            screen.displayIdentifier.map { DisplayOption(id: $0, name: screen.localizedName) }
+        }
+    }
+}

--- a/Sources/Settings/Preferences.swift
+++ b/Sources/Settings/Preferences.swift
@@ -26,6 +26,18 @@ final class Preferences: ObservableObject {
         didSet { defaults.set(notchEdge.rawValue, forKey: Keys.edge) }
     }
 
+    /// The display the notch stays on, or the original focus-following behaviour.
+    @Published var displayPreference: DisplayPreference {
+        didSet {
+            switch displayPreference {
+            case .followActiveWindow:
+                defaults.removeObject(forKey: Keys.display)
+            case .display(let id):
+                defaults.set(id, forKey: Keys.display)
+            }
+        }
+    }
+
     /// Where the app itself shows up: Dock, menu bar, or nowhere.
     @Published var appPresence: AppPresence {
         didSet { defaults.set(appPresence.rawValue, forKey: Keys.presence) }
@@ -59,6 +71,7 @@ final class Preferences: ObservableObject {
         static let visibility = "notchVisibility"
         static let presence = "appPresence"
         static let edge = "notchEdge"
+        static let display = "notchDisplay"
         static let lastSeenVersion = "lastSeenVersion"
     }
 
@@ -113,6 +126,8 @@ final class Preferences: ObservableObject {
         // side of a Mac that no system chrome claims by default.
         self.notchEdge = defaults.string(forKey: Keys.edge)
             .flatMap(NotchEdge.init(rawValue:)) ?? .right
+        self.displayPreference = defaults.string(forKey: Keys.display)
+            .map(DisplayPreference.display) ?? .followActiveWindow
         // Absent means nothing has been shown yet, which is true of a fresh
         // install — so the current release reads as new to it.
         self.lastSeenVersion = defaults.string(forKey: Keys.lastSeenVersion)

--- a/Sources/Settings/SettingsView.swift
+++ b/Sources/Settings/SettingsView.swift
@@ -9,6 +9,7 @@ struct SettingsView: View {
     /// another app, so the user is always coming *back* here to see it — which
     /// makes returning focus the exact moment the old value is wrong.
     @State private var accounts: [ProviderSummary] = []
+    @State private var displays: [DisplayOption] = []
     /// Switching off has to reach the store's archive, not just the preference
     /// — see `UsageStore.signOut(providerID:)`.
     let signOut: (String) -> Void
@@ -70,6 +71,22 @@ struct SettingsView: View {
                 .pickerStyle(.segmented)
 
                 Text(preferences.notchEdge.explanation)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                Picker("Display", selection: $preferences.displayPreference) {
+                    Text("Follow active window").tag(DisplayPreference.followActiveWindow)
+                    ForEach(displays) { display in
+                        Text(display.name).tag(DisplayPreference.display(display.id))
+                    }
+                    if case .display(let id) = preferences.displayPreference,
+                       !displays.contains(where: { $0.id == id }) {
+                        Text("Unavailable display").tag(DisplayPreference.display(id))
+                    }
+                }
+
+                Text(displayExplanation)
                     .font(.caption)
                     .foregroundStyle(.secondary)
                     .fixedSize(horizontal: false, vertical: true)
@@ -141,10 +158,30 @@ struct SettingsView: View {
         // hunted for is not really a credit.
         .safeAreaInset(edge: .bottom, spacing: 0) { credit }
         .frame(width: SettingsView.width, height: SettingsView.height)
-        .onAppear { accounts = providers() }
+        .onAppear { refreshVisibleState() }
         .onReceive(NotificationCenter.default.publisher(
             for: NSWindow.didBecomeKeyNotification
-        )) { _ in accounts = providers() }
+        )) { _ in refreshVisibleState() }
+        .onReceive(NotificationCenter.default.publisher(
+            for: NSApplication.didChangeScreenParametersNotification
+        )) { _ in displays = DisplayOption.connected }
+    }
+
+    private func refreshVisibleState() {
+        accounts = providers()
+        displays = DisplayOption.connected
+    }
+
+    private var displayExplanation: String {
+        switch preferences.displayPreference {
+        case .followActiveWindow:
+            return "Moves to the display containing the window receiving keyboard input."
+        case .display(let id):
+            if let display = displays.first(where: { $0.id == id }) {
+                return "Pinned to \(display.name)."
+            }
+            return "That display is disconnected. Codenotch follows the active window until it returns."
+        }
     }
 
     private var credit: some View {

--- a/Tests/NotchGeometryTests.swift
+++ b/Tests/NotchGeometryTests.swift
@@ -4,6 +4,7 @@ import XCTest
 private struct FakeScreen: ScreenDescribing {
     var frameValue: CGRect
     var visibleFrameValue: CGRect
+    var displayIdentifier: String? = nil
 }
 
 final class NotchGeometryTests: XCTestCase {
@@ -31,6 +32,43 @@ final class NotchGeometryTests: XCTestCase {
         let frame = NotchGeometry.panelFrame(for: secondary, panelSize: CGSize(width: 334, height: 484))
         XCTAssertEqual(frame.maxX, 0, accuracy: 0.001)
         XCTAssertEqual(frame.midY, 920, accuracy: 0.5)
+    }
+
+    func testAChosenDisplayWinsOverTheActiveOne() {
+        let active = FakeScreen(frameValue: .zero, visibleFrameValue: .zero,
+                                displayIdentifier: "active")
+        let chosen = FakeScreen(frameValue: CGRect(x: 100, y: 0, width: 100, height: 100),
+                                visibleFrameValue: .zero, displayIdentifier: "chosen")
+
+        let result = NotchGeometry.preferredScreen(
+            from: [active, chosen], preference: .display("chosen"), activeScreen: active
+        )
+
+        XCTAssertEqual(result?.displayIdentifier, "chosen")
+    }
+
+    func testADisconnectedChoiceTemporarilyFallsBackToTheActiveDisplay() {
+        let active = FakeScreen(frameValue: .zero, visibleFrameValue: .zero,
+                                displayIdentifier: "active")
+
+        let result = NotchGeometry.preferredScreen(
+            from: [active], preference: .display("missing"), activeScreen: active
+        )
+
+        XCTAssertEqual(result?.displayIdentifier, "active")
+    }
+
+    func testFollowActiveWindowUsesTheActiveDisplay() {
+        let first = FakeScreen(frameValue: .zero, visibleFrameValue: .zero,
+                               displayIdentifier: "first")
+        let active = FakeScreen(frameValue: .zero, visibleFrameValue: .zero,
+                                displayIdentifier: "active")
+
+        let result = NotchGeometry.preferredScreen(
+            from: [first, active], preference: .followActiveWindow, activeScreen: active
+        )
+
+        XCTAssertEqual(result?.displayIdentifier, "active")
     }
 }
 

--- a/Tests/NotchLayoutTests.swift
+++ b/Tests/NotchLayoutTests.swift
@@ -445,6 +445,21 @@ final class PreferencesTests: XCTestCase {
         XCTAssertFalse(Preferences(defaults: defaults).isConnected("codex"))
     }
 
+    func testDisplayChoiceSurvivesARestart() {
+        let name = "PreferencesTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: name)!
+        defaults.removePersistentDomain(forName: name)
+
+        Preferences(defaults: defaults).displayPreference = .display("monitor-uuid")
+
+        XCTAssertEqual(Preferences(defaults: defaults).displayPreference,
+                       .display("monitor-uuid"))
+    }
+
+    func testDisplayDefaultsToFollowingTheActiveWindow() {
+        XCTAssertEqual(preferences().displayPreference, .followActiveWindow)
+    }
+
     /// The key is deliberately unchanged across the rename, so choices made
     /// before it survive.
     func testItReadsChoicesStoredUnderTheOldName() {


### PR DESCRIPTION
The notch currently follows `NSScreen.main`, so it moves whenever keyboard focus moves to a window on another display. This adds a Display picker beside the existing edge controls, allowing the notch to keep following the active window or stay pinned to a named physical display.

The selected display is stored by its persistent macOS display UUID. If that display is disconnected, Codenotch temporarily follows the active window and automatically returns when the selected display reconnects.

Closes #16.

## Validation

- `make test` — 557 tests, 0 failures
- Verified the real Settings UI lists “Follow active window” and connected displays by name
- Verified changing the selection updates and persists the preference
- Covered selected, active, disconnected, and reconnected display resolution with simulated screens

I only have one physical monitor available, so the final movement between physical displays still needs hardware verification. @makifej, would you be willing to test this draft on your three-display setup?
