### PR TITLE
Say when a session ends, and jump to it

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,38 @@ Any `~/.claude-<slug>` directory Claude Code has run against is found at launch;
 the default `~/.claude` always comes first, the rest in alphabetical order, so the
 rings never swap places.
 
+## When a session ends
+
+The notch opens itself for five seconds when an agent stops working, or stops
+to ask you something, and sounds the system alert. Clicking it while it is open
+brings that session's application to the front.
+
+The app, not the tab. A session publishes its pid and nothing else — no window,
+no tab, no tty — so the app is found by walking up the process tree from the
+agent to whatever launched it. Choosing the *tab* inside that app needs the
+terminal's own scripting interface, and there is no general one: Terminal.app
+and iTerm2 can match a tab by tty, Warp and Ghostty publish no scripting
+dictionary at all. So the app is raised for everybody and the tooltip names the
+session, which leaves the last hop one keystroke rather than working for two
+terminals and silently doing nothing in a third.
+
+Both halves switch off separately in Settings, because they fail differently:
+the peek is no use behind a full-screen window, and the sound is no use in a
+meeting. Each of the two events — finished, and waiting on you — picks its own
+sound there, with a preview button beside it.
+
+The sound is played as a file on the ordinary output rather than handed to
+`NSSound` as a system alert. A system alert goes through the interface
+sound-effects channel, which System Settings → Sound can switch off — and on a
+Mac where it is off, `NSSound.play()` reports success and nothing is heard.
+
+Only *leaving* busy counts. A question being answered is not a piece of work
+ending, and a session whose file disappears mid-turn — which is what quitting
+Claude Code looks like — is not announced at all, since there is no window left
+to jump to. Nothing is announced from the first reading either: every session
+already running at launch arrives with no history, and treating that as a
+transition would ring once per open window on every start.
+
 ## Placement
 
 The notch lives on any of the four screen edges. Right and left keep a

--- a/Sources/App/AppDelegate.swift
+++ b/Sources/App/AppDelegate.swift
@@ -13,6 +13,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var updater: Updater?
     private var statusItem: StatusItemController?
     private var cancellables = Set<AnyCancellable>()
+    /// Turns the monitors' running commentary into the one event worth
+    /// interrupting for: an agent that has just stopped working.
+    private var completions = SessionCompletionWatcher()
 
     /// The unit bundle is hosted by this app, so `xcodebuild test` launches it
     /// for real. Without this guard every test run put a live request on the
@@ -197,11 +200,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         for (id, monitor) in monitors {
             monitor.sessionsPublisher
                 .receive(on: RunLoop.main)
-                .sink { [weak controller] live in
+                .sink { [weak self, weak controller] live in
+                    guard let controller else { return }
                     withAnimation(.spring(response: 0.3, dampingFraction: 0.85)) {
-                        controller?.model.sessions[id] = live
+                        controller.model.sessions[id] = live
                     }
-                    controller?.model.now = Date()
+                    controller.model.now = Date()
+                    // The publisher delivers on the main run loop, but the
+                    // closure itself is nonisolated — the same assertion the
+                    // notch controller's timers make.
+                    MainActor.assumeIsolated { self?.announceCompletions(on: controller) }
                 }
                 .store(in: &cancellables)
             monitor.start()
@@ -212,6 +220,33 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         controller.show()
         notchController = controller
+    }
+
+    /// Open the notch, and make a noise, when something has just finished.
+    ///
+    /// The watcher is fed on every publication whether or not anything is
+    /// switched on, because it is a difference engine: skipping a reading would
+    /// leave it comparing against a state two changes old, and the *next*
+    /// transition it reported would be one that never happened.
+    ///
+    /// Several sessions can land in the same reading — one turn ending often
+    /// unblocks another — and that gets one peek and one chime rather than a
+    /// chord. The newest is the one offered, since it is the one whose window
+    /// you were most recently in.
+    @MainActor
+    private func announceCompletions(on controller: NotchWindowController) {
+        let events = completions.absorb(controller.model.sessions)
+        guard let event = events.first, let preferences else { return }
+        Log.usage.info("session \(event.session.name, privacy: .public) \(String(describing: event.reason), privacy: .public)")
+
+        if preferences.sessionEndSound {
+            SessionChime.play(event.reason == .blocked
+                              ? preferences.sessionBlockedSoundName
+                              : preferences.sessionEndSoundName)
+        }
+        guard preferences.announceSessionEnd else { return }
+        controller.peek(for: preferences.peekDuration.seconds,
+                        focusing: event.session.processID)
     }
 
     /// Closing the settings window must not take the app with it.

--- a/Sources/App/SessionChime.swift
+++ b/Sources/App/SessionChime.swift
@@ -1,0 +1,94 @@
+import AVFoundation
+import AppKit
+
+/// The sound a finished session makes.
+///
+/// Plays the audio file itself rather than handing a name to `NSSound`.
+/// `NSSound(named:)` resolves a system alert, and a system alert is routed
+/// through the interface-sound-effects channel — which System Settings → Sound
+/// can switch off, and which a good number of people have switched off, since
+/// it is also what makes the Mac click and swoosh at them all day. On such a
+/// machine `NSSound.play()` returns true and nothing is heard. Reading the same
+/// file into an `AVAudioPlayer` puts it on the ordinary output path, where the
+/// only thing that silences it is the volume control.
+enum SessionChime {
+    /// A turn ended. Short and unremarkable — this fires whenever any window
+    /// finishes, which on a busy afternoon is often.
+    static let defaultFinished = "Glass"
+    /// A session is blocked on you. Two-toned, so it reads as different from
+    /// the ordinary one without being an alarm.
+    static let defaultBlocked = "Funk"
+
+    /// Where macOS keeps alert sounds, most specific first, so a user's own
+    /// file shadows a system one of the same name.
+    private static let directories = [
+        "\(NSHomeDirectory())/Library/Sounds",
+        "/Library/Sounds",
+        "/System/Library/Sounds"
+    ]
+
+    private static let extensions = ["aiff", "aif", "m4a", "wav", "caf"]
+
+    /// Every sound the picker can offer, by name, in the order macOS lists them.
+    static var available: [String] {
+        var seen = Set<String>()
+        var names: [String] = []
+        for directory in directories {
+            let files = (try? FileManager.default.contentsOfDirectory(atPath: directory)) ?? []
+            for file in files.sorted() {
+                let url = URL(fileURLWithPath: file)
+                guard extensions.contains(url.pathExtension.lowercased()) else { continue }
+                let name = url.deletingPathExtension().lastPathComponent
+                if seen.insert(name).inserted { names.append(name) }
+            }
+        }
+        return names.sorted { $0.localizedCaseInsensitiveCompare($1) == .orderedAscending }
+    }
+
+    static func url(for name: String) -> URL? {
+        for directory in directories {
+            for ext in extensions {
+                let url = URL(fileURLWithPath: directory).appendingPathComponent("\(name).\(ext)")
+                if FileManager.default.fileExists(atPath: url.path) { return url }
+            }
+        }
+        return nil
+    }
+
+    /// Plays the named sound, if it is still there. Returns whether it started.
+    ///
+    /// The player is held for the length of the sound: a stack local is
+    /// deallocated on the way out of this function and stops mid-note.
+    ///
+    /// The return value is not decoration — it is what a test can assert on,
+    /// and asserting on it is what keeps `play()` out of the log interpolation
+    /// below. See the comment there.
+    @discardableResult
+    static func play(_ name: String) -> Bool {
+        guard let url = url(for: name) else {
+            Log.usage.error("no sound file named \(name, privacy: .public)")
+            return false
+        }
+        do {
+            let player = try AVAudioPlayer(contentsOf: url)
+            player.prepareToPlay()
+            playing = player
+            // On its own line, and never inside the log interpolation below.
+            // Logger's interpolations are autoclosures evaluated only when the
+            // level is enabled, so a `play()` written into one does not happen
+            // at all on an ordinary run — the app logs nothing and plays
+            // nothing, and every part of it looks correct.
+            let started = player.play()
+            Log.usage.debug("chime \(name, privacy: .public): \(started, privacy: .public)")
+            return started
+        } catch {
+            // Worth falling back for rather than going silent: whatever stops
+            // AVFoundation reading the file — an unreadable custom sound, a
+            // format it will not open — has nothing to do with NSSound.
+            Log.usage.error("chime \(name, privacy: .public) failed: \(error.localizedDescription, privacy: .public)")
+            return NSSound(named: name)?.play() ?? false
+        }
+    }
+
+    private static var playing: AVAudioPlayer?
+}

--- a/Sources/Notch/NotchWindowController.swift
+++ b/Sources/Notch/NotchWindowController.swift
@@ -40,6 +40,27 @@ final class NotchWindowController {
     /// twitchy rather than responsive.
     private let foldGrace: TimeInterval = 0.45
     private var foldWork: DispatchWorkItem?
+    /// Folds the notch again after a peek, when nothing else is holding it open.
+    private var peekWork: DispatchWorkItem?
+    /// The session a peek is currently offering, and how long the offer lasts.
+    ///
+    /// A click on the open notch normally pins it or refetches a ring; while
+    /// this is set and unexpired it jumps to the session instead. The expiry is
+    /// what keeps the two apart — without it, the *next* click on the notch,
+    /// minutes later and about something else, would still be raising a
+    /// terminal window.
+    private var pendingFocus: (pid: pid_t, until: Date)?
+    /// When the current peek's five seconds are up.
+    ///
+    /// The hover fold has to be told to leave it alone until then. Without
+    /// this the cursor poll — which runs every 0.3s and asks "is the pointer on
+    /// the notch?", to which the answer during a peek is almost always no —
+    /// scheduled a fold immediately, and the notch opened and shut inside a
+    /// second. A peek is not the pointer arriving, so the pointer leaving is
+    /// not what should end it.
+    private var peekUntil: Date?
+    /// The standing visibility choice, so a peek never overrides Hidden.
+    private var visibility: NotchVisibility = .onHover
     /// Whether we have pushed the pointing hand onto the cursor stack.
     private var isPointing = false
     /// The usable area the panel was last placed against.
@@ -86,6 +107,8 @@ final class NotchWindowController {
 
     func stop() {
         setPointing(false)
+        peekUntil = nil
+        peekWork?.cancel()
         foldWork?.cancel()
         cursorTimer?.invalidate()
         cursorTimer = nil
@@ -352,6 +375,9 @@ final class NotchWindowController {
             return
         }
 
+        // A peek holds the notch open for its own duration; only after that
+        // does the pointer get a say again.
+        if let peekUntil, peekUntil > Date() { return }
         guard model.isExpanded, !model.staysOpen, foldWork == nil else { return }
         let work = DispatchWorkItem { [weak self] in
             MainActor.assumeIsolated {
@@ -391,7 +417,40 @@ final class NotchWindowController {
     /// A click on a ring refetches that provider; a click anywhere else on the
     /// open notch pins it. The ring is the more specific target, so it wins.
     func handleClick() {
-        guard let panel, model.isExpanded else {
+        guard let panel else {
+            setExpanded(true)
+            return
+        }
+        let local = localCursor(in: panel.frame)
+
+        // The handle sits inside the notch, so it has to be tested before the
+        // cells — otherwise the cell band nearest the foot of the stack swallows
+        // it and clicking the gear refetches a provider instead.
+        if model.isExpanded, isOverHandle(local) {
+            onOpenSettings?()
+            return
+        }
+        // A peek is a question — "this one just finished, do you want it?" —
+        // and the click that follows is the answer. It outranks pinning and
+        // refetching for as long as the offer stands, and for no longer.
+        //
+        // Tested before the folded case below, not after: the grace period
+        // outlives the peek by a couple of seconds precisely so that a hand
+        // that arrived late still lands on the session, and answering it by
+        // merely re-opening the notch would waste that click.
+        if takePendingFocus() {
+            peekWork?.cancel()
+            peekWork = nil
+            peekUntil = nil
+            withAnimation(NotchMotion.unfold) {
+                model.isExpanded = false
+                model.hoveredIndex = nil
+            }
+            setPointing(false)
+            updateInteractiveRects()
+            return
+        }
+        guard model.isExpanded else {
             // Opens it, the same as the pointer arriving would — it must not
             // also pin it. The pill's hot zone is deliberately generous, since
             // it is a small target on a screen edge, so a click aimed at
@@ -401,15 +460,6 @@ final class NotchWindowController {
             // the ordinary hover behaviour, which a plain `setExpanded` leaves
             // intact.
             setExpanded(true)
-            return
-        }
-        let local = localCursor(in: panel.frame)
-
-        // The handle sits inside the notch, so it has to be tested before the
-        // cells — otherwise the cell band nearest the foot of the stack swallows
-        // it and clicking the gear refetches a provider instead.
-        if isOverHandle(local) {
-            onOpenSettings?()
             return
         }
         if notchRect.contains(local),
@@ -489,6 +539,11 @@ final class NotchWindowController {
     private var edgeChange = 0
 
     func apply(_ visibility: NotchVisibility) {
+        self.visibility = visibility
+        // A standing choice outranks a peek that happens to be in flight.
+        peekWork?.cancel()
+        peekWork = nil
+        peekUntil = nil
         switch visibility {
         case .alwaysShow:
             panel?.orderFrontRegardless()
@@ -521,6 +576,76 @@ final class NotchWindowController {
         }
         setPointing(false)
         updateInteractiveRects()
+    }
+
+    // MARK: - Peeking
+
+    /// Open the notch by itself for a moment, because something happened.
+    ///
+    /// Distinct from `setExpanded(true)`, which is the pointer arriving: this
+    /// has no pointer to leave again, so it schedules its own close. The close
+    /// checks the same two conditions the hover fold does — pinned open, or the
+    /// pointer now resting on it — because a peek that arrives while you are
+    /// already reading the notch must not yank it shut underneath you.
+    ///
+    /// `pid` is the agent's process, used only if the peek is clicked; nil
+    /// leaves the click doing what it ordinarily does.
+    func peek(for duration: TimeInterval, focusing pid: pid_t?) {
+        // Hidden is a standing choice that the notch is not to be on screen.
+        // Something finishing is not grounds to overrule it — the chime still
+        // sounds, which is the part that works with nothing visible.
+        guard visibility != .hidden, let panel else {
+            Log.usage.debug("peek skipped: notch hidden")
+            return
+        }
+        Log.usage.debug("peek for \(duration, privacy: .public)s, pid \(pid ?? -1, privacy: .public)")
+
+        if let pid {
+            pendingFocus = (pid: pid, until: Date().addingTimeInterval(duration + Self.focusGrace))
+        }
+        peekUntil = Date().addingTimeInterval(duration)
+
+        panel.orderFrontRegardless()
+        foldWork?.cancel()
+        foldWork = nil
+        peekWork?.cancel()
+        withAnimation(NotchMotion.unfold) { model.isExpanded = true }
+        updateInteractiveRects()
+
+        let work = DispatchWorkItem { [weak self] in
+            MainActor.assumeIsolated {
+                guard let self, let panel = self.panel else { return }
+                self.peekWork = nil
+                self.peekUntil = nil
+                guard !self.model.staysOpen else { return }
+                // Left open if the peek did its job and the pointer is already
+                // there; the ordinary hover fold takes it from here.
+                guard !self.liveRect.contains(self.localCursor(in: panel.frame)) else { return }
+                withAnimation(NotchMotion.unfold) {
+                    self.model.isExpanded = false
+                    self.model.hoveredIndex = nil
+                }
+                self.setPointing(false)
+                self.updateInteractiveRects()
+                Log.usage.debug("peek folded")
+            }
+        }
+        peekWork = work
+        DispatchQueue.main.asyncAfter(deadline: .now() + duration, execute: work)
+    }
+
+    /// How long after a peek folds a click still counts as answering it. Covers
+    /// the reach for the mouse that started while the notch was still open.
+    private static let focusGrace: TimeInterval = 2
+
+    /// Raise the terminal the peeked session is running in, if the offer stands.
+    private func takePendingFocus() -> Bool {
+        guard let pending = pendingFocus, pending.until > Date() else {
+            pendingFocus = nil
+            return false
+        }
+        pendingFocus = nil
+        return SessionFocus.activateApp(owning: pending.pid)
     }
 
     /// Clicking the open notch pins it, so it stays put while you read it.

--- a/Sources/Sessions/AgentSession.swift
+++ b/Sources/Sessions/AgentSession.swift
@@ -1,3 +1,4 @@
+import Darwin
 import Foundation
 
 /// One agent session, whichever tool it belongs to.
@@ -24,4 +25,32 @@ struct AgentSession: Identifiable, Equatable {
     let waitingFor: String?
     /// When it entered its current state.
     let since: Date
+    /// The agent's own process, when the tool publishes one.
+    ///
+    /// Only used to find the window it is running in — see `SessionFocus`.
+    /// Nil for the tools that report activity from a database or a log file
+    /// rather than from a process, and a nil here costs nothing but the ability
+    /// to jump to that session.
+    let processID: pid_t?
+
+    /// Written out rather than synthesised so `processID` can default to nil:
+    /// four of the five monitors have no pid to give, and a memberwise
+    /// initialiser would have made every one of them say so.
+    init(
+        id: String,
+        name: String,
+        detail: String,
+        state: State,
+        waitingFor: String?,
+        since: Date,
+        processID: pid_t? = nil
+    ) {
+        self.id = id
+        self.name = name
+        self.detail = detail
+        self.state = state
+        self.waitingFor = waitingFor
+        self.since = since
+        self.processID = processID
+    }
 }

--- a/Sources/Sessions/ClaudeSessionRecord.swift
+++ b/Sources/Sessions/ClaudeSessionRecord.swift
@@ -44,7 +44,8 @@ struct ClaudeSessionRecord {
             detail: "\(Self.surface(json["entrypoint"] as? String)) · \(folder)",
             state: state,
             waitingFor: (json["waitingFor"] as? String) ?? (json["needs"] as? String),
-            since: millis.map { Date(timeIntervalSince1970: $0 / 1000) } ?? Date()
+            since: millis.map { Date(timeIntervalSince1970: $0 / 1000) } ?? Date(),
+            processID: pid
         )
     }
 

--- a/Sources/Sessions/GrokActivityMonitor.swift
+++ b/Sources/Sessions/GrokActivityMonitor.swift
@@ -97,7 +97,8 @@ enum GrokActivity {
             detail: "Grok",
             state: .busy,
             waitingFor: nil,
-            since: modified
+            since: modified,
+            processID: pid
         )
     }
 

--- a/Sources/Sessions/SessionCompletionWatcher.swift
+++ b/Sources/Sessions/SessionCompletionWatcher.swift
@@ -1,0 +1,78 @@
+import Foundation
+
+/// Notices the moment an agent stops working.
+///
+/// The monitors publish *what is true now*; nothing in them says what changed.
+/// That difference is the whole event here — a session sitting at `idle` is
+/// unremarkable, a session that was `busy` a second ago and is `idle` now is
+/// the thing worth looking up for. So this keeps the previous state of every
+/// session and reports only the crossings.
+///
+/// Pure and free of AppKit on purpose: it is the part with the edge cases, and
+/// tests can drive it directly.
+struct SessionCompletionWatcher {
+    /// Why a session is being announced.
+    enum Reason: Equatable {
+        /// Ran to the end of its turn.
+        case finished
+        /// Stopped to ask something, and is waiting on an answer.
+        case blocked
+    }
+
+    struct Event: Equatable {
+        let session: AgentSession
+        let reason: Reason
+        /// Which provider's ring it belongs to, so the notch can point at it.
+        let providerID: String
+    }
+
+    /// The last state seen for every session, keyed by provider and session id.
+    private var previous: [String: AgentSession.State] = [:]
+    /// Nothing is announced from the first reading.
+    ///
+    /// Every session already running when Codenotch launches arrives with no
+    /// history, and treating that as a transition would ring once per session
+    /// on every start — including a restart in the middle of the night after a
+    /// Sparkle update. The first pass only records.
+    private var hasSeeded = false
+
+    /// Feed the monitors' current view; get back what just changed.
+    mutating func absorb(_ sessions: [String: [AgentSession]]) -> [Event] {
+        var current: [String: AgentSession.State] = [:]
+        var events: [Event] = []
+
+        for (providerID, live) in sessions {
+            for session in live {
+                let key = "\(providerID)\u{1}\(session.id)"
+                current[key] = session.state
+                guard hasSeeded, let was = previous[key] else { continue }
+                guard let reason = Self.reason(from: was, to: session.state) else { continue }
+                events.append(Event(session: session, reason: reason, providerID: providerID))
+            }
+        }
+
+        // Sessions that vanished are dropped rather than announced. A session
+        // file disappears when the process exits — often *while* it was busy,
+        // because quitting Claude Code mid-turn is an ordinary thing to do —
+        // and a chime for a window that is already gone points at nothing.
+        previous = current
+        hasSeeded = true
+        // Newest first, so the one that just landed is the one a single click
+        // reaches.
+        return events.sorted { $0.session.since > $1.session.since }
+    }
+
+    /// Only leaving `busy` counts.
+    ///
+    /// `waiting` to `idle` is the tail of a question that was answered, and
+    /// `idle` to `idle` is the steady state of a window nobody is using —
+    /// neither is a piece of work ending.
+    static func reason(from was: AgentSession.State, to now: AgentSession.State) -> Reason? {
+        guard was == .busy else { return nil }
+        switch now {
+        case .idle:    return .finished
+        case .waiting: return .blocked
+        case .busy:    return nil
+        }
+    }
+}

--- a/Sources/Sessions/SessionFocus.swift
+++ b/Sources/Sessions/SessionFocus.swift
@@ -1,0 +1,72 @@
+import AppKit
+import Darwin
+import Foundation
+
+/// Brings the window an agent is running in to the front.
+///
+/// A session knows its own pid and nothing else — Claude Code publishes no
+/// window, tab or tty. What it does have is a parent: the shell that launched
+/// it, whose parent is the terminal application. So the app is found by walking
+/// up the process tree until something turns up that macOS considers an
+/// application, and that is what gets raised.
+///
+/// This stops at the application. Selecting the *tab* inside it needs the
+/// terminal's own scripting interface and there is no general one: Terminal.app
+/// and iTerm2 can match a tab by tty over AppleScript, Warp and Ghostty publish
+/// no scripting dictionary at all. Rather than work for two terminals and
+/// silently do nothing in a third, the app is raised for everybody and the
+/// tooltip names the session so the last hop is one keystroke.
+enum SessionFocus {
+    /// Raise whichever application owns this process.
+    ///
+    /// Returns false when the chain runs out before an application appears,
+    /// which is the honest answer for an agent started by launchd, over ssh, or
+    /// from a process that has since been reparented to init.
+    @discardableResult
+    static func activateApp(owning pid: pid_t) -> Bool {
+        guard let app = owningApp(of: pid) else {
+            Log.usage.debug("no owning app for pid \(pid, privacy: .public)")
+            return false
+        }
+        // `activate()` rather than the deprecated options form: the notch's own
+        // panel is non-activating, so there is no focus of ours to hand over
+        // and nothing to co-ordinate.
+        return app.activate()
+    }
+
+    /// The nearest ancestor process that macOS knows as a running application.
+    static func owningApp(of pid: pid_t) -> NSRunningApplication? {
+        for candidate in ancestry(of: pid) {
+            if let app = NSRunningApplication(processIdentifier: candidate),
+               app.bundleIdentifier != nil {
+                return app
+            }
+        }
+        return nil
+    }
+
+    /// The process and its parents, nearest first.
+    ///
+    /// Bounded rather than looped until pid 1: a corrupted `kinfo_proc` that
+    /// reports itself as its own parent would otherwise spin forever, and no
+    /// real chain from an agent to its terminal is more than a handful deep.
+    static func ancestry(of pid: pid_t, limit: Int = 8) -> [pid_t] {
+        var chain: [pid_t] = []
+        var current = pid
+        while chain.count < limit, current > 1 {
+            chain.append(current)
+            guard let parent = parent(of: current), parent != current else { break }
+            current = parent
+        }
+        return chain
+    }
+
+    static func parent(of pid: pid_t) -> pid_t? {
+        var info = kinfo_proc()
+        var size = MemoryLayout<kinfo_proc>.stride
+        var mib: [Int32] = [CTL_KERN, KERN_PROC, KERN_PROC_PID, pid]
+        guard sysctl(&mib, u_int(mib.count), &info, &size, nil, 0) == 0, size > 0
+        else { return nil }
+        return info.kp_eproc.e_ppid
+    }
+}

--- a/Sources/Settings/PeekDuration.swift
+++ b/Sources/Settings/PeekDuration.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+/// How long the notch stays open when it opens by itself.
+///
+/// A fixed set rather than a free number: the useful range is narrow, and the
+/// values outside it are worse than they look. Below a second or two the notch
+/// is gone before a glance can land on it; much beyond ten it stops reading as
+/// an announcement and starts being a thing parked on the screen edge that has
+/// to be waited out.
+enum PeekDuration: String, CaseIterable, Identifiable {
+    case brief
+    case standard
+    case long
+
+    var id: String { rawValue }
+
+    var seconds: TimeInterval {
+        switch self {
+        case .brief:    return 3
+        case .standard: return 5
+        case .long:     return 10
+        }
+    }
+
+    var title: String {
+        switch self {
+        case .brief:    return "3 seconds"
+        case .standard: return "5 seconds"
+        case .long:     return "10 seconds"
+        }
+    }
+
+    var explanation: String {
+        switch self {
+        case .brief:
+            return "Long enough to notice, short enough to ignore."
+        case .standard:
+            return "Long enough to read the session's name and reach for it."
+        case .long:
+            return "Stays until you have had a chance to look up."
+        }
+    }
+}

--- a/Sources/Settings/Preferences.swift
+++ b/Sources/Settings/Preferences.swift
@@ -31,6 +31,45 @@ final class Preferences: ObservableObject {
         didSet { defaults.set(appPresence.rawValue, forKey: Keys.presence) }
     }
 
+    /// Open the notch for a few seconds when an agent stops working.
+    ///
+    /// On by default: the app already knows the moment a session ends, and a
+    /// user who installed a thing that watches sessions is unlikely to want
+    /// that particular fact kept from them. It is a peek, not a notification —
+    /// nothing to dismiss, and it takes no focus.
+    @Published var announceSessionEnd: Bool {
+        didSet { defaults.set(announceSessionEnd, forKey: Keys.announceSessionEnd) }
+    }
+
+    /// How long that peek lasts.
+    @Published var peekDuration: PeekDuration {
+        didSet { defaults.set(peekDuration.rawValue, forKey: Keys.peekDuration) }
+    }
+
+    /// Sound the system alert alongside the peek.
+    ///
+    /// Separate from the peek because they fail differently: the peek is no use
+    /// on another Space or behind a full-screen window, and the sound is no use
+    /// in a meeting. Kept switchable on its own so neither one forces the
+    /// other.
+    @Published var sessionEndSound: Bool {
+        didSet { defaults.set(sessionEndSound, forKey: Keys.sessionEndSound) }
+    }
+
+    /// Which sound a finished turn makes.
+    @Published var sessionEndSoundName: String {
+        didSet { defaults.set(sessionEndSoundName, forKey: Keys.sessionEndSoundName) }
+    }
+
+    /// And which one a session blocked on you makes.
+    ///
+    /// A separate choice because the two say different things — one is "that's
+    /// done", the other is "you are the hold-up" — and a single sound for both
+    /// makes the second one easy to ignore.
+    @Published var sessionBlockedSoundName: String {
+        didSet { defaults.set(sessionBlockedSoundName, forKey: Keys.sessionBlockedSoundName) }
+    }
+
     /// The version whose changes have already been shown.
     ///
     /// Written when the What's New dialogue is dismissed rather than when it
@@ -60,6 +99,11 @@ final class Preferences: ObservableObject {
         static let presence = "appPresence"
         static let edge = "notchEdge"
         static let lastSeenVersion = "lastSeenVersion"
+        static let announceSessionEnd = "announceSessionEnd"
+        static let sessionEndSound = "sessionEndSound"
+        static let peekDuration = "peekDuration"
+        static let sessionEndSoundName = "sessionEndSoundName"
+        static let sessionBlockedSoundName = "sessionBlockedSoundName"
     }
 
     /// True the very first time this copy runs, and never again.
@@ -116,6 +160,16 @@ final class Preferences: ObservableObject {
         // Absent means nothing has been shown yet, which is true of a fresh
         // install — so the current release reads as new to it.
         self.lastSeenVersion = defaults.string(forKey: Keys.lastSeenVersion)
+        // Both default to on, so `bool(forKey:)` — which answers false for a
+        // key that was never written — cannot stand in for the default.
+        self.announceSessionEnd = defaults.object(forKey: Keys.announceSessionEnd) as? Bool ?? true
+        self.sessionEndSound = defaults.object(forKey: Keys.sessionEndSound) as? Bool ?? true
+        self.peekDuration = defaults.string(forKey: Keys.peekDuration)
+            .flatMap(PeekDuration.init(rawValue:)) ?? .standard
+        self.sessionEndSoundName = defaults.string(forKey: Keys.sessionEndSoundName)
+            ?? SessionChime.defaultFinished
+        self.sessionBlockedSoundName = defaults.string(forKey: Keys.sessionBlockedSoundName)
+            ?? SessionChime.defaultBlocked
         // Read from the system rather than from our own store: the user can turn
         // this off in System Settings, and a remembered `true` would then be a lie.
         self.launchAtLogin = Self.isRegisteredForLogin

--- a/Sources/Settings/SettingsView.swift
+++ b/Sources/Settings/SettingsView.swift
@@ -87,6 +87,54 @@ struct SettingsView: View {
                     .fixedSize(horizontal: false, vertical: true)
             }
 
+            // Its own section rather than a line in General: this is the only
+            // part of the app that speaks first, and a switch that stops the
+            // Mac making a noise has to be findable by someone who is looking
+            // for exactly that and nothing else.
+            Section("When a session ends") {
+                Toggle("Open the notch for a moment", isOn: $preferences.announceSessionEnd)
+
+                Picker("For", selection: $preferences.peekDuration) {
+                    ForEach(PeekDuration.allCases) { Text($0.title).tag($0) }
+                }
+                .pickerStyle(.segmented)
+                .disabled(!preferences.announceSessionEnd)
+
+                Text(preferences.peekDuration.explanation)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                Toggle("Play a sound", isOn: $preferences.sessionEndSound)
+
+                // Two sounds, because the two events say different things: one
+                // is "that's done", the other is "you are the hold-up". Each
+                // has a preview beside it — picking an alert sound you cannot
+                // hear until the next time it fires is guesswork.
+                SoundRow(label: "Finished", name: $preferences.sessionEndSoundName,
+                         pickerEnabled: preferences.sessionEndSound)
+                SoundRow(label: "Waiting on you", name: $preferences.sessionBlockedSoundName,
+                         pickerEnabled: preferences.sessionEndSound)
+
+                Text("Codenotch already knows the moment an agent stops working "
+                     + "or stops to ask you something. Clicking the notch while "
+                     + "it is open brings that session's app to the front — the "
+                     + "app, not the tab: only some terminals let anything "
+                     + "outside them choose a tab, so the tooltip names the "
+                     + "session instead.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                Text("The sound plays on the ordinary output, not the interface "
+                     + "sound-effects channel — so it is still heard with "
+                     + "\u{201C}Play user interface sound effects\u{201D} "
+                     + "switched off in System Settings → Sound.")
+                    .font(.caption)
+                    .foregroundStyle(.tertiary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
             // Startup and updates together: both are about what Codenotch does
             // without being asked, and one switch under its own header looked
             // like an oversight rather than a section.
@@ -232,6 +280,38 @@ struct SettingsView: View {
 
 /// One provider: whether Codenotch reads it, whose account that is, and where
 /// to go if there is nothing to read.
+/// One sound choice, with a preview button.
+private struct SoundRow: View {
+    let label: String
+    @Binding var name: String
+    /// The preview stays live even with the sound switched off — it is how you
+    /// find out what you are switching on, and a dead button teaches nothing.
+    let pickerEnabled: Bool
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Picker(label, selection: $name) {
+                // A sound that has been removed since it was chosen still has
+                // to appear, or the picker would silently show a different one
+                // and the setting would look like it had changed itself.
+                if !SessionChime.available.contains(name) {
+                    Text("\(name) (missing)").tag(name)
+                }
+                ForEach(SessionChime.available, id: \.self) { Text($0).tag($0) }
+            }
+            .disabled(!pickerEnabled)
+            Button {
+                Log.usage.info("preview \(name, privacy: .public)")
+                SessionChime.play(name)
+            } label: {
+                Image(systemName: "play.circle")
+            }
+            .buttonStyle(.borderless)
+            .help("Play \(name)")
+        }
+    }
+}
+
 private struct AccountRow: View {
     let provider: ProviderSummary
     @ObservedObject var preferences: Preferences

--- a/Tests/SessionCompletionTests.swift
+++ b/Tests/SessionCompletionTests.swift
@@ -1,0 +1,247 @@
+import XCTest
+@testable import Codenotch
+
+final class SessionCompletionTests: XCTestCase {
+    private func session(
+        _ id: String, _ state: AgentSession.State, since: Date = Date(), pid: pid_t? = nil
+    ) -> AgentSession {
+        AgentSession(id: id, name: id, detail: "Terminal · \(id)",
+                     state: state, waitingFor: nil, since: since, processID: pid)
+    }
+
+    /// Everything already running at launch arrives with no history. Treating
+    /// that as a transition would chime once per open window on every start.
+    func testFirstReadingAnnouncesNothing() {
+        var watcher = SessionCompletionWatcher()
+        XCTAssertTrue(watcher.absorb(["claude": [session("a", .busy), session("b", .idle)]]).isEmpty)
+    }
+
+    func testBusyToIdleIsFinished() {
+        var watcher = SessionCompletionWatcher()
+        _ = watcher.absorb(["claude": [session("a", .busy)]])
+        let events = watcher.absorb(["claude": [session("a", .idle)]])
+        XCTAssertEqual(events.count, 1)
+        XCTAssertEqual(events.first?.reason, .finished)
+        XCTAssertEqual(events.first?.providerID, "claude")
+        XCTAssertEqual(events.first?.session.id, "a")
+    }
+
+    func testBusyToWaitingIsBlocked() {
+        var watcher = SessionCompletionWatcher()
+        _ = watcher.absorb(["claude": [session("a", .busy)]])
+        XCTAssertEqual(watcher.absorb(["claude": [session("a", .waiting)]]).first?.reason, .blocked)
+    }
+
+    /// A question that was answered is not a piece of work ending — the work
+    /// carries on, and announcing it would fire on every prompt.
+    func testWaitingToIdleIsSilent() {
+        var watcher = SessionCompletionWatcher()
+        _ = watcher.absorb(["claude": [session("a", .waiting)]])
+        XCTAssertTrue(watcher.absorb(["claude": [session("a", .idle)]]).isEmpty)
+    }
+
+    func testUnchangedStateIsSilent() {
+        var watcher = SessionCompletionWatcher()
+        _ = watcher.absorb(["claude": [session("a", .busy)]])
+        XCTAssertTrue(watcher.absorb(["claude": [session("a", .busy)]]).isEmpty)
+    }
+
+    /// Quitting Claude Code mid-turn removes the session file while it still
+    /// says `busy`. There is no window left to jump to, so there is nothing to
+    /// announce.
+    func testSessionThatVanishesIsSilent() {
+        var watcher = SessionCompletionWatcher()
+        _ = watcher.absorb(["claude": [session("a", .busy)]])
+        XCTAssertTrue(watcher.absorb(["claude": []]).isEmpty)
+    }
+
+    /// …and it is forgotten, so a later session that recycles the id is seeded
+    /// afresh rather than compared against a state from before it existed.
+    func testVanishedSessionIsForgotten() {
+        var watcher = SessionCompletionWatcher()
+        _ = watcher.absorb(["claude": [session("a", .busy)]])
+        _ = watcher.absorb(["claude": []])
+        XCTAssertTrue(watcher.absorb(["claude": [session("a", .idle)]]).isEmpty)
+    }
+
+    /// Two tools can hold the same session id without being the same session.
+    func testProvidersAreKeptApart() {
+        var watcher = SessionCompletionWatcher()
+        _ = watcher.absorb(["claude": [session("a", .busy)], "grok": [session("a", .idle)]])
+        let events = watcher.absorb(["claude": [session("a", .idle)], "grok": [session("a", .idle)]])
+        XCTAssertEqual(events.map(\.providerID), ["claude"])
+    }
+
+    /// One turn ending often unblocks another. The newest is offered, because
+    /// it is the window you were most recently in.
+    func testNewestEventComesFirst() {
+        let old = Date(timeIntervalSince1970: 1_000)
+        let new = Date(timeIntervalSince1970: 2_000)
+        var watcher = SessionCompletionWatcher()
+        _ = watcher.absorb(["claude": [session("a", .busy), session("b", .busy)]])
+        let events = watcher.absorb([
+            "claude": [session("a", .idle, since: old), session("b", .idle, since: new)]
+        ])
+        XCTAssertEqual(events.map(\.session.id), ["b", "a"])
+    }
+
+    /// The pid is what a click on the peek acts on, so it has to survive the
+    /// trip from the session file to the event.
+    func testProcessIDReachesTheEvent() {
+        var watcher = SessionCompletionWatcher()
+        _ = watcher.absorb(["claude": [session("a", .busy, pid: 4242)]])
+        let events = watcher.absorb(["claude": [session("a", .idle, pid: 4242)]])
+        XCTAssertEqual(events.first?.session.processID, 4242)
+    }
+
+    // MARK: - Focus
+
+    /// The walk starts with the process it was asked about — an agent's own
+    /// pid is a legitimate answer, since a GUI tool may be the app itself.
+    func testAncestryStartsWithTheProcessItself() {
+        XCTAssertEqual(SessionFocus.ancestry(of: getpid()).first, getpid())
+        XCTAssertNotNil(SessionFocus.parent(of: getpid()))
+    }
+
+    /// Adopted by launchd — which is what happens to a test host, and to any
+    /// agent whose terminal has already quit — the chain is the process alone.
+    /// launchd is never the app anybody meant.
+    func testAncestryExcludesLaunchd() {
+        XCTAssertFalse(SessionFocus.ancestry(of: getpid()).contains(1))
+    }
+
+    func testAncestryIsBounded() {
+        XCTAssertLessThanOrEqual(SessionFocus.ancestry(of: getpid(), limit: 3).count, 3)
+    }
+
+    /// launchd is nobody's child, and a pid that does not exist has no parent
+    /// to report — neither may be walked past.
+    func testAncestryStopsAtTheTop() {
+        XCTAssertEqual(SessionFocus.ancestry(of: 1), [])
+    }
+
+    /// Above the kernel's pid ceiling, so nothing can ever be there. A session
+    /// file outliving its process is the ordinary case this stands in for.
+    func testUnknownProcessHasNoParent() {
+        XCTAssertNil(SessionFocus.parent(of: 999_999))
+        XCTAssertEqual(SessionFocus.ancestry(of: 999_999), [999_999])
+        XCTAssertNil(SessionFocus.owningApp(of: 999_999))
+    }
+
+    /// A pid the session file left behind must not raise whatever window has
+    /// since been given that number — it simply finds nothing.
+    func testSessionFileRecordsThePID() {
+        let record = ClaudeSessionRecord(json: [
+            "pid": NSNumber(value: 4242),
+            "cwd": "/tmp/project",
+            "status": "busy"
+        ])
+        XCTAssertEqual(record?.session.processID, 4242)
+    }
+}
+
+/// The peek has to survive the pointer not being there.
+@MainActor
+final class PeekTests: XCTestCase {
+    private func pump(_ seconds: TimeInterval) {
+        RunLoop.current.run(until: Date().addingTimeInterval(seconds))
+    }
+
+    /// The regression this exists for: the cursor poll runs every 0.3s and
+    /// folds the notch 0.45s after finding the pointer somewhere else, which
+    /// during a peek it almost always is. The notch opened and shut inside a
+    /// second — the announcement was there, and nobody could have seen it.
+    ///
+    /// Only asserts that it is *still open* well past that window. Whether it
+    /// closes afterwards depends on where the mouse happens to be on the
+    /// machine running this, which is not something a test may assume.
+    func testAPeekOutlastsTheHoverFold() {
+        let controller = NotchWindowController()
+        controller.show()
+        defer { controller.stop() }
+
+        controller.peek(for: 2, focusing: nil)
+        XCTAssertTrue(controller.model.isExpanded)
+        pump(1.2)
+        XCTAssertTrue(controller.model.isExpanded,
+                      "the pointer being elsewhere must not end a peek early")
+    }
+
+    /// Hidden is a standing choice. Something finishing does not overrule it.
+    func testAPeekDoesNotOverrideHidden() {
+        let controller = NotchWindowController()
+        controller.show()
+        defer { controller.stop() }
+
+        controller.apply(.hidden)
+        controller.peek(for: 2, focusing: nil)
+        XCTAssertFalse(controller.model.isExpanded)
+    }
+}
+
+/// The peek's length is a setting, so the setting has to survive a round trip.
+final class PeekDurationTests: XCTestCase {
+    func testEveryDurationIsAUsefulLength() {
+        for duration in PeekDuration.allCases {
+            XCTAssertGreaterThanOrEqual(duration.seconds, 1)
+            XCTAssertLessThanOrEqual(duration.seconds, 30)
+        }
+    }
+
+    /// The raw values are written to UserDefaults, so renaming a case would
+    /// silently reset everybody's choice to the default.
+    func testRawValuesAreStable() {
+        XCTAssertEqual(PeekDuration.allCases.map(\.rawValue), ["brief", "standard", "long"])
+        XCTAssertEqual(PeekDuration(rawValue: "standard")?.seconds, 5)
+    }
+
+    /// An unrecognised stored value — a downgrade, a hand-edited domain — has
+    /// to land on the default rather than on nothing.
+    func testAnUnknownStoredValueFallsBack() {
+        XCTAssertNil(PeekDuration(rawValue: "forever"))
+    }
+}
+
+/// The chime resolves files itself, so that resolution is worth checking.
+final class SessionChimeTests: XCTestCase {
+    func testTheDefaultSoundsExist() {
+        XCTAssertNotNil(SessionChime.url(for: SessionChime.defaultFinished))
+        XCTAssertNotNil(SessionChime.url(for: SessionChime.defaultBlocked))
+    }
+
+    func testTheSystemSoundsAreOffered() {
+        let available = SessionChime.available
+        XCTAssertTrue(available.contains("Glass"))
+        XCTAssertTrue(available.contains("Funk"))
+        XCTAssertEqual(available, available.sorted {
+            $0.localizedCaseInsensitiveCompare($1) == .orderedAscending
+        })
+    }
+
+    /// The picker shows the stored name whether or not it resolves, so a sound
+    /// that has gone missing must not silently become a different one.
+    func testAnUnknownSoundResolvesToNothing() {
+        XCTAssertNil(SessionChime.url(for: "NotASound"))
+        XCTAssertFalse(SessionChime.available.contains("NotASound"))
+    }
+
+    /// The regression this exists for: `play()` was written inside the log
+    /// interpolation that reports its result. `Logger`'s interpolations are
+    /// autoclosures, evaluated only when the level is enabled — so on an
+    /// ordinary run, with debug logging off, the call never happened. Nothing
+    /// logged, nothing played, and every line of it looked right.
+    ///
+    /// Asserting on the return value is what keeps the call on its own line.
+    func testPlayingActuallyStarts() {
+        XCTAssertTrue(SessionChime.play(SessionChime.defaultFinished))
+        XCTAssertFalse(SessionChime.play("NotASound"))
+    }
+
+    /// Names are extension-free: the picker shows them and the preference
+    /// stores them, so a stored name has to be one the resolver accepts back.
+    func testEveryOfferedSoundResolves() {
+        for name in SessionChime.available {
+            XCTAssertNotNil(SessionChime.url(for: name), "\(name) is offered but does not resolve")
+        }
+    }
+}


### PR DESCRIPTION
The monitors already know the moment an agent stops working — the notch just never said so, which leaves it as something to watch rather than something that tells you. This closes that gap: a busy session going idle, or going to waiting, opens the notch for a few seconds and plays a sound, and a click while it is open raises the application that session is running in.

### What it does not announce

- **Waiting → idle.** A question that was answered is not a piece of work ending; announcing it would fire on every prompt.
- **A session whose file disappears mid-turn** — what quitting Claude Code looks like. There is no window left to jump to.
- **The first reading.** Every session already running at launch arrives with no history, and treating that as a transition would ring once per open window on every start, including a restart in the night after an update.

`SessionCompletionWatcher` holds all of that, free of AppKit so the edge cases are driven directly from tests. `AgentSession` gains an optional pid — Claude Code and Grok publish one, the other three monitors do not, and a nil there costs only the ability to jump.

### The jump raises the app, not the tab

A session publishes a pid and nothing else — no window, no tty — so `SessionFocus` walks the process tree from the agent to whatever launched it. Selecting the *tab* inside that app needs the terminal's own scripting interface and there is no general one: Terminal.app and iTerm2 can match a tab by tty, Warp and Ghostty publish no scripting dictionary at all. Raising the app for everybody, with the tooltip naming the session, beat working in two terminals and silently doing nothing in a third.

### Two things that are not obvious from the diff

**A peek is not the pointer arriving, so the pointer leaving must not end it.** `cursorMoved` runs every 0.3s and folds the notch 0.45s after finding the pointer elsewhere, which during a peek it almost always is. Without a deadline the fold logic respects, the notch opened and shut inside a second and the announcement could not be seen. `PeekTests.testAPeekOutlastsTheHoverFold` covers it — I checked it fails with the guard removed.

**The chime plays the file through `AVAudioPlayer` rather than handing a name to `NSSound`.** `NSSound(named:)` resolves a system alert, and system alerts route through the interface sound-effects channel — the one System Settings → Sound switches off with \"Play user interface sound effects\", which is also what makes the Mac click and swoosh all day, so plenty of people have it off. On my machine it is off (`com.apple.sound.uiaudio.enabled = 0`), and I would rather an announcement not depend on a setting that is about something else entirely. Reading the file into an `AVAudioPlayer` puts it on the ordinary output path, where the only thing that silences it is the volume control. `NSSound` stays as the fallback for a file AVFoundation will not open.

To be straight about it: I first reached for this after a silence that turned out to be my own bug — `play()` written inside the `Logger` interpolation reporting its result, which on an ordinary run is never evaluated. That is fixed and tested here (`testPlayingActuallyStarts`), and I have **not** since verified that `NSSound` alone would be inaudible with the sound-effects channel off. The reason above is the mechanism and the setting, not a measurement. Happy to go back to `NSSound` if you would rather keep the dependency small.

### Settings

Its own section rather than a line in General — this is the only part of the app that speaks first, and a switch that stops the Mac making a noise has to be findable by someone looking for exactly that.

The peek and the sound switch off separately because they fail differently: the peek is no use behind a full-screen window, the sound is no use in a meeting. Each of the two events picks its own sound with a preview button beside it, since choosing an alert you cannot hear until the next time it fires is guesswork. The peek's length is a choice of three — below a second or two it is gone before a glance lands, much beyond ten it stops reading as an announcement.

### Checks

- `make test` passes: 578 tests, 0 failures.
- 25 new tests across `SessionCompletionWatcher`, `SessionFocus`, `PeekDuration` and the chime, in `Tests/SessionCompletionTests.swift`. Two of them are regression tests for bugs found while building this, and I checked both fail with their fix removed: the peek being folded away by the cursor poll, and `play()` being swallowed by a `Logger` autoclosure.
- No layout constants touched, so nothing to re-check against the design frame.

Verified against real sessions as well as fixtures — the unified log shows the transition, the chime and the peek's full length:

```
session codenotch-selftest finished
chime Glass: true
peek for 5.000000s, pid 91202
peek folded          ← 5.02s later
```

Note: `make build` currently fails on a machine without a Developer ID certificate, for a reason unrelated to this change — the ad-hoc fallback in the Makefile never fires. That is #24's to fix; this PR was built and tested with the override applied by hand.