### PR TITLE
Fix the ad-hoc signing fallback, which never fired

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,11 @@ DEST    := platform=macOS,arch=arm64
 # changes nothing: project.yml's stable identity is what keeps a keychain
 # "Always Allow" grant alive across rebuilds, and forcing ad-hoc there would
 # throw that away and bring the prompt back on every `make run`.
-ifeq (,$(shell security find-identity -v -p codesigning 2>/dev/null | grep -c "Developer ID Application"))
+# `grep -c` prints "0" and exits 1 when it matches nothing, so the emptiness
+# test was never true: on a machine without the certificate DEV_SIGN stayed
+# empty and the build tried to sign with an identity that is not there.
+# Compare against the count itself.
+ifeq (0,$(shell security find-identity -v -p codesigning 2>/dev/null | grep -c "Developer ID Application"))
 DEV_SIGN := CODE_SIGN_IDENTITY="-" DEVELOPMENT_TEAM="" CODE_SIGN_STYLE=Automatic
 endif
 


### PR DESCRIPTION
CONTRIBUTING says `make build` needs no Apple Developer account, and the comment above the test in the Makefile says the same: with no Developer ID certificate in the keychain, `DEV_SIGN` should force ad-hoc signing so a contributor can build. It never did.

The test asks whether `grep -c` produced empty output:

```make
ifeq (,$(shell security find-identity -v -p codesigning 2>/dev/null | grep -c "Developer ID Application"))
```

`grep -c` prints a count, and the count on no match is the string `"0"` — never empty. So the `ifeq` was false on exactly the machines it exists for, `DEV_SIGN` stayed empty, and the build used `project.yml`'s identity:

```
error: No signing certificate "Developer ID Application" found
```

Comparing against the count instead fixes it. On the maintainer's machine, where the count is `1`, nothing changes.

Verified both ways on a Mac with no Developer ID certificate: `make build` fails on `main` and succeeds on this branch.