### PR TITLE
Fix: allow dotted AM/PM markers in ResetCopyTests on non-English locales

### DIFF
--- a/Sources/Model/ResetCopy.swift
+++ b/Sources/Model/ResetCopy.swift
@@ -47,7 +47,7 @@ enum ResetCopy {
         let formatter = DateFormatter()
         formatter.calendar = calendar
         formatter.timeZone = calendar.timeZone
-        formatter.locale = .current
+        formatter.locale = calendar.locale ?? .current
         return formatter
     }
 

--- a/Tests/ResetCopyTests.swift
+++ b/Tests/ResetCopyTests.swift
@@ -42,7 +42,19 @@ final class ResetCopyTests: XCTestCase {
     func testAbsoluteTimeUsesAColon() {
         let text = ResetCopy.text(for: now.addingTimeInterval(6 * 60 * 60), now: now)
         XCTAssertTrue(text.contains(":"), "expected a colon in \(text)")
-        XCTAssertFalse(text.contains("."), "expected no full stop in \(text)")
+        let hasPeriodBetweenDigits = text.range(of: #"\d+\.\d+"#, options: .regularExpression) != nil
+        XCTAssertFalse(hasPeriodBetweenDigits, "expected no full stop between time digits in \(text)")
+    }
+
+    /// Spanish (and similar locales) format AM/PM as "a. m." / "p. m." with
+    /// periods, but the time separator itself must still be a colon.
+    func testSpanishLocaleKeepsColonTimeSeparator() {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.locale = Locale(identifier: "es_ES")
+        let text = ResetCopy.text(for: now.addingTimeInterval(6 * 60 * 60), now: now, calendar: calendar)
+        XCTAssertTrue(text.contains(":"), "expected a colon in \(text)")
+        let hasPeriodBetweenDigits = text.range(of: #"\d+\.\d+"#, options: .regularExpression) != nil
+        XCTAssertFalse(hasPeriodBetweenDigits, "expected no full stop between time digits in \(text)")
     }
 
     func testPastResetsReadAsResetting() {


### PR DESCRIPTION
## Problem

`ResetCopyTests.testAbsoluteTimeUsesAColon` asserted `!text.contains(".")`. The test was written to verify that the time separator is a colon (`h:mm`) rather than a period (`h.mm`), which occurs in some European templates.

However, on Spanish (and several other non-English) locales, AM/PM markers format with periods as `"a. m."` / `"p. m."`. As a result, running `make test` on a Spanish-locale Mac failed `testAbsoluteTimeUsesAColon` even though the time separator was correctly formatted as a colon. (This pre-existing test failure was also noted in #20).

Additionally, `ResetCopy.formatter(for:)` unconditionally hardcoded `formatter.locale = .current`, ignoring any custom `calendar.locale` that callers or test suites injected.

## Changes

1. **`Sources/Model/ResetCopy.swift`**:
   - `ResetCopy.formatter(for:)` now respects `calendar.locale ?? .current`.
2. **`Tests/ResetCopyTests.swift`**:
   - Updated `testAbsoluteTimeUsesAColon` to check that no period occurs between digits (`#"\d+\.\d+"#`), keeping the colon time-separator check while permitting dotted AM/PM markers.
   - Added `testSpanishLocaleKeepsColonTimeSeparator` to explicitly pin and verify this behavior under `es_ES`.

## Verification

- `make test` passes with 0 failures (553 passed tests).