### PR TITLE
Show a notch on every display or just the main one

### DIFF
--- a/Sources/App/AppDelegate.swift
+++ b/Sources/App/AppDelegate.swift
@@ -3,7 +3,7 @@ import Combine
 import SwiftUI
 
 final class AppDelegate: NSObject, NSApplicationDelegate {
-    private var notchController: NotchWindowController?
+    private var notchFleet: NotchFleet?
     private var store: UsageStore?
     private var monitors: [String: any AgentActivityMonitor] = [:]
     private var preferences: Preferences?
@@ -38,26 +38,33 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         NSApp.setActivationPolicy(.regular)
         guard !isRunningTests else { return }
 
-        let controller = NotchWindowController()
+        // Before Preferences reads anything, or the first launch flag and
+        // every choice would be read from an empty domain.
+        Preferences.migrateFromPreviousName()
+        let preferences = Preferences()
+        self.preferences = preferences
+
+        // One notch per display: the fleet owns a controller for each screen
+        // the scope asks for and fans every reading out to all of them. The
+        // stored edge goes in up front, before any panel is ever put up — the
+        // sink below delivers on the next run loop turn, by which time the
+        // notch would already have flashed on the default edge.
+        let fleet = NotchFleet(scope: preferences.notchScope, edge: preferences.notchEdge)
+        self.notchFleet = fleet
 
         // `CODENOTCH_DEMO=1` puts the design frame's three providers on screen
         // with its numbers, for screenshots and for eyeballing the layout.
         if ProcessInfo.processInfo.environment["CODENOTCH_DEMO"] == "1" {
-            controller.model.snapshots = Fixtures.snapshots()
+            fleet.setSnapshots(Fixtures.snapshots())
         } else {
             // Nothing needs a browser session at the moment. `WebSessionProvider`
             // and `Sites.perplexity` are kept: they are the working pattern for a
             // site behind bot management, and re-registering is one line.
             let webProviders: [WebSessionProvider] = []
-            controller.signInItems = webProviders.map { provider in
+            fleet.signInItems = webProviders.map { provider in
                 (title: "Sign in to \(provider.displayName)…",
                  action: { [weak provider] in provider?.presentSignIn() })
             }
-            // Before Preferences reads anything, or the first launch flag and
-            // every choice would be read from an empty domain.
-            Preferences.migrateFromPreviousName()
-            let preferences = Preferences()
-            self.preferences = preferences
 
             // Cursor reads the editor's own session rather than a browser one:
             // signing into cursor.com separately created a second, empty account.
@@ -74,13 +81,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                     + webProviders,
                 disconnected: preferences.disconnectedProviders
             )
-
-            // The stored edge goes in before the panel is ever put up. The
-            // sink below delivers on the next run loop turn, by which time the
-            // notch has already been shown on the default edge — so without
-            // this, every launch on any other edge opens with a flash of the
-            // right-hand one and then crossfades away from it.
-            controller.model.edge = preferences.notchEdge
 
             let updater = Updater()
             self.updater = updater
@@ -99,7 +99,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 },
                 retry: { [weak store] in store?.reauthorize(providerID: $0) }
             )
-            controller.onOpenSettings = { [weak settings] in settings?.show() }
+            fleet.onOpenSettings = { [weak settings] in settings?.show() }
             self.settings = settings
 
             // What changed, once per version — including on a fresh install,
@@ -138,12 +138,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
             preferences.$notchVisibility
                 .receive(on: RunLoop.main)
-                .sink { [weak controller] in controller?.apply($0) }
+                .sink { [weak fleet] in fleet?.apply($0) }
                 .store(in: &cancellables)
 
             preferences.$notchEdge
                 .receive(on: RunLoop.main)
-                .sink { [weak controller] in controller?.apply(edge: $0) }
+                .sink { [weak fleet] in fleet?.apply(edge: $0) }
+                .store(in: &cancellables)
+
+            preferences.$notchScope
+                .receive(on: RunLoop.main)
+                .sink { [weak fleet] in fleet?.apply(scope: $0) }
                 .store(in: &cancellables)
 
             preferences.$disconnectedProviders
@@ -153,19 +158,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
             store.$snapshots
                 .receive(on: RunLoop.main)
-                .sink { [weak controller] snapshots in
-                    withAnimation(NotchMotion.unfold) {
-                        controller?.model.snapshots = snapshots
-                    }
-                    controller?.model.now = Date()
+                .sink { [weak fleet] snapshots in
+                    fleet?.setSnapshots(snapshots)
                 }
                 .store(in: &cancellables)
             store.start()
-            controller.onRefresh = { [weak store] in store?.refreshNow() }
-            controller.onRefreshProvider = { [weak store] id in store?.refresh(providerID: id) }
+            fleet.onRefresh = { [weak store] in store?.refreshNow() }
+            fleet.onRefreshProvider = { [weak store] id in store?.refresh(providerID: id) }
             store.$refreshing
                 .receive(on: RunLoop.main)
-                .sink { [weak controller] ids in controller?.model.refreshing = ids }
+                .sink { [weak fleet] ids in fleet?.setRefreshing(ids) }
                 .store(in: &cancellables)
 
             // CODENOTCH_DISCOVER=<url> loads that page in the signed-in WebView
@@ -197,11 +199,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         for (id, monitor) in monitors {
             monitor.sessionsPublisher
                 .receive(on: RunLoop.main)
-                .sink { [weak controller] live in
-                    withAnimation(.spring(response: 0.3, dampingFraction: 0.85)) {
-                        controller?.model.sessions[id] = live
-                    }
-                    controller?.model.now = Date()
+                .sink { [weak fleet] live in
+                    fleet?.setSessions(providerID: id, sessions: live)
                 }
                 .store(in: &cancellables)
             monitor.start()
@@ -210,8 +209,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         store?.isBusy = { monitors.values.contains { m in m.sessions.contains { $0.state == .busy } } }
         self.monitors = monitors
 
-        controller.show()
-        notchController = controller
+        fleet.show()
     }
 
     /// Closing the settings window must not take the app with it.
@@ -238,6 +236,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     func applicationWillTerminate(_ notification: Notification) {
         store?.stop()
         monitors.values.forEach { $0.stop() }
-        notchController?.stop()
+        notchFleet?.stop()
     }
 }

--- a/Sources/Notch/NotchFleet.swift
+++ b/Sources/Notch/NotchFleet.swift
@@ -1,0 +1,209 @@
+import AppKit
+import Combine
+import SwiftUI
+
+/// One notch per display: owns a `NotchWindowController` for each screen the
+/// scope asks for and fans every reading, session and setting out to all of
+/// them.
+///
+/// Each controller keeps its own model — hover, open state and screen size are
+/// per-display facts, and sharing one model would unfold every notch when the
+/// pointer reaches any of them. The fleet is the only thing that is shared: it
+/// remembers the latest of everything so a controller created later (a display
+/// plugged in at noon) starts with today's readings rather than empty rings.
+@MainActor
+final class NotchFleet {
+    private var controllers: [NSNumber: NotchWindowController] = [:]
+    private var cancellables = Set<AnyCancellable>()
+
+    private(set) var scope: NotchScreenScope
+    private var edge: NotchEdge
+    private var visibility: NotchVisibility = .onHover
+    private var snapshots: [ProviderSnapshot] = []
+    private var refreshing: Set<String> = []
+    private var sessions: [String: [AgentSession]] = [:]
+
+    /// Hooked up by the app delegate; driven by the notch's own chrome.
+    var onRefresh: (() -> Void)?
+    var onRefreshProvider: ((String) -> Void)?
+    var onOpenSettings: (() -> Void)?
+    var signInItems: [(title: String, action: () -> Void)] = []
+
+    /// What the fleet settled on, for tests that need to see panels come and
+    /// go rather than take our word for it.
+    var controllersForTesting: [NotchWindowController] { Array(controllers.values) }
+
+    init(scope: NotchScreenScope, edge: NotchEdge) {
+        self.scope = scope
+        self.edge = edge
+    }
+
+    func show() {
+        reconcile(screens: NSScreen.screens)
+        NotificationCenter.default.publisher(
+            for: NSApplication.didChangeScreenParametersNotification
+        )
+        .sink { [weak self] _ in
+            MainActor.assumeIsolated {
+                self?.reconcile(screens: NSScreen.screens)
+            }
+        }
+        .store(in: &cancellables)
+    }
+
+    func stop() {
+        cancellables.removeAll()
+        for id in controllers.keys {
+            controllers[id]?.retire()
+        }
+        controllers.removeAll()
+    }
+
+    // MARK: - Settings
+
+    func apply(scope: NotchScreenScope) {
+        self.scope = scope
+        reconcile(screens: NSScreen.screens)
+    }
+
+    func apply(edge: NotchEdge) {
+        self.edge = edge
+        for controller in controllers.values {
+            controller.apply(edge: edge)
+        }
+    }
+
+    func apply(_ visibility: NotchVisibility) {
+        self.visibility = visibility
+        for controller in controllers.values {
+            controller.apply(visibility)
+        }
+    }
+
+    // MARK: - Readings
+
+    func setSnapshots(_ snapshots: [ProviderSnapshot]) {
+        self.snapshots = snapshots
+        let now = Date()
+        for controller in controllers.values {
+            withAnimation(NotchMotion.unfold) {
+                controller.model.snapshots = snapshots
+            }
+            controller.model.now = now
+        }
+    }
+
+    func setRefreshing(_ ids: Set<String>) {
+        self.refreshing = ids
+        for controller in controllers.values {
+            controller.model.refreshing = ids
+        }
+    }
+
+    func setSessions(providerID id: String, sessions live: [AgentSession]) {
+        sessions[id] = live
+        let now = Date()
+        for controller in controllers.values {
+            withAnimation(.spring(response: 0.3, dampingFraction: 0.85)) {
+                controller.model.sessions[id] = live
+            }
+            controller.model.now = now
+        }
+    }
+
+    // MARK: - Reconciliation
+
+    /// Which notch a screen is, stable across polls while it stays connected.
+    ///
+    /// Every real display reports an `NSScreenNumber`; the fallback derives one
+    /// from the origin so a screen without a number still gets a notch rather
+    /// than none — at worst it is re-created when it moves.
+    ///
+    /// Nonisolated: pure computation on its argument, safe to call from anywhere.
+    nonisolated static func key(for screen: NSScreen) -> NSNumber {
+        if let number = screen.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? NSNumber {
+            return number
+        }
+        let origin = screen.frame.origin
+        return NSNumber(value: Int(origin.x) * 31 + Int(origin.y))
+    }
+
+    /// Pure, so the add/remove maths can be tested without any displays: which
+    /// keys to retire and which to create, in a stable order.
+    ///
+    /// Nonisolated: pure computation on its arguments, safe to call from anywhere.
+    nonisolated static func planReconciliation(
+        current: Set<NSNumber>, desired: [NSNumber]
+    ) -> (remove: [NSNumber], add: [NSNumber]) {
+        let want = Set(desired)
+        let remove = current.subtracting(want).sorted { $0.intValue < $1.intValue }
+        var seen = Set<NSNumber>()
+        let add = desired.filter { want.contains($0) && !current.contains($0) && seen.insert($0).inserted }
+        return (remove, add)
+    }
+
+    /// Exposed so a test can drive the fleet against the real screen list.
+    func reconcileForTesting() {
+        reconcile(screens: NSScreen.screens)
+    }
+
+    private func reconcile(screens: [NSScreen]) {
+        let desired: [NSScreen]
+        switch scope {
+        case .mainDisplay:
+            desired = NotchGeometry.preferredScreen(from: screens).map { [$0] } ?? []
+        case .allDisplays:
+            desired = screens
+        }
+        let keys = desired.map(Self.key)
+        // Screen numbers are unique per display; if they ever are not, fall
+        // back to a single notch rather than keying two panels as one.
+        guard Set(keys).count == keys.count else {
+            for id in controllers.keys {
+                controllers[id]?.retire()
+            }
+            controllers.removeAll()
+            if let main = NotchGeometry.preferredScreen(from: screens) {
+                controllers[Self.key(for: main)] = makeController(on: main)
+            }
+            return
+        }
+        // The common case — one notch following the menu-bar screen — keeps
+        // its controller and moves it, the way a single panel always did,
+        // instead of tearing a panel down and building another.
+        if scope == .mainDisplay, controllers.count == 1,
+           let screen = desired.first, let controller = controllers.values.first {
+            controller.assignedScreen = screen
+            controller.relocate()
+            return
+        }
+        let plan = Self.planReconciliation(current: Set(controllers.keys), desired: keys)
+        for id in plan.remove {
+            controllers[id]?.retire()
+            controllers[id] = nil
+        }
+        for (screen, id) in zip(desired, keys) where plan.add.contains(id) {
+            controllers[id] = makeController(on: screen)
+        }
+    }
+
+    /// A controller that starts where every other one already is: same edge,
+    /// same readings, same open state — a display plugged in at noon must not
+    /// open on empty rings.
+    private func makeController(on screen: NSScreen) -> NotchWindowController {
+        let controller = NotchWindowController()
+        controller.assignedScreen = screen
+        controller.model.edge = edge
+        controller.onRefresh = onRefresh
+        controller.onRefreshProvider = onRefreshProvider
+        controller.onOpenSettings = onOpenSettings
+        controller.signInItems = signInItems
+        controller.model.snapshots = snapshots
+        controller.model.refreshing = refreshing
+        controller.model.sessions = sessions
+        controller.model.now = Date()
+        controller.apply(visibility)
+        controller.show()
+        return controller
+    }
+}

--- a/Sources/Notch/NotchWindowController.swift
+++ b/Sources/Notch/NotchWindowController.swift
@@ -26,6 +26,11 @@ final class NotchWindowController {
 
     private var panel: NotchPanel?
     private var hostingView: NotchHostingView<NotchRootView>?
+
+    /// The display this notch belongs to. Nil follows the menu-bar screen,
+    /// which is what a single-controller setup did before the fleet existed —
+    /// so leaving it unset changes nothing.
+    var assignedScreen: NSScreen?
     private var cancellables = Set<AnyCancellable>()
     private var mouseMonitors: [Any] = []
     private var clearHoverWork: DispatchWorkItem?
@@ -96,8 +101,19 @@ final class NotchWindowController {
 
     // MARK: - Placement
 
+    /// The screen this notch lives on: its assigned display while that display
+    /// is still connected, the menu-bar screen otherwise — so unplugging the
+    /// display never strands the panel on a screen that no longer exists.
+    func currentScreen() -> NSScreen? {
+        if let assigned = assignedScreen,
+           NSScreen.screens.contains(where: { $0 === assigned }) {
+            return assigned
+        }
+        return NotchGeometry.preferredScreen(from: NSScreen.screens)
+    }
+
     func relocate(cellCount: Int? = nil) {
-        guard let screen = NotchGeometry.preferredScreen(from: NSScreen.screens) else { return }
+        guard let screen = currentScreen() else { return }
         model.adopt(screen: screen)
         let size = model.panelSize(cellCount: cellCount ?? model.snapshots.count)
         let frame = NotchGeometry.panelFrame(for: screen, panelSize: size, edge: model.edge)
@@ -288,7 +304,7 @@ final class NotchWindowController {
     /// Has the Dock appeared, gone away, moved or resized since we last placed
     /// the panel? Nothing notifies us, so this is asked rather than told.
     private func followUsableAreaIfItMoved() {
-        guard let screen = NotchGeometry.preferredScreen(from: NSScreen.screens) else { return }
+        guard let screen = currentScreen() else { return }
         guard screen.visibleFrame != lastVisibleFrame else { return }
         relocate()
     }
@@ -521,6 +537,15 @@ final class NotchWindowController {
         }
         setPointing(false)
         updateInteractiveRects()
+    }
+
+    /// Tear down a controller whose display is gone: hide first so no panel
+    /// lingers on a screen that no longer exists, then stop its timers and
+    /// monitors — a retired controller that kept polling would relocate
+    /// another display's panel underneath a parked pointer.
+    func retire() {
+        apply(.hidden)
+        stop()
     }
 
     /// Clicking the open notch pins it, so it stays put while you read it.

--- a/Sources/Settings/NotchScreenScope.swift
+++ b/Sources/Settings/NotchScreenScope.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+/// Which displays get a notch when more than one is connected.
+///
+/// One notch per display rather than one stretched across them: each panel is
+/// welded to its own screen edge, and hovering one opens only that one — a
+/// shared open state would unfold the notch on every screen at once, including
+/// the one you are not looking at.
+enum NotchScreenScope: String, CaseIterable, Identifiable {
+    /// Only the display with the menu bar. What a single-panel setup always did.
+    case mainDisplay
+    /// Every connected display gets its own notch.
+    case allDisplays
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .mainDisplay: return "Main display"
+        case .allDisplays: return "All displays"
+        }
+    }
+
+    var explanation: String {
+        switch self {
+        case .mainDisplay:
+            return "The notch appears only on the display with the menu bar."
+        case .allDisplays:
+            return "Each display gets its own notch, and hovering one opens only that one."
+        }
+    }
+}

--- a/Sources/Settings/Preferences.swift
+++ b/Sources/Settings/Preferences.swift
@@ -26,6 +26,11 @@ final class Preferences: ObservableObject {
         didSet { defaults.set(notchEdge.rawValue, forKey: Keys.edge) }
     }
 
+    /// Which displays get a notch when more than one is connected.
+    @Published var notchScope: NotchScreenScope {
+        didSet { defaults.set(notchScope.rawValue, forKey: Keys.scope) }
+    }
+
     /// Where the app itself shows up: Dock, menu bar, or nowhere.
     @Published var appPresence: AppPresence {
         didSet { defaults.set(appPresence.rawValue, forKey: Keys.presence) }
@@ -59,6 +64,7 @@ final class Preferences: ObservableObject {
         static let visibility = "notchVisibility"
         static let presence = "appPresence"
         static let edge = "notchEdge"
+        static let scope = "notchScope"
         static let lastSeenVersion = "lastSeenVersion"
     }
 
@@ -113,6 +119,11 @@ final class Preferences: ObservableObject {
         // side of a Mac that no system chrome claims by default.
         self.notchEdge = defaults.string(forKey: Keys.edge)
             .flatMap(NotchEdge.init(rawValue:)) ?? .right
+        // Absent means never chosen. Main display only, because that is what a
+        // single-panel setup always did — all-displays on a fresh install
+        // would put notches where none were expected.
+        self.notchScope = defaults.string(forKey: Keys.scope)
+            .flatMap(NotchScreenScope.init(rawValue:)) ?? .mainDisplay
         // Absent means nothing has been shown yet, which is true of a fresh
         // install — so the current release reads as new to it.
         self.lastSeenVersion = defaults.string(forKey: Keys.lastSeenVersion)

--- a/Sources/Settings/SettingsView.swift
+++ b/Sources/Settings/SettingsView.swift
@@ -74,6 +74,16 @@ struct SettingsView: View {
                     .foregroundStyle(.secondary)
                     .fixedSize(horizontal: false, vertical: true)
 
+                Picker("Displays", selection: $preferences.notchScope) {
+                    ForEach(NotchScreenScope.allCases) { Text($0.title).tag($0) }
+                }
+                .pickerStyle(.segmented)
+
+                Text(preferences.notchScope.explanation)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+
                 // "App icon", not "Icon": the two rows above it are about the
                 // notch, and on its own the word would read as another of them.
                 Picker("App icon", selection: $preferences.appPresence) {

--- a/Tests/NotchLayoutTests.swift
+++ b/Tests/NotchLayoutTests.swift
@@ -1,3 +1,4 @@
+import AppKit
 import XCTest
 @testable import Codenotch
 
@@ -627,6 +628,125 @@ final class NotchVisibilityTests: XCTestCase {
         for mode in NotchVisibility.allCases {
             XCTAssertFalse(mode.title.isEmpty)
             XCTAssertFalse(mode.explanation.isEmpty)
+        }
+    }
+}
+
+/// Which displays get a notch. Its default matters: get it wrong and a fresh
+/// install with two displays either shows a notch where none was expected or
+/// hides the one that was always there.
+final class NotchScreenScopeTests: XCTestCase {
+    private func defaults() -> UserDefaults {
+        let name = "NotchScreenScopeTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: name)!
+        defaults.removePersistentDomain(forName: name)
+        return defaults
+    }
+
+    @MainActor
+    func testItDefaultsToMainDisplayOnly() {
+        XCTAssertEqual(Preferences(defaults: defaults()).notchScope, .mainDisplay)
+    }
+
+    @MainActor
+    func testTheChoiceSurvivesARestart() {
+        let defaults = defaults()
+        Preferences(defaults: defaults).notchScope = .allDisplays
+        XCTAssertEqual(Preferences(defaults: defaults).notchScope, .allDisplays)
+    }
+
+    /// A value written by a future version must not leave every display bare —
+    /// it falls back to the main one.
+    @MainActor
+    func testAnUnknownStoredValueFallsBackToMainDisplay() {
+        let defaults = defaults()
+        defaults.set("projector", forKey: "notchScope")
+        XCTAssertEqual(Preferences(defaults: defaults).notchScope, .mainDisplay)
+    }
+
+    func testEveryScopeIsOfferedAndNamed() {
+        XCTAssertEqual(NotchScreenScope.allCases.count, 2)
+        for scope in NotchScreenScope.allCases {
+            XCTAssertFalse(scope.title.isEmpty)
+            XCTAssertFalse(scope.explanation.isEmpty)
+        }
+    }
+}
+
+/// The fleet's add/remove maths, without any displays: which controllers to
+/// retire and which to create when the screen list changes.
+final class NotchFleetReconcileTests: XCTestCase {
+    private func key(_ n: Int) -> NSNumber { NSNumber(value: n) }
+
+    func testAnEmptyFleetAddsEveryDesiredScreen() {
+        let plan = NotchFleet.planReconciliation(current: [], desired: [key(1), key(2)])
+        XCTAssertTrue(plan.remove.isEmpty)
+        XCTAssertEqual(plan.add, [key(1), key(2)])
+    }
+
+    func testAnUnchangedListPlansNothing() {
+        let plan = NotchFleet.planReconciliation(
+            current: [key(1), key(2)], desired: [key(2), key(1)])
+        XCTAssertTrue(plan.remove.isEmpty)
+        XCTAssertTrue(plan.add.isEmpty)
+    }
+
+    func testAGoneScreenIsRetiredAndANewOneAdded() {
+        let plan = NotchFleet.planReconciliation(
+            current: [key(1), key(2)], desired: [key(2), key(3)])
+        XCTAssertEqual(plan.remove, [key(1)])
+        XCTAssertEqual(plan.add, [key(3)])
+    }
+
+    func testDisconnectingEverythingRetiresEverything() {
+        let plan = NotchFleet.planReconciliation(current: [key(1)], desired: [])
+        XCTAssertEqual(plan.remove, [key(1)])
+        XCTAssertTrue(plan.add.isEmpty)
+    }
+
+    /// Screen keys identify notches one-to-one, so real displays must never
+    /// share one — otherwise two panels would be keyed as a single controller.
+    func testRealScreensHaveDistinctKeys() {
+        let screens = NSScreen.screens
+        guard !screens.isEmpty else { return }
+        let keys = screens.map(NotchFleet.key)
+        XCTAssertEqual(Set(keys).count, keys.count)
+    }
+}
+
+/// The fleet against the real screen list: main-only keeps a single notch,
+/// all-displays one per screen. On a one-display Mac both are one — the point
+/// is the count follows the scope, not a fixed number.
+@MainActor
+final class NotchFleetScopeTests: XCTestCase {
+    func testMainDisplayKeepsASingleNotch() {
+        let fleet = NotchFleet(scope: .mainDisplay, edge: .right)
+        fleet.show()
+        defer { fleet.stop() }
+        XCTAssertEqual(fleet.controllersForTesting.count, min(1, NSScreen.screens.count))
+    }
+
+    func testAllDisplaysKeepsOneNotchPerScreen() {
+        let fleet = NotchFleet(scope: .allDisplays, edge: .right)
+        fleet.show()
+        defer { fleet.stop() }
+        XCTAssertEqual(fleet.controllersForTesting.count, NSScreen.screens.count)
+    }
+
+    /// A controller created late — a display plugged in at noon — starts with
+    /// today's readings rather than empty rings.
+    func testLateControllersStartWithCurrentReadings() {
+        let fleet = NotchFleet(scope: .mainDisplay, edge: .right)
+        fleet.show()
+        defer { fleet.stop() }
+        let reading = ProviderSnapshot(
+            id: "codex", displayName: "Codex", glyph: .openai,
+            fidelity: .official, status: .ok,
+            windows: [LimitWindow(id: "primary", label: "5h limit", usedFraction: 0.27)],
+            headlineID: "primary")
+        fleet.setSnapshots([reading])
+        for controller in fleet.controllersForTesting {
+            XCTAssertEqual(controller.model.snapshots, [reading])
         }
     }
 }


### PR DESCRIPTION
Appearance gets a Displays picker: Main display / All displays. All displays puts a notch on every connected screen, each with independent hover — reaching for one opens only that one.

Why one notch per display: each panel is welded to its own screen edge with its own open state and screen size (tooltip budgets come out of it). A shared model would unfold every notch when the pointer reaches any of them, including the display you are not looking at.

- New `NotchScreenScope` setting (`notchScope`, default main display so current behavior is unchanged) plus a Displays segmented picker next to Edge.
- New `NotchFleet`: owns one `NotchWindowController` per display keyed by `NSScreenNumber`, reconciles on screen-parameter changes, and fans out snapshots, sessions, refreshing, edge, visibility and callbacks. A controller created late (display plugged in at noon) starts with current readings. The single-notch case keeps its controller and moves it, the way a lone panel always did.
- `NotchWindowController` gains `assignedScreen` (nil follows the menu-bar screen, i.e. old behavior) and `retire()` for clean teardown when a display disconnects.

Tests: 564 tests, 0 failures — 12 new (scope defaults/persistence/unknown-value fallback, pure reconcile maths, fleet counts against the real screen list, late-controller readings). No layout-math changes.

Notes: merge after #26 — plain `make test` on a contributor machine needs its Makefile ad-hoc fix (verified here with manual ad-hoc flags). And the all-screens path is test-exercised only; I have one display, so worth an eyeball on a multi-screen setup.