### PR TITLE
Fix Cursor enterprise usage metering and Auth0 sign-in detection

### DIFF
--- a/Sources/Providers/CursorCredentials.swift
+++ b/Sources/Providers/CursorCredentials.swift
@@ -55,15 +55,40 @@ struct CursorCredentials {
         defer { sqlite3_close(db) }
 
         guard let token = value(forKey: "cursorAuth/accessToken", in: db),
-              let account = value(forKey: "cursorAuth/stripeMembershipAuthId", in: db),
-              !token.isEmpty, !account.isEmpty
+              !token.isEmpty
         else { throw UsageProviderError.needsAuth }
 
+        // Prefer the editor's cached WorkOS id when present. Recent Cursor
+        // builds (Auth0 / enterprise in particular) often omit
+        // `stripeMembershipAuthId` even while signed in — the JWT `sub` is the
+        // same value the cookie needs, so fall back to it rather than telling
+        // the user to sign in again.
+        let account = value(forKey: "cursorAuth/stripeMembershipAuthId", in: db)
+            .flatMap { $0.isEmpty ? nil : $0 }
+            ?? subject(fromJWT: token)
+        guard let account, !account.isEmpty else { throw UsageProviderError.needsAuth }
+
         return CursorCredentials(accountID: account, accessToken: token)
+    }
+
+    /// `sub` claim from an unsigned JWT payload — Cursor's access token is a
+    /// standard three-part JWT whose subject is the WorkOS / Auth0 user id.
+    static func subject(fromJWT token: String) -> String? {
+        let parts = token.split(separator: ".", omittingEmptySubsequences: false)
+        guard parts.count >= 2 else { return nil }
+        var base64 = parts[1]
+            .replacingOccurrences(of: "-", with: "+")
+            .replacingOccurrences(of: "_", with: "/")
+        while base64.count % 4 != 0 { base64.append("=") }
+        guard let data = Data(base64Encoded: base64),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let sub = json["sub"] as? String,
+              !sub.isEmpty
+        else { return nil }
+        return sub
     }
 
     private static func value(forKey key: String, in db: OpaquePointer?) -> String? {
         SQLiteStore.rows(in: db, sql: "SELECT value FROM ItemTable WHERE key = ?", bind: key).first
     }
 }
-

--- a/Sources/Providers/CursorUsage.swift
+++ b/Sources/Providers/CursorUsage.swift
@@ -14,12 +14,25 @@ import Foundation
 ///     "onDemand": { "enabled": false, "used": 0, "limit": null } } }
 /// ```
 ///
+/// Enterprise / team plans ship a different shape — no `plan` percentages,
+/// just a hard `overall` ceiling:
+///
+/// ```json
+/// { "membershipType": "enterprise", "limitType": "team",
+///   "individualUsage": {
+///     "overall": { "enabled": true, "used": 6907, "limit": 45000, "remaining": 38093 } },
+///   "teamUsage": {
+///     "onDemand": { "enabled": true, "used": 0, "limit": 1000000 } } }
+/// ```
+///
 /// Cursor meters an **allowance, not a request count** — the dashboard's "Your
 /// included usage · N% used" is `totalPercentUsed`. The `used`/`limit` pair sits
 /// at zero on a free plan even while real usage is happening, because the
 /// allowance arrives as `breakdown.bonus` rather than as a dollar limit. Reading
 /// `used`/`limit` therefore reports 0% for an account that is 10% through its
-/// month, which is exactly what this parser used to do.
+/// month, which is exactly what this parser used to do. Enterprise is the
+/// opposite: there is no percentage field, so `used`/`limit` on `overall` is
+/// the reading.
 enum CursorUsage {
     static func windows(fromJSON json: String) throws -> [LimitWindow] {
         guard let data = json.data(using: .utf8),
@@ -29,6 +42,7 @@ enum CursorUsage {
         let resetsAt = date(root["billingCycleEnd"])
         let usage = root["individualUsage"] as? [String: Any] ?? [:]
         let plan = usage["plan"] as? [String: Any] ?? [:]
+        let team = root["teamUsage"] as? [String: Any] ?? [:]
 
         var windows: [LimitWindow] = []
 
@@ -53,6 +67,20 @@ enum CursorUsage {
         if let onDemand = spendWindow(usage["onDemand"], id: "on_demand",
                                       label: "On demand", resetsAt: resetsAt) {
             windows.append(onDemand)
+        }
+
+        // Enterprise / team plans omit `plan` entirely and meter a hard
+        // `overall` ceiling instead. Keep the window id as `included` so the
+        // provider's headlineID still resolves.
+        if windows.isEmpty,
+           let overall = spendWindow(usage["overall"], id: "included",
+                                     label: "Included usage", resetsAt: resetsAt) {
+            windows.append(overall)
+        }
+        if let teamOnDemand = spendWindow(team["onDemand"], id: "team_on_demand",
+                                          label: "Team on demand", resetsAt: resetsAt),
+           (teamOnDemand.usedFraction ?? 0) > 0 {
+            windows.append(teamOnDemand)
         }
 
         guard windows.isEmpty else { return windows }

--- a/Tests/CursorUsageTests.swift
+++ b/Tests/CursorUsageTests.swift
@@ -104,6 +104,17 @@ final class CursorCredentialsTests: XCTestCase {
             }
         }
     }
+
+    func testSubjectIsReadFromTheAccessTokenJWT() {
+        // {"sub":"auth0|user_ABC","aud":"https://cursor.com"}
+        let payload = Data(#"{"sub":"auth0|user_ABC","aud":"https://cursor.com"}"#.utf8)
+            .base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .trimmingCharacters(in: CharacterSet(charactersIn: "="))
+        let jwt = "hdr.\(payload).sig"
+        XCTAssertEqual(CursorCredentials.subject(fromJWT: jwt), "auth0|user_ABC")
+    }
 }
 
 /// Confirmed against a real account switched mid-cycle: Cursor reports 0% and
@@ -132,5 +143,43 @@ final class CursorZeroUsageTests: XCTestCase {
                                                  with: "\"totalPercentUsed\":34")
         let windows = try CursorUsage.windows(fromJSON: used)
         XCTAssertEqual(windows.first?.usedFraction ?? 0, 0.34, accuracy: 0.0001)
+    }
+}
+
+
+/// Enterprise / team plans omit `plan.totalPercentUsed` and meter a hard
+/// `overall` ceiling instead. Verbatim shape from a live enterprise account.
+final class CursorEnterpriseUsageTests: XCTestCase {
+    private let recorded = """
+    {"billingCycleStart":"2026-09-01T00:00:00.000Z",
+     "billingCycleEnd":"2026-10-01T00:00:00.000Z",
+     "membershipType":"enterprise","limitType":"team","isUnlimited":false,
+     "autoModelSelectedDisplayMessage":"You've used 0% of your included total usage",
+     "namedModelSelectedDisplayMessage":"You've used 0% of your included API usage",
+     "individualUsage":{
+       "overall":{"enabled":true,"used":6907,"limit":45000,"remaining":38093}},
+     "teamUsage":{
+       "onDemand":{"enabled":true,"used":0,"limit":1000000,"remaining":1000000}}}
+    """
+
+    func testOverallCeilingIsTheIncludedWindow() throws {
+        let windows = try CursorUsage.windows(fromJSON: recorded)
+        XCTAssertEqual(windows.map(\.id), ["included"])
+        XCTAssertEqual(windows[0].label, "Included usage")
+        XCTAssertEqual(windows[0].usedFraction ?? -1, 6907.0 / 45000.0, accuracy: 0.0001)
+    }
+
+    func testUnusedTeamOnDemandIsOmitted() throws {
+        let windows = try CursorUsage.windows(fromJSON: recorded)
+        XCTAssertFalse(windows.contains { $0.id == "team_on_demand" })
+    }
+
+    func testTeamOnDemandAppearsOnceTouched() throws {
+        let touched = recorded.replacingOccurrences(
+            of: #""onDemand":{"enabled":true,"used":0,"limit":1000000,"remaining":1000000}"#,
+            with: #""onDemand":{"enabled":true,"used":250000,"limit":1000000,"remaining":750000}"#)
+        let windows = try CursorUsage.windows(fromJSON: touched)
+        XCTAssertEqual(windows.map(\.id), ["included", "team_on_demand"])
+        XCTAssertEqual(windows[1].usedFraction ?? -1, 0.25, accuracy: 0.0001)
     }
 }


### PR DESCRIPTION
## Summary
- Parse enterprise/team `individualUsage.overall` (`used`/`limit`) so the Cursor ring shows real usage instead of \"enterprise plan has nothing to meter\".
- Fall back to the access-token JWT `sub` when `cursorAuth/stripeMembershipAuthId` is missing (common on Auth0/enterprise), which previously showed \"sign in to Cursor in the IDE\" while already signed in.
- Add pinned tests from a live enterprise `GET /api/usage-summary` response.

## Test plan
- [ ] `make test`
- [ ] On an enterprise Cursor account: ring shows ~used/limit (e.g. 6907/45000 ≈ 15%) and resets at billing cycle end
- [ ] On a free/pro account: existing `plan.totalPercentUsed` behavior unchanged
- [ ] With `stripeMembershipAuthId` deleted from `state.vscdb` but a valid `accessToken` present: Cursor still authenticates


Made with [Cursor](https://cursor.com)