### PR TITLE
Fix the ad-hoc signing fallback so contributors can build without a certificate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ DEST    := platform=macOS,arch=arm64
 # changes nothing: project.yml's stable identity is what keeps a keychain
 # "Always Allow" grant alive across rebuilds, and forcing ad-hoc there would
 # throw that away and bring the prompt back on every `make run`.
-ifeq (,$(shell security find-identity -v -p codesigning 2>/dev/null | grep -c "Developer ID Application"))
+ifeq (0,$(shell security find-identity -v -p codesigning 2>/dev/null | grep -c "Developer ID Application"))
 DEV_SIGN := CODE_SIGN_IDENTITY="-" DEVELOPMENT_TEAM="" CODE_SIGN_STYLE=Automatic
 endif
 


### PR DESCRIPTION
## Problem

On any machine without the maintainer's "Developer ID Application" certificate, `make build`, `make test` and `make run` all fail:

```
error: No signing certificate "Developer ID Application" found: No "Developer ID Application" signing certificate matching team ID "6WFPL8B9FB" with a private key was found. (in target 'Codenotch' from project 'Codenotch')
```

The Makefile is meant to pass ad-hoc signing overrides in exactly that case (per CONTRIBUTING.md and the 1.5.0 release note "Contributors can build without a certificate"), but the check never fires:

```make
ifeq (,$(shell security find-identity -v -p codesigning 2>/dev/null | grep -c "Developer ID Application"))
```

`grep -c` prints `0` when nothing matches, never an empty string, so `$(shell …)` is `0`, the comparison against empty is false, and `DEV_SIGN` stays empty. On the maintainer's machine the count is non-zero and the condition is also false, which is why it looked like it worked.

## Fix

Compare against `0` instead of the empty string. One character; the maintainer's machine is unaffected, which is the behaviour the comment above the check describes.

## Verification

On a Mac with no Developer ID certificate in the keychain (macOS 27.0, Xcode 27.0 beta):

- `make build` now invokes `xcodebuild … CODE_SIGN_IDENTITY=- DEVELOPMENT_TEAM= CODE_SIGN_STYLE=Automatic build` and succeeds.
- `make test` runs all 552 tests with 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JNTLLKJfhKHC5KUwCu3q5a
