### PR TITLE
Add a Gemini API key provider read from the tools' own logs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ DEST    := platform=macOS,arch=arm64
 # changes nothing: project.yml's stable identity is what keeps a keychain
 # "Always Allow" grant alive across rebuilds, and forcing ad-hoc there would
 # throw that away and bring the prompt back on every `make run`.
-ifeq (,$(shell security find-identity -v -p codesigning 2>/dev/null | grep -c "Developer ID Application"))
+ifeq (0,$(shell security find-identity -v -p codesigning 2>/dev/null | grep -c "Developer ID Application"))
 DEV_SIGN := CODE_SIGN_IDENTITY="-" DEVELOPMENT_TEAM="" CODE_SIGN_STYLE=Automatic
 endif
 

--- a/Sources/App/AppDelegate.swift
+++ b/Sources/App/AppDelegate.swift
@@ -70,7 +70,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             let store = UsageStore(
                 providers: claudeProfiles.map { ClaudeOAuthProvider(profile: $0) }
                     + [CursorLocalProvider(), CodexLocalProvider(), AntigravityProvider(),
-                       GLMProvider(), GrokLocalProvider(), OpenCodeProvider()]
+                       GLMProvider(), GrokLocalProvider(), OpenCodeProvider(),
+                       // A closure, not the value: the provider is an actor and
+                       // re-reads the budget on every fetch, so a ceiling typed
+                       // into Settings applies without a restart.
+                       GeminiAPIProvider(budget: {
+                           Preferences.storedGeminiAPIMonthlyTokenBudget()
+                       })]
                     + webProviders,
                 disconnected: preferences.disconnectedProviders
             )
@@ -151,6 +157,19 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 .sink { [weak store] in store?.disconnected = $0 }
                 .store(in: &cancellables)
 
+            // Redraw the Gemini API ring against the new ceiling.
+            //
+            // `dropFirst` because `@Published` publishes the value it is given
+            // at init, and a refresh there would race the store's first poll.
+            // `receive(on:)` because `@Published` emits in `willSet` — the hop
+            // to the next run loop pass is what lets the `didSet` persist the
+            // number before the provider's closure goes looking for it.
+            preferences.$geminiAPIMonthlyTokenBudget
+                .dropFirst()
+                .receive(on: RunLoop.main)
+                .sink { [weak store] _ in store?.refresh(providerID: "gemini-api") }
+                .store(in: &cancellables)
+
             store.$snapshots
                 .receive(on: RunLoop.main)
                 .sink { [weak controller] snapshots in
@@ -189,7 +208,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             "cursor": CursorActivityMonitor(),
             "codex": CodexActivityMonitor(),
             "gemini": AntigravityActivityMonitor(),
-            "grok": GrokActivityMonitor()
+            "grok": GrokActivityMonitor(),
+            "gemini-api": GeminiCLIActivityMonitor()
         ]
         for profile in claudeProfiles {
             monitors[profile.id] = ClaudeSessionMonitor(directory: profile.sessionsDirectory)

--- a/Sources/Model/UsageModel.swift
+++ b/Sources/Model/UsageModel.swift
@@ -53,6 +53,17 @@ struct LimitWindow: Identifiable, Codable, Equatable {
         self.resetsAt = resetsAt
     }
 
+    /// A count short enough to sit inside a 44 pt ring.
+    ///
+    /// Requests and credits are three or four digits and print verbatim; token
+    /// counts run to seven, and "651061" under the ring is unreadable at that
+    /// width. The threshold is 10 000 so no existing provider's number changes.
+    static func compact(_ count: Int) -> String {
+        if count < 10_000 { return "\(count)" }
+        if count < 1_000_000 { return "\(count / 1_000)k" }
+        return String(format: "%.1fM", Double(count) / 1_000_000)
+    }
+
     /// What the tooltip says on the line under the bar.
     var summary: String {
         if let usedFraction {
@@ -66,10 +77,10 @@ struct LimitWindow: Identifiable, Codable, Equatable {
             return "\(used)% Used · \(max(0, 100 - used))% left"
         }
         if let remaining {
-            return remaining == 1 ? "1 left" : "\(remaining) left"
+            return remaining == 1 ? "1 left" : "\(Self.compact(remaining)) left"
         }
         if let used {
-            return used == 1 ? "1 used" : "\(used) used"
+            return used == 1 ? "1 used" : "\(Self.compact(used)) used"
         }
         return "No reading"
     }
@@ -137,8 +148,8 @@ struct ProviderSnapshot: Identifiable, Equatable {
     /// What the cell prints under the ring.
     var headlineText: String {
         if let usedFraction { return "\(Int((usedFraction * 100).rounded()))%" }
-        if let remaining = headline?.remaining { return "\(remaining)" }
-        if let used = headline?.used { return "\(used)" }
+        if let remaining = headline?.remaining { return LimitWindow.compact(remaining) }
+        if let used = headline?.used { return LimitWindow.compact(used) }
         return "—"
     }
 

--- a/Sources/Providers/GeminiAPICredentials.swift
+++ b/Sources/Providers/GeminiAPICredentials.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+/// Who is paying for the Gemini calls this ring counts — as far as that can be
+/// told without ever touching the key.
+///
+/// Google publishes no usage endpoint for an API key, so there is nothing here
+/// to authenticate with and no reason to read a secret: the key stays wherever
+/// its owner put it (`GEMINI_API_KEY`, an `.env` file, `auth.json`, the
+/// keychain) and none of that is opened. The only things worth naming on the
+/// settings row are which tools' logs the numbers came from, and how Gemini CLI
+/// was told to pay — the free `oauth-personal` login is a quota, not a bill,
+/// and calling it "metered" would put a price on it.
+///
+/// `~/.gemini/settings.json` is where the CLI records that choice:
+///
+/// ```
+/// {"security":{"auth":{"selectedType":"gemini-api-key"}}}
+/// ```
+///
+/// The CLI accepts comments in that file and `JSONSerialization` does not, so
+/// every failure to read it answers "unknown" rather than guessing — the label
+/// is a courtesy, and a wrong one would be worse than none.
+enum GeminiAPICredentials {
+    static var settingsFile: URL {
+        URL(fileURLWithPath: NSHomeDirectory())
+            .appendingPathComponent(".gemini/settings.json")
+    }
+
+    static func authType(at file: URL = GeminiAPICredentials.settingsFile) -> String? {
+        guard let data = try? Data(contentsOf: file),
+              let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let security = root["security"] as? [String: Any],
+              let auth = security["auth"] as? [String: Any],
+              let type = auth["selectedType"] as? String,
+              !type.isEmpty
+        else { return nil }
+        return type
+    }
+
+    /// No tool kept a log means there is no account to describe — not an empty
+    /// one, none — so the settings row stays quiet rather than claiming a key.
+    static func account(tools: [String], authType: String?) -> ProviderAccount? {
+        guard !tools.isEmpty else { return nil }
+        let isGoogleAccount = authType == "oauth-personal"
+        return ProviderAccount(
+            label: isGoogleAccount ? "Google account" : "API key",
+            // "metered" rather than a plan name: a bare key is not on a plan,
+            // it is charged per token at a price that changes under the app.
+            plan: isGoogleAccount ? nil : "metered",
+            // The tools that wrote the numbers, which is the honest answer to
+            // "whose reading is this" when no credential was borrowed at all.
+            source: tools.joined(separator: ", "),
+            manageURL: nil
+        )
+    }
+}

--- a/Sources/Providers/GeminiAPIProvider.swift
+++ b/Sources/Providers/GeminiAPIProvider.swift
@@ -1,0 +1,148 @@
+import Foundation
+
+/// Tokens spent against a bare `GEMINI_API_KEY`, added up from the logs the
+/// tools that made the calls keep for themselves.
+///
+/// There is no endpoint behind this one. Google meters an API key on the
+/// billing account and publishes nothing an app could read, so the only record
+/// of a call is the one Gemini CLI, OpenCode or Hermes wrote after making it.
+/// Each of those keeps its own count, each counts a slightly different thing,
+/// and the three readers next door reconcile that; what is left here is adding
+/// them up and saying which log each row came from, because a single
+/// unattributable total is impossible to check against anything.
+///
+/// Nothing is cached: every fetch re-reads three local paths, which is
+/// prompt-free — no keychain is involved, and no network is either.
+actor GeminiAPIProvider: UsageProvider {
+    /// Spelled once, because the pure snapshot builder below is static and
+    /// cannot reach the instance. An id that drifted from the one the archive
+    /// and the disconnected set are keyed by would lose the user's state.
+    fileprivate static let providerID = "gemini-api"
+    fileprivate static let providerName = "Gemini API"
+
+    nonisolated let id = GeminiAPIProvider.providerID
+    nonisolated let displayName = GeminiAPIProvider.providerName
+    // The Gemini sparkle, not Antigravity's arch: this row is the model API,
+    // and the arch is the editor's own mark, which the neighbouring provider
+    // already wears.
+    nonisolated let glyph = ProviderGlyph.geminiSpark
+
+    nonisolated private let cliRoot: URL
+    nonisolated private let openCodeDatabase: URL
+    nonisolated private let hermesDatabase: URL
+    nonisolated private let settingsFile: URL
+    /// Read fresh on every fetch rather than captured once: the user can change
+    /// it in Settings while the app runs, and the ring has to follow.
+    private let budget: @Sendable () -> Int?
+
+    /// The tools the last fetch actually found, for the settings row.
+    /// `nonisolated(unsafe)` because `account()` reads it off the actor, the
+    /// same bargain `GLMProvider.lastKnownPlan` makes; the worst a race can do
+    /// is name yesterday's tools for one row-draw.
+    nonisolated(unsafe) private var lastTools: [String] = []
+
+    init(
+        cliRoot: URL = GeminiCLIUsage.sessionsRoot,
+        openCodeDatabase: URL = OpenCodeGeminiUsage.database,
+        hermesDatabase: URL = HermesGeminiUsage.database,
+        settingsFile: URL = GeminiAPICredentials.settingsFile,
+        budget: @escaping @Sendable () -> Int?
+    ) {
+        self.cliRoot = cliRoot
+        self.openCodeDatabase = openCodeDatabase
+        self.hermesDatabase = hermesDatabase
+        self.settingsFile = settingsFile
+        self.budget = budget
+    }
+
+    nonisolated var signInRoute: SignInRoute {
+        .guidance("There is nothing to sign in to: the count is added up from what "
+                  + "Gemini CLI, OpenCode and Hermes recorded about their own calls. "
+                  + "Your API key is never read.")
+    }
+
+    nonisolated func account() -> ProviderAccount? {
+        GeminiAPICredentials.account(
+            tools: lastTools,
+            authType: GeminiAPICredentials.authType(at: settingsFile)
+        )
+    }
+
+    func fetchSnapshot() async throws -> ProviderSnapshot {
+        let now = Date()
+        let sources = sources(now: now)
+        // Not an error and not a missing sign-in: none of the three tools has
+        // ever run here, so there is genuinely nothing being metered.
+        guard !sources.isEmpty else {
+            throw UsageProviderError.nothingMetered(
+                "No Gemini CLI, OpenCode or Hermes sessions found")
+        }
+        lastTools = sources.map(\.name)
+        return Self.snapshot(sources: sources, budget: budget(), now: now)
+    }
+
+    /// One entry per tool that has state on disk, in a fixed order so the
+    /// tooltip's rows do not shuffle between refreshes. A reader answering
+    /// `nil` means its tool was never installed, which is not the same as a
+    /// zero and must not be shown as one.
+    private func sources(now: Date) -> [GeminiTokenSource] {
+        let readings: [(id: String, name: String, usage: GeminiTokenUsage?)] = [
+            ("cli", "Gemini CLI", GeminiCLIUsage.read(root: cliRoot, now: now)),
+            ("opencode", "OpenCode", OpenCodeGeminiUsage.read(database: openCodeDatabase, now: now)),
+            ("hermes", "Hermes", HermesGeminiUsage.read(database: hermesDatabase, now: now))
+        ]
+        return readings.compactMap { reading in
+            reading.usage.map {
+                GeminiTokenSource(id: reading.id, name: reading.name, usage: $0)
+            }
+        }
+    }
+
+    /// The whole visible surface, kept pure so it can be tested without a disk.
+    static func snapshot(
+        sources: [GeminiTokenSource],
+        budget: Int?,
+        now: Date = Date()
+    ) -> ProviderSnapshot {
+        // A budget of zero or less is the same statement as no budget, and
+        // dividing by it would draw an infinite ring.
+        let budget = budget.flatMap { $0 > 0 ? $0 : nil }
+        let total = sources.reduce(GeminiTokenUsage.zero) { $0.adding($1.usage) }
+        let calendar = GeminiTokenUsage.calendar
+
+        var windows = [
+            LimitWindow(
+                id: "month",
+                label: budget.map { "Tokens this month · budget \(LimitWindow.compact($0))" }
+                    ?? "Tokens this month · billed per token, no limit",
+                usedFraction: budget.map { Double(total.tokensThisMonth) / Double($0) },
+                used: total.tokensThisMonth,
+                resetsAt: calendar.dateInterval(of: .month, for: now)?.end
+            ),
+            LimitWindow(
+                id: "today",
+                label: "Tokens today",
+                used: total.tokensToday,
+                resetsAt: calendar.dateInterval(of: .day, for: now)?.end
+            )
+        ]
+        // The rows that make the headline checkable: which tool spent what.
+        windows += sources.map {
+            LimitWindow(id: $0.id, label: "\($0.name) · this month", used: $0.usage.tokensThisMonth)
+        }
+
+        return ProviderSnapshot(
+            id: providerID,
+            displayName: providerName,
+            glyph: .geminiSpark,
+            // `.manual` once there is a budget, because the ceiling the ring
+            // fills against is the user's own guess, not a limit Google set.
+            // Either way the number is ours, so the tooltip keeps its `~`.
+            fidelity: budget == nil ? .derived : .manual,
+            status: .ok,
+            windows: windows,
+            headlineID: "month",
+            block: nil
+        )
+    }
+}

--- a/Sources/Providers/GeminiCLIUsage.swift
+++ b/Sources/Providers/GeminiCLIUsage.swift
@@ -1,0 +1,126 @@
+import Foundation
+
+/// Tokens Gemini CLI recorded for itself, read out of its chat recordings.
+///
+/// The files are append-only JSONL under `~/.gemini/tmp/<projectHash>/chats/`.
+/// Line one is a header; everything after it is either a message record or a
+/// patch:
+///
+/// ```
+/// {"sessionId":"6f0a…","projectHash":"9d2c…","startTime":"2026-09-01T09:12:33.104Z",
+///  "lastUpdated":"2026-09-01T09:41:02.881Z","kind":"main"}
+/// {"id":"c7f2…","timestamp":"2026-09-01T09:12:41.402Z","type":"gemini","model":"gemini-2.5-pro",
+///  "content":"…","tokens":{"input":12345,"output":218,"cached":11000,"thoughts":64,
+///  "tool":0,"total":12627}}
+/// {"$set":{"lastUpdated":"2026-09-01T09:41:02.881Z"}}
+/// {"$rewindTo":"c7f2…"}
+/// ```
+///
+/// Two rules the file's shape forces, both verified against Gemini CLI
+/// 0.58.0's `ChatRecordingService`:
+///
+/// - A `gemini` record is written the moment the turn starts, without
+///   `tokens`, and written *again* with the same `id` once `usageMetadata`
+///   arrives. Counting lines instead of ids double-counts every answered call:
+///   26 lines in a real session are 15 calls.
+/// - `$rewindTo` un-does the transcript, not the bill. Google charged for the
+///   rewound call, so it stays counted.
+///
+/// `total` is the field to read: it already is input + output + thoughts +
+/// tool, and `cached` is a subset of `input`, so summing the parts would count
+/// the cache twice.
+enum GeminiCLIUsage {
+    static var sessionsRoot: URL {
+        URL(fileURLWithPath: NSHomeDirectory()).appendingPathComponent(".gemini/tmp")
+    }
+
+    /// `nil` means Gemini CLI has no state on disk at all, which is a different
+    /// answer from "it ran and spent nothing" — the provider drops the row
+    /// entirely rather than showing a zero for a tool that was never installed.
+    static func read(
+        root: URL = GeminiCLIUsage.sessionsRoot,
+        now: Date = Date()
+    ) -> GeminiTokenUsage? {
+        let manager = FileManager.default
+        guard let projects = try? manager.contentsOfDirectory(
+            at: root, includingPropertiesForKeys: nil
+        ) else { return nil }
+
+        let startOfMonth = GeminiTokenUsage.startOfMonth(now: now)
+        var entries: [(at: Date, tokens: Int, calls: Int)] = []
+
+        for project in projects {
+            let chats = project.appendingPathComponent("chats")
+            guard let sessions = try? manager.contentsOfDirectory(
+                at: chats, includingPropertiesForKeys: [.contentModificationDateKey]
+            ) else { continue }
+
+            for session in sessions where session.pathExtension == "jsonl" {
+                // Append-only: no record inside can be newer than the file
+                // itself, so a file last written before this month cannot
+                // contribute. After a few months of sessions that is most of
+                // them, and each one would otherwise be parsed line by line.
+                let modified = try? session.resourceValues(
+                    forKeys: [.contentModificationDateKey]
+                ).contentModificationDate
+                if let modified, modified < startOfMonth { continue }
+
+                guard let text = try? String(contentsOf: session, encoding: .utf8) else { continue }
+                entries.append(contentsOf: calls(in: text))
+            }
+        }
+        return GeminiTokenUsage.bucket(entries, now: now)
+    }
+
+    private static func calls(in text: String) -> [(at: Date, tokens: Int, calls: Int)] {
+        var answered: [String: Record] = [:]
+        for line in text.split(separator: "\n") {
+            guard let data = line.data(using: .utf8),
+                  let record = try? JSONDecoder().decode(Record.self, from: data),
+                  let id = record.id,
+                  record.type == "gemini",
+                  record.tokens != nil
+            else { continue }
+            // Later line wins: the second write of an id is the one that
+            // carries the usage the API reported.
+            answered[id] = record
+        }
+
+        return answered.values.compactMap { record in
+            guard let stamp = record.timestamp, let at = parse(stamp) else { return nil }
+            return (at: at, tokens: record.tokens?.total ?? 0, calls: 1)
+        }
+    }
+
+    /// Everything is optional because the same file holds headers, `$set`
+    /// patches and `$rewindTo` markers; those decode into a record of all nils
+    /// and are dropped by the filter rather than by a second decoder.
+    private struct Record: Decodable {
+        let id: String?
+        let type: String?
+        let timestamp: String?
+        let tokens: Tokens?
+    }
+
+    private struct Tokens: Decodable {
+        let total: Int
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            total = try container.decodeIfPresent(Int.self, forKey: .total) ?? 0
+        }
+
+        private enum CodingKeys: String, CodingKey { case total }
+    }
+
+    /// The CLI writes fractional seconds, but not on every record, and
+    /// `ISO8601DateFormatter` rejects the string when the option does not match
+    /// the text exactly.
+    static func parse(_ value: String) -> Date? {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        if let date = formatter.date(from: value) { return date }
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter.date(from: value)
+    }
+}

--- a/Sources/Providers/GeminiTokenUsage.swift
+++ b/Sources/Providers/GeminiTokenUsage.swift
@@ -1,0 +1,70 @@
+import Foundation
+
+/// Tokens billed against a bare `GEMINI_API_KEY`, counted from the logs the
+/// tools keep for themselves.
+///
+/// Google publishes no usage endpoint for an API key, so the only number that
+/// exists is the one each tool wrote down after its own call. Three tools keep
+/// such a log — Gemini CLI, OpenCode and Hermes — and each of them stamps its
+/// records in UTC. The bill and the user's day are local, though, so every
+/// reader hands its entries to `bucket` rather than doing the arithmetic
+/// itself: one routine is the only way the three rows in the tooltip can agree
+/// on where "today" and "this month" start.
+struct GeminiTokenUsage: Equatable {
+    var tokensThisMonth = 0
+    var tokensToday = 0
+    var callsThisMonth = 0
+
+    static let zero = GeminiTokenUsage()
+
+    func adding(_ other: GeminiTokenUsage) -> GeminiTokenUsage {
+        GeminiTokenUsage(
+            tokensThisMonth: tokensThisMonth + other.tokensThisMonth,
+            tokensToday: tokensToday + other.tokensToday,
+            callsThisMonth: callsThisMonth + other.callsThisMonth
+        )
+    }
+
+    /// Local, deliberately. `Calendar.current` would follow the user's chosen
+    /// calendar identifier as well as their zone, and a non-Gregorian month is
+    /// not the month Google bills.
+    static var calendar: Calendar {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = .current
+        return calendar
+    }
+
+    /// Local midnight on the first of `now`'s month. Readers use it to throw
+    /// away files and rows that cannot contribute before parsing them.
+    static func startOfMonth(now: Date, calendar: Calendar = GeminiTokenUsage.calendar) -> Date {
+        calendar.dateInterval(of: .month, for: now)!.start
+    }
+
+    /// The one place a timestamp turns into a window.
+    ///
+    /// A call with no tokens is a call that was aborted before the model
+    /// answered — OpenCode writes those rows with every counter at zero. It
+    /// costs nothing, so it is not a call either.
+    static func bucket(
+        _ entries: [(at: Date, tokens: Int, calls: Int)],
+        now: Date,
+        calendar: Calendar = GeminiTokenUsage.calendar
+    ) -> GeminiTokenUsage {
+        var usage = GeminiTokenUsage.zero
+        for entry in entries where entry.tokens > 0 {
+            guard calendar.isDate(entry.at, equalTo: now, toGranularity: .month) else { continue }
+            usage.tokensThisMonth += entry.tokens
+            usage.callsThisMonth += entry.calls
+            if calendar.isDate(entry.at, inSameDayAs: now) { usage.tokensToday += entry.tokens }
+        }
+        return usage
+    }
+}
+
+/// One tool's contribution, kept separate so the tooltip can say which log a
+/// number came from instead of presenting one unattributable total.
+struct GeminiTokenSource: Equatable {
+    let id: String
+    let name: String
+    let usage: GeminiTokenUsage
+}

--- a/Sources/Providers/HermesGeminiUsage.swift
+++ b/Sources/Providers/HermesGeminiUsage.swift
@@ -1,0 +1,73 @@
+import Foundation
+import SQLite3
+
+/// Tokens Hermes billed to a `GEMINI_API_KEY`, read out of its own usage table.
+///
+/// Hermes keeps a running total per session and model in `~/.hermes/state.db`:
+///
+/// ```
+/// session_model_usage(session_id, model, billing_provider, billing_base_url,
+///                     billing_mode, task, api_call_count, input_tokens,
+///                     output_tokens, cache_read_tokens, cache_write_tokens,
+///                     reasoning_tokens, estimated_cost_usd, actual_cost_usd,
+///                     cost_status, cost_source, first_seen REAL, last_seen REAL)
+/// ```
+///
+/// `billing_provider == "gemini"` is Hermes's id for "Google AI Studio", which
+/// is the bare API key against `generativelanguage.googleapis.com/v1beta`. The
+/// id survives a `GEMINI_BASE_URL` override — the base url moves to its own
+/// column — so matching on it and not on the url is what keeps a proxied setup
+/// counted.
+///
+/// `reasoning_tokens` is left out of the sum on purpose. Hermes's own
+/// `CanonicalUsage.total_tokens` treats reasoning as part of `output_tokens`,
+/// so adding it back would bill every thinking model twice. That is the
+/// opposite of OpenCode next door, where `reasoning` is a separate component.
+///
+/// A row is an aggregate over a whole session, not a single call, so there is
+/// no per-call timestamp to bucket by: `last_seen` is the closest thing, and a
+/// session straddling midnight or month end lands wholly in the bucket of its
+/// last call. Hermes's own `/usage` report has exactly the same granularity.
+enum HermesGeminiUsage {
+    static var database: URL {
+        URL(fileURLWithPath: NSHomeDirectory())
+            .appendingPathComponent(".hermes/state.db")
+    }
+
+    /// `nil` means Hermes has no database on disk, which is a different answer
+    /// from "it ran and spent nothing" — the provider drops the row entirely
+    /// rather than showing a zero for a tool that was never installed.
+    static func read(
+        database: URL = HermesGeminiUsage.database,
+        now: Date = Date()
+    ) -> GeminiTokenUsage? {
+        guard let db = SQLiteStore.open(database) else { return nil }
+        defer { sqlite3_close(db) }
+
+        // `last_seen` is epoch seconds as a REAL. Filtering in SQL keeps the
+        // read to this month's sessions however long the user has run Hermes.
+        let startOfMonth = Int(GeminiTokenUsage.startOfMonth(now: now).timeIntervalSince1970)
+        let rows = SQLiteStore.rows(
+            in: db,
+            sql: """
+            SELECT last_seen,
+                   input_tokens + cache_read_tokens + cache_write_tokens + output_tokens,
+                   api_call_count
+            FROM session_model_usage
+            WHERE billing_provider = 'gemini'
+              AND last_seen >= \(startOfMonth)
+            """,
+            columns: 3
+        )
+
+        let entries: [(at: Date, tokens: Int, calls: Int)] = rows.compactMap { row in
+            guard let seconds = Double(row[0]) else { return nil }
+            return (
+                at: Date(timeIntervalSince1970: seconds),
+                tokens: Int(row[1]) ?? 0,
+                calls: Int(row[2]) ?? 0
+            )
+        }
+        return GeminiTokenUsage.bucket(entries, now: now)
+    }
+}

--- a/Sources/Providers/OpenCodeGeminiUsage.swift
+++ b/Sources/Providers/OpenCodeGeminiUsage.swift
@@ -1,0 +1,75 @@
+import Foundation
+import SQLite3
+
+/// Tokens OpenCode billed to a `GEMINI_API_KEY`, read out of its own message log.
+///
+/// OpenCode keeps every message in `~/.local/share/opencode/opencode.db`, one
+/// row per message with the interesting part as JSON in `data`:
+///
+/// ```
+/// message(id TEXT, session_id TEXT, time_created INTEGER, time_updated INTEGER, data TEXT)
+/// {"role":"assistant","providerID":"google","modelID":"gemini-2.5-pro",
+///  "tokens":{"input":2834,"output":51,"reasoning":17,"cache":{"read":93106,"write":0},
+///            "total":96008},"cost":0.0}
+/// ```
+///
+/// `providerID == "google"` is OpenCode's name for the bare API key, and only
+/// that: `google-vertex` is Vertex AI, billed against a GCP project rather than
+/// this key, so it must not be added here.
+///
+/// `total` is authoritative when OpenCode wrote one, and the five components
+/// are the fallback because `input` there excludes the cache — the real row
+/// above adds up as 2834 + 51 + 17 + 93106 + 0 = 96008 only when `cache.read`
+/// is included. An aborted message is stored with every counter at zero and no
+/// `total`; `GeminiTokenUsage.bucket` drops it.
+///
+/// Nothing is linked to run `json_extract`: the system libsqlite3 already
+/// carries the JSON functions. The unrelated `OpenCodeProvider` next door
+/// measures the OpenCode Go plan against OpenCode's own server; this reader
+/// never leaves the disk.
+enum OpenCodeGeminiUsage {
+    static var database: URL {
+        URL(fileURLWithPath: NSHomeDirectory())
+            .appendingPathComponent(".local/share/opencode/opencode.db")
+    }
+
+    /// `nil` means OpenCode has no database on disk, which is a different
+    /// answer from "it ran and spent nothing" — the provider drops the row
+    /// entirely rather than showing a zero for a tool that was never installed.
+    static func read(
+        database: URL = OpenCodeGeminiUsage.database,
+        now: Date = Date()
+    ) -> GeminiTokenUsage? {
+        guard let db = SQLiteStore.open(database) else { return nil }
+        defer { sqlite3_close(db) }
+
+        // `time_created` is indexed and holds milliseconds. Filtering on it in
+        // SQL keeps the JSON extraction off every message the user ever sent.
+        let startOfMonth = Int(GeminiTokenUsage.startOfMonth(now: now).timeIntervalSince1970 * 1000)
+        let rows = SQLiteStore.rows(
+            in: db,
+            sql: """
+            SELECT time_created,
+                   json_extract(data, '$.tokens.total'),
+                   json_extract(data, '$.tokens.input'),
+                   json_extract(data, '$.tokens.output'),
+                   json_extract(data, '$.tokens.reasoning'),
+                   json_extract(data, '$.tokens.cache.read'),
+                   json_extract(data, '$.tokens.cache.write')
+            FROM message
+            WHERE json_extract(data, '$.role') = 'assistant'
+              AND json_extract(data, '$.providerID') = 'google'
+              AND time_created >= \(startOfMonth)
+            """,
+            columns: 7
+        )
+
+        let entries: [(at: Date, tokens: Int, calls: Int)] = rows.compactMap { row in
+            guard let milliseconds = Double(row[0]) else { return nil }
+            let total = Int(row[1]) ?? 0
+            let tokens = total > 0 ? total : (2...6).reduce(0) { $0 + (Int(row[$1]) ?? 0) }
+            return (at: Date(timeIntervalSince1970: milliseconds / 1000), tokens: tokens, calls: 1)
+        }
+        return GeminiTokenUsage.bucket(entries, now: now)
+    }
+}

--- a/Sources/Providers/ProviderGlyph.swift
+++ b/Sources/Providers/ProviderGlyph.swift
@@ -10,6 +10,13 @@ enum ProviderGlyph: String, Codable, Equatable {
     /// written under, and renaming it would make every stored reading for this
     /// provider undecodable.
     case antigravity = "gemini"
+    /// Gemini's own sparkle, for the provider that meters a raw API key.
+    ///
+    /// It cannot be called `gemini`: that raw value already names Antigravity's
+    /// arch inside every archived snapshot, and swapping its meaning would
+    /// redraw old readings as a mark they were never written for. So the
+    /// sparkle gets a key of its own instead.
+    case geminiSpark = "gemini-spark"
     case glm
     case grok
     case opencode
@@ -35,6 +42,7 @@ enum ProviderGlyph: String, Codable, Equatable {
         case .cursor: return 0.97
         case .openai: return 0.94
         case .antigravity: return 1.0
+        case .geminiSpark: return 1.0
         case .glm:    return 0.95
         case .grok:   return 1.0
         case .opencode: return 0.95
@@ -49,6 +57,7 @@ enum ProviderGlyph: String, Codable, Equatable {
         case .third:  return GlyphOutline.third
         case .cursor: return GlyphOutline.cursor
         case .antigravity: return GlyphOutline.antigravity
+        case .geminiSpark: return GlyphOutline.gemini
         case .glm:    return GlyphOutline.glm
         case .grok:   return GlyphOutline.grok
         case .opencode: return GlyphOutline.opencode

--- a/Sources/Sessions/GeminiCLIActivityMonitor.swift
+++ b/Sources/Sessions/GeminiCLIActivityMonitor.swift
@@ -1,0 +1,104 @@
+import Combine
+import Foundation
+
+/// Notices when Gemini CLI is working.
+///
+/// Its chat recordings hold no pid — nothing in the JSONL names the process —
+/// so `ProcessLiveness` has nothing to verify and recency is the only signal
+/// there is. It is a good one: the CLI appends a `$set lastUpdated` patch on
+/// every message, so a file written moments ago is a turn in progress. Cursor
+/// and Antigravity stand on the same substitute.
+///
+/// Only Gemini CLI gets a monitor. OpenCode and Hermes keep their token counts
+/// in databases that are written for reasons that have nothing to do with a
+/// Gemini call, so their modification dates would report work that is not this
+/// provider's.
+final class GeminiCLIActivityMonitor: AgentActivityMonitor {
+    @Published private(set) var sessions: [AgentSession] = []
+    var sessionsPublisher: AnyPublisher<[AgentSession], Never> { $sessions.eraseToAnyPublisher() }
+
+    private let root: URL
+    private let interval: TimeInterval
+    /// How recently a session file must have been written to count as live.
+    /// Generous, because a model can think for a while between two lines.
+    private let staleAfter: TimeInterval
+    private var timer: Timer?
+
+    init(root: URL = GeminiCLIUsage.sessionsRoot,
+         interval: TimeInterval = 2,
+         staleAfter: TimeInterval = 45) {
+        self.root = root
+        self.interval = interval
+        self.staleAfter = staleAfter
+    }
+
+    func start() {
+        stop()
+        poll()
+        let timer = Timer(timeInterval: interval, repeats: true) { [weak self] _ in
+            self?.poll()
+        }
+        RunLoop.main.add(timer, forMode: .common)
+        self.timer = timer
+    }
+
+    func stop() {
+        timer?.invalidate()
+        timer = nil
+    }
+
+    private func poll() {
+        let found = Self.read(root: root, staleAfter: staleAfter)
+        guard found != sessions else { return }
+        sessions = found
+    }
+
+    static func read(root: URL, staleAfter: TimeInterval, now: Date = Date()) -> [AgentSession] {
+        let manager = FileManager.default
+        guard let projects = try? manager.contentsOfDirectory(
+            at: root, includingPropertiesForKeys: nil
+        ) else { return [] }
+
+        var newest: (session: URL, project: URL, modified: Date)?
+        for project in projects {
+            let chats = project.appendingPathComponent("chats")
+            guard let files = try? manager.contentsOfDirectory(
+                at: chats, includingPropertiesForKeys: [.contentModificationDateKey]
+            ) else { continue }
+
+            for file in files where file.pathExtension == "jsonl" {
+                guard let modified = (try? file.resourceValues(
+                    forKeys: [.contentModificationDateKey]
+                ))?.contentModificationDate else { continue }
+                if newest == nil || modified > newest!.modified {
+                    newest = (file, project, modified)
+                }
+            }
+        }
+
+        // An older session is a finished turn, and showing it as work in
+        // progress would be a guess dressed as a fact.
+        guard let newest, now.timeIntervalSince(newest.modified) <= staleAfter else { return [] }
+        return [AgentSession(
+            id: "gemini-api.\(newest.session.deletingPathExtension().lastPathComponent)",
+            name: "Gemini CLI",
+            detail: "Working in \(projectName(of: newest.project))",
+            state: .busy,
+            waitingFor: nil,
+            since: newest.modified
+        )]
+    }
+
+    /// The directory is named after a hash of the working directory, which says
+    /// nothing to whoever reads the tooltip; the CLI writes the path that hash
+    /// stands for beside it, and the last component of that path is the folder
+    /// the user knows the project by.
+    private static func projectName(of project: URL) -> String {
+        let marker = project.appendingPathComponent(".project_root")
+        if let text = try? String(contentsOf: marker, encoding: .utf8) {
+            let path = text.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !path.isEmpty { return URL(fileURLWithPath: path).lastPathComponent }
+        }
+        return project.lastPathComponent
+    }
+}

--- a/Sources/Settings/Preferences.swift
+++ b/Sources/Settings/Preferences.swift
@@ -31,6 +31,23 @@ final class Preferences: ObservableObject {
         didSet { defaults.set(appPresence.rawValue, forKey: Keys.presence) }
     }
 
+    /// The ceiling the Gemini API ring fills against, counted in tokens.
+    ///
+    /// In tokens rather than money because a bare `GEMINI_API_KEY` publishes no
+    /// limit of any kind — there is nothing to read, so the ceiling has to come
+    /// from the user — and because prices change under the app while a token
+    /// stays a token. `nil` means no ceiling, which is the honest default: the
+    /// key is billed per token with no cap.
+    @Published var geminiAPIMonthlyTokenBudget: Int? {
+        didSet {
+            if let budget = geminiAPIMonthlyTokenBudget, budget > 0 {
+                defaults.set(budget, forKey: Keys.geminiAPIMonthlyTokenBudget)
+            } else {
+                defaults.removeObject(forKey: Keys.geminiAPIMonthlyTokenBudget)
+            }
+        }
+    }
+
     /// The version whose changes have already been shown.
     ///
     /// Written when the What's New dialogue is dismissed rather than when it
@@ -60,6 +77,22 @@ final class Preferences: ObservableObject {
         static let presence = "appPresence"
         static let edge = "notchEdge"
         static let lastSeenVersion = "lastSeenVersion"
+        /// A new key, so there is nothing under the old app name to migrate.
+        static let geminiAPIMonthlyTokenBudget = "geminiAPIMonthlyTokenBudget"
+    }
+
+    /// The budget read straight from disk, off the main actor.
+    ///
+    /// The Gemini API provider is an actor and asks for this on every fetch, and
+    /// `@Published` state is main-actor-isolated where `UserDefaults` is
+    /// thread-safe — so the provider reads the store, not the object.
+    nonisolated static func storedGeminiAPIMonthlyTokenBudget(
+        defaults: UserDefaults = .standard
+    ) -> Int? {
+        guard let budget = defaults.object(forKey: Keys.geminiAPIMonthlyTokenBudget) as? Int,
+              budget > 0
+        else { return nil }
+        return budget
     }
 
     /// True the very first time this copy runs, and never again.
@@ -116,6 +149,7 @@ final class Preferences: ObservableObject {
         // Absent means nothing has been shown yet, which is true of a fresh
         // install — so the current release reads as new to it.
         self.lastSeenVersion = defaults.string(forKey: Keys.lastSeenVersion)
+        self.geminiAPIMonthlyTokenBudget = Self.storedGeminiAPIMonthlyTokenBudget(defaults: defaults)
         // Read from the system rather than from our own store: the user can turn
         // this off in System Settings, and a remembered `true` would then be a lie.
         self.launchAtLogin = Self.isRegisteredForLogin

--- a/Sources/Settings/SettingsView.swift
+++ b/Sources/Settings/SettingsView.swift
@@ -191,7 +191,8 @@ struct SettingsView: View {
         "Codenotch reads usage from tools already signed in on this Mac — it "
         + "never asks for your password. Install and sign in to any of Claude "
         + "Code (the terminal tool, not the Claude app), Cursor, Codex, "
-        + "Antigravity, GLM, Grok or OpenCode, and its ring appears in the notch."
+        + "Antigravity, GLM, Grok, OpenCode or a Gemini API key (via Gemini "
+        + "CLI, OpenCode or Hermes), and its ring appears in the notch."
 
     /// Said before it happens rather than after. A system dialogue asking to
     /// read a *credential*, from an app installed a minute ago, looks alarming
@@ -306,6 +307,28 @@ private struct AccountRow: View {
 
     @ViewBuilder
     private var detail: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            accountDetail
+            // Google publishes no limit for a bare API key, so the ring has
+            // nothing to fill against until the user names a ceiling itself.
+            if isConnected, provider.id == "gemini-api" {
+                HStack(spacing: 6) {
+                    Text("Monthly budget")
+                    TextField("None", value: $preferences.geminiAPIMonthlyTokenBudget,
+                              format: .number)
+                        .textFieldStyle(.roundedBorder)
+                        .frame(width: 110)
+                    Text("tokens")
+                }
+                .foregroundStyle(.secondary)
+                .help("Fills the ring against a ceiling you choose; Google publishes "
+                      + "none for an API key.")
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var accountDetail: some View {
         if !isConnected {
             Text("Signed out — nothing is read, and no readings are kept.")
                 .foregroundStyle(.tertiary)

--- a/TASKS.md
+++ b/TASKS.md
@@ -1055,6 +1055,105 @@ it and then notice when the answer changes.
       fraction needs a limit, no limit is published, and a denominator we made
       up would put a confident ring on a guess.
 
+### Gemini API key, via the tools' own logs
+
+- [x] **There is no endpoint to ask.** A bare `GEMINI_API_KEY` is billed per
+      token and Google publishes no usage or quota resource for one — unlike
+      Claude, Cursor and Codex, which each answer with a figure. So this
+      provider does not call anything. It adds up what the tools that spent the
+      key already wrote down on this Mac.
+- [x] **The key itself is never read**, and nothing here goes looking for it:
+      not `~/.zshrc`, not an `.env`, not `opencode.json`, not `auth.json`, not
+      the keychain. Knowing the key would not produce a number anyway, so
+      reading it would be a prompt and a liability bought for nothing. The only
+      credential-shaped thing touched is `~/.gemini/settings.json`, and only for
+      `security.auth.selectedType`, which names *how* the calls were paid for.
+- [x] Three sources, each with a **single definition of "tokens"** chosen from
+      that tool's own source so nothing is counted twice:
+      * **Gemini CLI** — `tokens.total` in
+        `~/.gemini/tmp/<project>/chats/session-*.jsonl`. It is already
+        input + output + thoughts + tool, and `cached` is a *subset* of `input`,
+        so summing the parts would double-count the cache.
+      * **OpenCode** — `tokens.total` from `opencode.db` when present and above
+        zero, else `input + output + reasoning + cache.read + cache.write`.
+        OpenCode's `input` excludes the cached part, so the components add up:
+        a real row reads 96008 = 2834 + 51 + 17 + 93106 + 0.
+      * **Hermes** — `input + cache_read + cache_write + output` from
+        `session_model_usage`. Reasoning is **excluded here but not for
+        OpenCode**, and that asymmetry is deliberate: Hermes's own
+        `CanonicalUsage.total_tokens` counts reasoning inside `output_tokens`,
+        so adding `reasoning_tokens` would bill those tokens twice, whereas
+        OpenCode's `reasoning` is a separate quantity.
+- [x] **The CLI's JSONL appends the same call twice.** Verified against Gemini
+      CLI 0.58.0's bundled `ChatRecordingService`: a `gemini` record is written
+      as soon as the answer starts, and written *again* with the same `id` once
+      `usageMetadata` arrives. Read naively, 26 lines in a real session became
+      26 calls where there were 15. So records are deduped by `id` with the last
+      one winning, and everything else — the header line, `{"$set":...}` patches,
+      `user` records, garbage — falls through.
+- [x] **`{"$rewindTo":"<id>"}` is ignored on purpose.** Rewinding the
+      conversation does not refund the call: those tokens were generated and
+      billed. Honouring the rewind would make the notch quietly under-report
+      exactly when someone is iterating hardest.
+- [x] Buckets are **local month and local day**, not UTC. Every timestamp on
+      disk is UTC, but the bill and the user's "today" are local, and the three
+      rows in the tooltip have to agree on where the boundary is — so all three
+      readers feed one routine, `GeminiTokenUsage.bucket`. Reading a UTC
+      timestamp as local time here would repeat the bug `procStart` and
+      `AntigravityActivity` each hit once already — the same mistake a third
+      time.
+- [x] Each reader pre-filters before it parses, because these files only grow:
+      the CLI skips any session file whose modification date predates the start
+      of the month (a file cannot hold records newer than its own mtime), and
+      both databases push the same cut-off into SQL against the indexed time
+      column. `json_extract` does the OpenCode filtering inside the system
+      libsqlite3, so nothing extra is linked.
+- [x] **Hermes rows are bucketed by `last_seen`**, whole. Its table stores one
+      aggregate per session and model, not per call, so a session straddling
+      midnight or month end lands entirely in the bucket of its last call. That
+      is the same granularity Hermes's own `/usage` reports, and splitting it
+      would mean inventing a distribution.
+- [x] `.derived` with no budget, `.manual` once the user sets one. The ceiling
+      in Settings is in **tokens, not money**: an API key publishes no limit, and
+      prices change under an app that ships every few weeks, so a currency
+      figure would go stale silently. Either way the tooltip keeps its `~` — the
+      number is assembled here, not quoted from Google.
+- [x] Counts are compacted for the ring (`651k`, `1.1M`). A 44 pt ring cannot
+      hold seven digits, and below 10 000 the digits are printed verbatim so no
+      existing request or credit count changes.
+- [x] Busy detection watches **Gemini CLI only**, by modification date. The
+      session file holds no pid, so `ProcessLiveness` has nothing to verify, but
+      the CLI patches `lastUpdated` on every message — the same mtime substitute
+      Antigravity and Cursor use. OpenCode's and Hermes's databases are written
+      for reasons that have nothing to do with a Gemini call, so their mtimes
+      would report work that is not this provider's.
+- [x] **Two departures from the provider template**, both deliberate. The
+      protocol extension's default `signInRoute` offers to sign in, and here
+      there is nothing to sign into, so this provider overrides it with a
+      `.guidance` message saying so and saying the key is never read; the
+      default would have put a button in Settings that could only fail. And
+      `lastTools` is `nonisolated(unsafe)` behind a `nonisolated func
+      account()`, the bargain `GLMProvider.lastKnownPlan` already makes: the
+      settings row asks for the account off the actor, and the worst a race can
+      do is name yesterday's tools for one row-draw.
+- [x] **The ring first shipped with the wrong mark.** `.antigravity` draws
+      Antigravity's arch, not the Gemini sparkle — the arch is the editor's own
+      logo, and the row next to it already wears it. The sparkle was sitting in
+      `GlyphOutline.gemini`, generated and referenced by nothing since the
+      Antigravity provider took the name. It could not simply reclaim the raw
+      value `gemini`: that string is an archive key, so a new case
+      `geminiSpark = "gemini-spark"` was added instead. A `gemini-api` snapshot
+      archived before this change still decodes as the arch and draws it until
+      the next poll overwrites it; one stale ring for one refresh is not worth a
+      migration.
+- [x] **Cloud Monitoring was considered and set aside.** It really does publish
+      official per-project counters, including
+      `generate_content_usage_output_token_count`, which would be a `.official`
+      reading. It needs gcloud application-default credentials and a token
+      refresh this app does not do, and the whole design here is to borrow a
+      credential another tool already holds rather than to acquire one. Worth
+      revisiting if the app ever grows a Google sign-in for another reason.
+
 ### Choosing how much the notch shows
 
 - [x] Three modes, not the two asked for. The default is neither "always" nor

--- a/Tests/GeminiAPITests.swift
+++ b/Tests/GeminiAPITests.swift
@@ -1,0 +1,676 @@
+import SQLite3
+import XCTest
+@testable import Codenotch
+
+/// A date in the calendar the readers use, so a fixture and the `now` it is
+/// measured against cannot disagree about the zone.
+private func localDate(_ year: Int, _ month: Int, _ day: Int, hour: Int = 12) -> Date {
+    var components = DateComponents()
+    components.year = year
+    components.month = month
+    components.day = day
+    components.hour = hour
+    return GeminiTokenUsage.calendar.date(from: components)!
+}
+
+/// The three readers all funnel through `bucket`, so its edges decide whether
+/// the tooltip's rows add up to its headline.
+final class GeminiTokenUsageTests: XCTestCase {
+    private let now = localDate(2026, 9, 15)
+
+    func testAnEntryTodayCountsInBothWindows() {
+        let usage = GeminiTokenUsage.bucket(
+            [(at: localDate(2026, 9, 15, hour: 9), tokens: 1200, calls: 1)], now: now)
+        XCTAssertEqual(usage, GeminiTokenUsage(
+            tokensThisMonth: 1200, tokensToday: 1200, callsThisMonth: 1))
+    }
+
+    func testAnEntryEarlierThisMonthCountsInTheMonthOnly() {
+        let usage = GeminiTokenUsage.bucket(
+            [(at: localDate(2026, 9, 3), tokens: 1200, calls: 1)], now: now)
+        XCTAssertEqual(usage, GeminiTokenUsage(
+            tokensThisMonth: 1200, tokensToday: 0, callsThisMonth: 1))
+    }
+
+    /// Same day of a different month. Comparing days alone would file it under
+    /// "today".
+    func testAnEntryLastMonthCountsInNeither() {
+        let usage = GeminiTokenUsage.bucket(
+            [(at: localDate(2026, 8, 15), tokens: 1200, calls: 1)], now: now)
+        XCTAssertEqual(usage, GeminiTokenUsage.zero)
+    }
+
+    /// An aborted call costs nothing and is not a call.
+    func testAZeroTokenEntryAddsNoCall() {
+        let usage = GeminiTokenUsage.bucket([
+            (at: now, tokens: 0, calls: 1),
+            (at: now, tokens: 300, calls: 1)
+        ], now: now)
+        XCTAssertEqual(usage, GeminiTokenUsage(
+            tokensThisMonth: 300, tokensToday: 300, callsThisMonth: 1))
+    }
+
+    func testStartOfMonthIsLocalMidnightOnTheFirst() {
+        XCTAssertEqual(GeminiTokenUsage.startOfMonth(now: now), localDate(2026, 9, 1, hour: 0))
+    }
+
+    func testAddingSumsEveryWindow() {
+        let first = GeminiTokenUsage(tokensThisMonth: 10, tokensToday: 4, callsThisMonth: 1)
+        let second = GeminiTokenUsage(tokensThisMonth: 5, tokensToday: 5, callsThisMonth: 2)
+        XCTAssertEqual(first.adding(second), GeminiTokenUsage(
+            tokensThisMonth: 15, tokensToday: 9, callsThisMonth: 3))
+    }
+}
+
+/// Fixtures follow the real recording: a header line, records written twice,
+/// and the patches the CLI appends between them.
+final class GeminiCLIUsageTests: XCTestCase {
+    private var root: URL!
+    private let now = localDate(2026, 9, 15)
+
+    override func setUpWithError() throws {
+        root = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("gemini-cli-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: root)
+    }
+
+    /// The modification date is set explicitly because the reader skips files
+    /// older than the month under test, and the machine's own clock is not the
+    /// `now` these tests measure against.
+    private func write(
+        _ lines: [String],
+        project: String = "9d2c",
+        name: String = "session-a",
+        modified: Date? = nil
+    ) throws {
+        let chats = root.appendingPathComponent("\(project)/chats")
+        try FileManager.default.createDirectory(at: chats, withIntermediateDirectories: true)
+        let file = chats.appendingPathComponent("\(name).jsonl")
+        try lines.joined(separator: "\n").write(to: file, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes(
+            [.modificationDate: modified ?? now], ofItemAtPath: file.path)
+    }
+
+    private func stamp(_ date: Date) -> String {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        formatter.timeZone = TimeZone(identifier: "UTC")!
+        return formatter.string(from: date)
+    }
+
+    private func gemini(_ id: String, at: Date, total: Int?) -> String {
+        let tokens = total.map {
+            #","tokens":{"input":11,"output":7,"cached":4,"thoughts":2,"tool":0,"total":\#($0)}"#
+        } ?? ""
+        return #"{"id":"\#(id)","timestamp":"\#(stamp(at))","type":"gemini","#
+            + #""model":"gemini-2.5-pro","content":"ok"\#(tokens)}"#
+    }
+
+    private let header = #"{"sessionId":"6f0a","projectHash":"9d2c","#
+        + #""startTime":"2026-09-15T09:12:33.104Z","#
+        + #""lastUpdated":"2026-09-15T09:41:02.881Z","kind":"main"}"#
+
+    /// The CLI appends the same record twice, once when the turn starts and
+    /// once when `usageMetadata` arrives. Counting lines would bill it twice.
+    func testTheSameRecordAppendedTwiceCountsOnce() throws {
+        try write([
+            header,
+            gemini("c7f2", at: now, total: 1200),
+            gemini("c7f2", at: now, total: 1200)
+        ])
+        XCTAssertEqual(GeminiCLIUsage.read(root: root, now: now), GeminiTokenUsage(
+            tokensThisMonth: 1200, tokensToday: 1200, callsThisMonth: 1))
+    }
+
+    /// Everything the file holds besides an answered call, including the
+    /// `$rewindTo` marker: the rewound call was still billed, but it is counted
+    /// through its own record, never through the marker.
+    func testItIgnoresHeadersPatchesAndAnythingUnparsable() throws {
+        try write([
+            header,
+            gemini("c7f2", at: now, total: nil),
+            #"{"id":"u1","timestamp":"\#(stamp(now))","type":"user","content":"hi"}"#,
+            #"{"$set":{"lastUpdated":"2026-09-15T09:41:02.881Z"}}"#,
+            #"{"$rewindTo":"c7f2"}"#,
+            "not json at all",
+            gemini("d3a9", at: now, total: 500)
+        ])
+        XCTAssertEqual(GeminiCLIUsage.read(root: root, now: now), GeminiTokenUsage(
+            tokensThisMonth: 500, tokensToday: 500, callsThisMonth: 1))
+    }
+
+    /// `model` is missing, `null` or `"auto"` depending on how the turn was
+    /// routed; none of that says anything about whether it was billed.
+    func testARecordWithANullModelStillCounts() throws {
+        try write([
+            header,
+            #"{"id":"c7f2","timestamp":"\#(stamp(now))","type":"gemini","model":null,"#
+                + #""tokens":{"input":11,"output":7,"cached":4,"thoughts":2,"tool":0,"total":900}}"#
+        ])
+        XCTAssertEqual(GeminiCLIUsage.read(root: root, now: now), GeminiTokenUsage(
+            tokensThisMonth: 900, tokensToday: 900, callsThisMonth: 1))
+    }
+
+    func testItSeparatesTodayFromTheRestOfTheMonthAndDropsLastMonth() throws {
+        try write([
+            header,
+            gemini("a", at: localDate(2026, 9, 15, hour: 8), total: 100),
+            gemini("b", at: localDate(2026, 9, 3), total: 200),
+            gemini("c", at: localDate(2026, 8, 28), total: 400)
+        ])
+        XCTAssertEqual(GeminiCLIUsage.read(root: root, now: now), GeminiTokenUsage(
+            tokensThisMonth: 300, tokensToday: 100, callsThisMonth: 2))
+    }
+
+    /// The pre-filter is what keeps the scan cheap after months of sessions,
+    /// and it is only sound because the file is append-only.
+    func testAFileLastWrittenBeforeThisMonthIsNotEvenOpened() throws {
+        try write([header, gemini("c7f2", at: now, total: 1200)],
+                  modified: localDate(2026, 8, 20))
+        XCTAssertEqual(GeminiCLIUsage.read(root: root, now: now), GeminiTokenUsage.zero)
+    }
+
+    /// "Never installed" is not "spent nothing": the provider drops the row for
+    /// the first and shows a zero for the second.
+    func testAMissingRootReadsAsNil() {
+        let missing = root.appendingPathComponent("nowhere")
+        XCTAssertNil(GeminiCLIUsage.read(root: missing, now: now))
+    }
+
+    func testAProjectWithoutChatsReadsAsZero() throws {
+        try FileManager.default.createDirectory(
+            at: root.appendingPathComponent("9d2c"), withIntermediateDirectories: true)
+        XCTAssertEqual(GeminiCLIUsage.read(root: root, now: now), GeminiTokenUsage.zero)
+    }
+}
+
+/// Fixtures carry OpenCode's real `message` shape, because the reader asks
+/// SQLite to reach into the JSON and a wrong nesting would silently read zero.
+final class OpenCodeGeminiUsageTests: XCTestCase {
+    private let now = localDate(2026, 9, 15)
+    private var databases: [URL] = []
+
+    override func tearDownWithError() throws {
+        for url in databases { try? FileManager.default.removeItem(at: url) }
+        databases = []
+    }
+
+    /// Written and closed before the reader opens it, so the WAL is
+    /// checkpointed away — the same state a quit OpenCode leaves behind.
+    private func makeDatabase(rows: [(created: Date, data: String)]) throws -> URL {
+        let url = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("opencode-\(UUID().uuidString).db")
+        databases.append(url)
+
+        var db: OpaquePointer?
+        XCTAssertEqual(sqlite3_open(url.path, &db), SQLITE_OK)
+        sqlite3_exec(db, "PRAGMA journal_mode=WAL;", nil, nil, nil)
+        sqlite3_exec(db, """
+        CREATE TABLE message (id TEXT, session_id TEXT, time_created INTEGER,
+                              time_updated INTEGER, data TEXT);
+        """, nil, nil, nil)
+        for (index, row) in rows.enumerated() {
+            let milliseconds = Int(row.created.timeIntervalSince1970 * 1000)
+            sqlite3_exec(db, """
+            INSERT INTO message VALUES ('m\(index)', 's1', \(milliseconds), \(milliseconds),
+                                        '\(row.data)');
+            """, nil, nil, nil)
+        }
+        sqlite3_close(db)
+        return url
+    }
+
+    private func message(
+        provider: String = "google",
+        role: String = "assistant",
+        total: Int? = nil,
+        input: Int = 0,
+        output: Int = 0,
+        reasoning: Int = 0,
+        read: Int = 0,
+        write: Int = 0
+    ) -> String {
+        let totalField = total.map { #","total":\#($0)"# } ?? ""
+        return #"{"role":"\#(role)","providerID":"\#(provider)","modelID":"gemini-2.5-pro","#
+            + #""tokens":{"input":\#(input),"output":\#(output),"reasoning":\#(reasoning),"#
+            + #""cache":{"read":\#(read),"write":\#(write)}\#(totalField)},"cost":0.0}"#
+    }
+
+    func testAnAnsweredCallTodayCountsInBothWindows() throws {
+        let url = try makeDatabase(rows: [(now, message(total: 1200, input: 900, output: 300))])
+        XCTAssertEqual(OpenCodeGeminiUsage.read(database: url, now: now), GeminiTokenUsage(
+            tokensThisMonth: 1200, tokensToday: 1200, callsThisMonth: 1))
+    }
+
+    func testACallEarlierThisMonthCountsInTheMonthOnly() throws {
+        let url = try makeDatabase(rows: [(localDate(2026, 9, 3), message(total: 200))])
+        XCTAssertEqual(OpenCodeGeminiUsage.read(database: url, now: now), GeminiTokenUsage(
+            tokensThisMonth: 200, tokensToday: 0, callsThisMonth: 1))
+    }
+
+    /// The SQL pre-filter on `time_created` is what makes the read cheap, so
+    /// last month has to be gone before the JSON is ever extracted.
+    func testACallLastMonthIsNotCounted() throws {
+        let url = try makeDatabase(rows: [(localDate(2026, 8, 28), message(total: 400))])
+        XCTAssertEqual(OpenCodeGeminiUsage.read(database: url, now: now), GeminiTokenUsage.zero)
+    }
+
+    /// The prompt is a row of its own and carries no tokens of its own; only
+    /// the assistant's reply records what the API charged for the pair.
+    func testAUserRowIsNotCounted() throws {
+        let url = try makeDatabase(rows: [(now, message(role: "user", total: 1200))])
+        XCTAssertEqual(OpenCodeGeminiUsage.read(database: url, now: now), GeminiTokenUsage.zero)
+    }
+
+    /// OpenCode talks to several providers out of one database, and only
+    /// `google` is the Gemini API key this ring is about.
+    func testAnotherProvidersRowIsNotCounted() throws {
+        let url = try makeDatabase(rows: [(now, message(provider: "lmstudio", total: 1200))])
+        XCTAssertEqual(OpenCodeGeminiUsage.read(database: url, now: now), GeminiTokenUsage.zero)
+    }
+
+    /// A message aborted before the model answered: every counter zero and no
+    /// `total` at all. It was not billed, so it is not a call.
+    func testAnAbortedMessageAddsNoCall() throws {
+        let url = try makeDatabase(rows: [(now, message())])
+        XCTAssertEqual(OpenCodeGeminiUsage.read(database: url, now: now), GeminiTokenUsage.zero)
+    }
+
+    /// The real row that fixes the sum: `input` excludes the cache, so only
+    /// adding `cache.read` back reproduces the `total` OpenCode itself wrote.
+    func testWithoutATotalTheComponentsIncludeTheCache() throws {
+        let url = try makeDatabase(rows: [
+            (now, message(input: 2834, output: 51, reasoning: 17, read: 93106, write: 0))
+        ])
+        XCTAssertEqual(OpenCodeGeminiUsage.read(database: url, now: now), GeminiTokenUsage(
+            tokensThisMonth: 96008, tokensToday: 96008, callsThisMonth: 1))
+    }
+
+    /// "Never installed" is not "spent nothing".
+    func testAMissingDatabaseReadsAsNil() {
+        let missing = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("opencode-\(UUID().uuidString).db")
+        XCTAssertNil(OpenCodeGeminiUsage.read(database: missing, now: now))
+    }
+}
+
+/// Fixtures carry Hermes's real `session_model_usage` columns, because the
+/// reader adds four of them together in SQL and a renamed column would sum to
+/// nothing without failing.
+final class HermesGeminiUsageTests: XCTestCase {
+    private let now = localDate(2026, 9, 15)
+    private var databases: [URL] = []
+
+    override func tearDownWithError() throws {
+        for url in databases { try? FileManager.default.removeItem(at: url) }
+        databases = []
+    }
+
+    /// One row of `session_model_usage`, defaulted to the shape the reader is
+    /// looking for so each test states only what it is about.
+    private struct Row {
+        var lastSeen: Date
+        var provider = "gemini"
+        var input = 0
+        var output = 0
+        var cacheRead = 0
+        var cacheWrite = 0
+        var reasoning = 0
+        var calls = 1
+    }
+
+    /// Written and closed before the reader opens it, so the WAL is
+    /// checkpointed away — the same state a quit Hermes leaves behind. The
+    /// foreign key to `sessions` is dropped because the reader never joins.
+    private func makeDatabase(rows: [Row]) throws -> URL {
+        let url = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("hermes-\(UUID().uuidString).db")
+        databases.append(url)
+
+        var db: OpaquePointer?
+        XCTAssertEqual(sqlite3_open(url.path, &db), SQLITE_OK)
+        sqlite3_exec(db, "PRAGMA journal_mode=WAL;", nil, nil, nil)
+        sqlite3_exec(db, """
+        CREATE TABLE session_model_usage (
+            session_id TEXT NOT NULL, model TEXT NOT NULL,
+            billing_provider TEXT NOT NULL DEFAULT '',
+            billing_base_url TEXT NOT NULL DEFAULT '',
+            billing_mode TEXT NOT NULL DEFAULT '', task TEXT NOT NULL DEFAULT '',
+            api_call_count INTEGER NOT NULL DEFAULT 0,
+            input_tokens INTEGER NOT NULL DEFAULT 0,
+            output_tokens INTEGER NOT NULL DEFAULT 0,
+            cache_read_tokens INTEGER NOT NULL DEFAULT 0,
+            cache_write_tokens INTEGER NOT NULL DEFAULT 0,
+            reasoning_tokens INTEGER NOT NULL DEFAULT 0,
+            estimated_cost_usd REAL NOT NULL DEFAULT 0,
+            actual_cost_usd REAL NOT NULL DEFAULT 0,
+            cost_status TEXT, cost_source TEXT, first_seen REAL, last_seen REAL);
+        """, nil, nil, nil)
+        for (index, row) in rows.enumerated() {
+            let seen = row.lastSeen.timeIntervalSince1970
+            sqlite3_exec(db, """
+            INSERT INTO session_model_usage VALUES (
+                's\(index)', 'gemini-2.5-pro', '\(row.provider)',
+                'https://generativelanguage.googleapis.com/v1beta', 'api-key', '',
+                \(row.calls), \(row.input), \(row.output), \(row.cacheRead),
+                \(row.cacheWrite), \(row.reasoning), 0, 0, 'estimated', 'table',
+                \(seen), \(seen));
+            """, nil, nil, nil)
+        }
+        sqlite3_close(db)
+        return url
+    }
+
+    /// Hermes counts reasoning inside `output_tokens`, so the row's own
+    /// `reasoning_tokens` must not be added on top: 100 + 50 + 5 + 20 = 175,
+    /// not 182. `api_call_count` is the row's own tally, because one row is a
+    /// whole session rather than a single call.
+    func testASessionTodayCountsInBothWindowsAndExcludesReasoning() throws {
+        let url = try makeDatabase(rows: [
+            Row(lastSeen: now, input: 100, output: 20, cacheRead: 50,
+                cacheWrite: 5, reasoning: 7, calls: 3)
+        ])
+        XCTAssertEqual(HermesGeminiUsage.read(database: url, now: now), GeminiTokenUsage(
+            tokensThisMonth: 175, tokensToday: 175, callsThisMonth: 3))
+    }
+
+    func testASessionEarlierThisMonthCountsInTheMonthOnly() throws {
+        let url = try makeDatabase(rows: [Row(lastSeen: localDate(2026, 9, 3), input: 200)])
+        XCTAssertEqual(HermesGeminiUsage.read(database: url, now: now), GeminiTokenUsage(
+            tokensThisMonth: 200, tokensToday: 0, callsThisMonth: 1))
+    }
+
+    /// The SQL pre-filter on `last_seen` is what makes the read cheap, so last
+    /// month has to be gone before the sum is ever computed.
+    func testASessionLastMonthIsNotCounted() throws {
+        let url = try makeDatabase(rows: [Row(lastSeen: localDate(2026, 8, 28), input: 400)])
+        XCTAssertEqual(HermesGeminiUsage.read(database: url, now: now), GeminiTokenUsage.zero)
+    }
+
+    /// Hermes routes to several providers out of one table, and only `gemini`
+    /// is Google AI Studio, which is the API key this ring is about.
+    func testAnotherProvidersSessionIsNotCounted() throws {
+        let url = try makeDatabase(rows: [
+            Row(lastSeen: now, provider: "lmstudio", input: 100, output: 20)
+        ])
+        XCTAssertEqual(HermesGeminiUsage.read(database: url, now: now), GeminiTokenUsage.zero)
+    }
+
+    /// "Never installed" is not "spent nothing".
+    func testAMissingDatabaseReadsAsNil() {
+        let missing = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("hermes-\(UUID().uuidString).db")
+        XCTAssertNil(HermesGeminiUsage.read(database: missing, now: now))
+    }
+
+    /// Installed but never pointed at Gemini: a real reading of nothing, which
+    /// the provider shows as a zero row rather than dropping.
+    func testAnEmptyTableReadsAsZero() throws {
+        let url = try makeDatabase(rows: [])
+        XCTAssertEqual(HermesGeminiUsage.read(database: url, now: now), GeminiTokenUsage.zero)
+    }
+}
+
+/// What the ring means and what the tooltip lists, which is the whole visible
+/// surface of a provider that never calls anything.
+final class GeminiAPISnapshotTests: XCTestCase {
+    private let now = localDate(2026, 9, 15)
+
+    private func source(
+        _ id: String, _ name: String, month: Int, today: Int = 0
+    ) -> GeminiTokenSource {
+        GeminiTokenSource(id: id, name: name, usage: GeminiTokenUsage(
+            tokensThisMonth: month, tokensToday: today, callsThisMonth: 1))
+    }
+
+    /// Every tool's row is listed after the two totals, in the order the
+    /// provider reads them, so the tooltip does not reshuffle between refreshes.
+    func testTwoSourcesAddUpIntoTheMonthAndTodayWindows() {
+        let snapshot = GeminiAPIProvider.snapshot(
+            sources: [
+                source("cli", "Gemini CLI", month: 400_000, today: 12_000),
+                source("opencode", "OpenCode", month: 251_061, today: 3_000)
+            ],
+            budget: nil,
+            now: now
+        )
+        XCTAssertEqual(snapshot.windows.map(\.id), ["month", "today", "cli", "opencode"])
+        XCTAssertEqual(snapshot.headlineID, "month")
+        // The sparkle, not Antigravity's arch, which the neighbouring row wears.
+        XCTAssertEqual(snapshot.glyph, .geminiSpark)
+        XCTAssertEqual(snapshot.headline?.used, 651_061)
+        XCTAssertEqual(snapshot.windows[1].used, 15_000)
+        XCTAssertEqual(snapshot.windows[2].label, "Gemini CLI · this month")
+        XCTAssertEqual(snapshot.windows[2].used, 400_000)
+        XCTAssertEqual(snapshot.windows[3].used, 251_061)
+    }
+
+    /// Without a budget there is no denominator to draw a ring against, and
+    /// inventing one would put a limit on a key Google does not limit.
+    func testWithoutABudgetTheMonthWindowHasNoFraction() {
+        let snapshot = GeminiAPIProvider.snapshot(
+            sources: [source("cli", "Gemini CLI", month: 651_061)], budget: nil, now: now)
+        XCTAssertEqual(snapshot.fidelity, .derived)
+        XCTAssertNil(snapshot.headline?.usedFraction)
+        XCTAssertTrue(snapshot.windows[0].label.contains("no limit"))
+        XCTAssertEqual(snapshot.headlineText, "651k")
+    }
+
+    /// The ceiling is the user's, not Google's, which is what `.manual` says.
+    func testABudgetFillsTheRingAndTurnsTheReadingManual() throws {
+        let snapshot = GeminiAPIProvider.snapshot(
+            sources: [source("cli", "Gemini CLI", month: 651_061)],
+            budget: 2_000_000,
+            now: now
+        )
+        XCTAssertEqual(snapshot.fidelity, .manual)
+        XCTAssertEqual(try XCTUnwrap(snapshot.headline?.usedFraction), 0.3255, accuracy: 0.0001)
+        XCTAssertTrue(snapshot.windows[0].label.contains("2.0M"),
+                      "budget label was \(snapshot.windows[0].label)")
+    }
+
+    /// Zero is how the settings field reads "none", and dividing by it would
+    /// draw an infinite ring.
+    func testABudgetOfZeroReadsAsNoBudget() {
+        let snapshot = GeminiAPIProvider.snapshot(
+            sources: [source("cli", "Gemini CLI", month: 651_061)], budget: 0, now: now)
+        XCTAssertEqual(snapshot.fidelity, .derived)
+        XCTAssertNil(snapshot.headline?.usedFraction)
+    }
+
+    /// The month rolls over at the end of the month it is counting, not at the
+    /// start of it.
+    func testTheMonthWindowResetsAfterNow() throws {
+        let snapshot = GeminiAPIProvider.snapshot(
+            sources: [source("cli", "Gemini CLI", month: 10)], budget: nil, now: now)
+        XCTAssertEqual(try XCTUnwrap(snapshot.headline?.resetsAt),
+                       localDate(2026, 10, 1, hour: 0))
+        XCTAssertEqual(try XCTUnwrap(snapshot.windows[1].resetsAt),
+                       localDate(2026, 9, 16, hour: 0))
+    }
+
+    func testTheAccountNamesTheKeyAndTheToolsItWasReadFrom() {
+        let account = GeminiAPICredentials.account(
+            tools: ["Gemini CLI", "OpenCode"], authType: "gemini-api-key")
+        XCTAssertEqual(account?.label, "API key")
+        XCTAssertEqual(account?.plan, "metered")
+        XCTAssertEqual(account?.source, "Gemini CLI, OpenCode")
+    }
+
+    /// The free login is a quota, not a bill; calling it metered would put a
+    /// price on it.
+    func testAGoogleAccountLoginIsNotMetered() {
+        let account = GeminiAPICredentials.account(
+            tools: ["Gemini CLI"], authType: "oauth-personal")
+        XCTAssertEqual(account?.label, "Google account")
+        XCTAssertNil(account?.plan)
+    }
+
+    /// No log means no account to describe, not an empty one.
+    func testNoToolsMeansNoAccount() {
+        XCTAssertNil(GeminiAPICredentials.account(tools: [], authType: "gemini-api-key"))
+    }
+
+    func testTheAuthTypeIsReadFromTheCLISettings() throws {
+        let file = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("gemini-settings-\(UUID().uuidString).json")
+        defer { try? FileManager.default.removeItem(at: file) }
+        try #"{"security":{"auth":{"selectedType":"gemini-api-key"}}}"#
+            .write(to: file, atomically: true, encoding: .utf8)
+        XCTAssertEqual(GeminiAPICredentials.authType(at: file), "gemini-api-key")
+    }
+
+    /// The label is a courtesy; a guessed one would be worse than none.
+    func testAMissingSettingsFileHasNoAuthType() {
+        let missing = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("gemini-settings-\(UUID().uuidString).json")
+        XCTAssertNil(GeminiAPICredentials.authType(at: missing))
+    }
+
+    private func missingPath(_ name: String) -> URL {
+        URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("\(name)-\(UUID().uuidString)")
+    }
+
+    /// None of the three tools installed is not an error and not a missing
+    /// sign-in — there is nothing being metered, and the row says so.
+    func testNoToolAtAllIsReportedAsNothingMetered() async {
+        let provider = GeminiAPIProvider(
+            cliRoot: missingPath("gemini-cli"),
+            openCodeDatabase: missingPath("opencode.db"),
+            hermesDatabase: missingPath("hermes.db"),
+            settingsFile: missingPath("settings.json"),
+            budget: { nil }
+        )
+        do {
+            _ = try await provider.fetchSnapshot()
+            XCTFail("expected nothingMetered")
+        } catch UsageProviderError.nothingMetered(let why) {
+            XCTAssertTrue(why.contains("Gemini CLI"), "message was \(why)")
+        } catch {
+            XCTFail("expected nothingMetered, got \(error)")
+        }
+    }
+
+    /// One tool installed gets one row. A zero for OpenCode and Hermes would
+    /// claim they had been asked and had spent nothing.
+    func testOnlyTheInstalledToolGetsARow() async throws {
+        let root = missingPath("gemini-cli")
+        let chats = root.appendingPathComponent("9d2c/chats")
+        try FileManager.default.createDirectory(at: chats, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        // `fetchSnapshot` reads the real clock, so the record is stamped now
+        // rather than at the fixed date the pure tests use.
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        formatter.timeZone = TimeZone(identifier: "UTC")!
+        let line = #"{"id":"c7f2","timestamp":"\#(formatter.string(from: Date()))","type":"gemini","#
+            + #""tokens":{"input":11,"output":7,"cached":4,"thoughts":2,"tool":0,"total":1200}}"#
+        try line.write(to: chats.appendingPathComponent("session-a.jsonl"),
+                       atomically: true, encoding: .utf8)
+
+        let provider = GeminiAPIProvider(
+            cliRoot: root,
+            openCodeDatabase: missingPath("opencode.db"),
+            hermesDatabase: missingPath("hermes.db"),
+            settingsFile: missingPath("settings.json"),
+            budget: { nil }
+        )
+        let snapshot = try await provider.fetchSnapshot()
+        XCTAssertEqual(snapshot.id, "gemini-api")
+        XCTAssertEqual(snapshot.windows.map(\.id), ["month", "today", "cli"])
+        XCTAssertEqual(snapshot.headline?.used, 1200)
+        // Set only once a fetch has found something, so the settings row can
+        // name the tools rather than an account nobody signed in to.
+        XCTAssertEqual(provider.account()?.source, "Gemini CLI")
+    }
+}
+
+/// Nothing in a chat recording names the process that wrote it, so how recently
+/// the file was appended to is the whole of the busy signal. Every fixture sets
+/// its own modification date: the machine's clock must not decide whether a
+/// test passes.
+@MainActor
+final class GeminiCLIActivityMonitorTests: XCTestCase {
+    private var root: URL!
+    private let now = Date(timeIntervalSince1970: 1_789_000_000)
+
+    override func setUpWithError() throws {
+        root = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("gemini-cli-monitor-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: root)
+    }
+
+    @discardableResult
+    private func session(
+        project: String,
+        name: String = "session-a",
+        projectRoot: String? = nil,
+        modified: Date
+    ) throws -> URL {
+        let directory = root.appendingPathComponent(project)
+        let chats = directory.appendingPathComponent("chats")
+        try FileManager.default.createDirectory(at: chats, withIntermediateDirectories: true)
+        if let projectRoot {
+            try projectRoot.write(to: directory.appendingPathComponent(".project_root"),
+                                  atomically: true, encoding: .utf8)
+        }
+        let file = chats.appendingPathComponent("\(name).jsonl")
+        try "{}".write(to: file, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.modificationDate: modified],
+                                              ofItemAtPath: file.path)
+        return file
+    }
+
+    func testAJustWrittenSessionReadsAsWorking() throws {
+        try session(project: "9d2c", projectRoot: "/Users/x/Projects/codenotch", modified: now)
+        let sessions = GeminiCLIActivityMonitor.read(root: root, staleAfter: 45, now: now)
+        XCTAssertEqual(sessions.count, 1)
+        XCTAssertEqual(sessions.first?.state, .busy)
+        XCTAssertEqual(sessions.first?.name, "Gemini CLI")
+        XCTAssertEqual(sessions.first?.detail, "Working in codenotch")
+        XCTAssertEqual(sessions.first?.id, "gemini-api.session-a")
+    }
+
+    /// A finished turn is not work in progress.
+    func testAnOldSessionIsNotWorking() throws {
+        try session(project: "9d2c", modified: now.addingTimeInterval(-60))
+        XCTAssertTrue(GeminiCLIActivityMonitor.read(root: root, staleAfter: 45, now: now).isEmpty)
+    }
+
+    func testNoSessionsIsQuietRatherThanAnError() {
+        let absent = root.appendingPathComponent("nowhere")
+        XCTAssertTrue(GeminiCLIActivityMonitor.read(root: absent, staleAfter: 45, now: now).isEmpty)
+    }
+
+    /// Projects accumulate under `~/.gemini/tmp`; only the newest file says what
+    /// is happening now.
+    func testTheNewestSessionWins() throws {
+        try session(project: "old", name: "session-old", projectRoot: "/Users/x/old-thing",
+                    modified: now.addingTimeInterval(-600))
+        try session(project: "live", name: "session-live", projectRoot: "/Users/x/live-thing",
+                    modified: now)
+        let sessions = GeminiCLIActivityMonitor.read(root: root, staleAfter: 45, now: now)
+        XCTAssertEqual(sessions.count, 1)
+        XCTAssertEqual(sessions.first?.id, "gemini-api.session-live")
+        XCTAssertEqual(sessions.first?.detail, "Working in live-thing")
+    }
+
+    /// Older recordings have no `.project_root` beside them. The hash is a poor
+    /// name, but it is a true one, and a missing marker must not cost the
+    /// session its row.
+    func testAMissingProjectRootFallsBackToTheDirectoryName() throws {
+        try session(project: "9d2c", modified: now)
+        let sessions = GeminiCLIActivityMonitor.read(root: root, staleAfter: 45, now: now)
+        XCTAssertEqual(sessions.first?.detail, "Working in 9d2c")
+    }
+}

--- a/Tests/NotchLayoutTests.swift
+++ b/Tests/NotchLayoutTests.swift
@@ -455,6 +455,54 @@ final class PreferencesTests: XCTestCase {
 
         XCTAssertFalse(Preferences(defaults: defaults).isConnected("cursor"))
     }
+
+    /// No ceiling is the honest default: an API key is billed per token and
+    /// publishes no limit, so the ring stays unfilled until the user names one.
+    func testTheGeminiTokenBudgetStartsUnset() {
+        XCTAssertNil(preferences().geminiAPIMonthlyTokenBudget)
+    }
+
+    func testTheGeminiTokenBudgetSurvivesARestart() {
+        let name = "PreferencesTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: name)!
+        defaults.removePersistentDomain(forName: name)
+
+        Preferences(defaults: defaults).geminiAPIMonthlyTokenBudget = 2_000_000
+
+        XCTAssertEqual(Preferences(defaults: defaults).geminiAPIMonthlyTokenBudget, 2_000_000)
+        // The provider is an actor and reads the store directly, off the main
+        // actor — so that path has to see the same value.
+        XCTAssertEqual(Preferences.storedGeminiAPIMonthlyTokenBudget(defaults: defaults),
+                       2_000_000)
+    }
+
+    /// Clearing the field has to remove the key, not leave the old ceiling
+    /// behind for the next launch to read back.
+    func testClearingTheGeminiTokenBudgetForgetsIt() {
+        let name = "PreferencesTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: name)!
+        defaults.removePersistentDomain(forName: name)
+
+        let p = Preferences(defaults: defaults)
+        p.geminiAPIMonthlyTokenBudget = 2_000_000
+        p.geminiAPIMonthlyTokenBudget = nil
+
+        XCTAssertNil(defaults.object(forKey: "geminiAPIMonthlyTokenBudget"))
+        XCTAssertNil(Preferences(defaults: defaults).geminiAPIMonthlyTokenBudget)
+    }
+
+    /// A budget of zero would divide the ring by nothing, so it reads as no
+    /// budget at all rather than as a ceiling already blown.
+    func testAZeroGeminiTokenBudgetReadsAsNone() {
+        let name = "PreferencesTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: name)!
+        defaults.removePersistentDomain(forName: name)
+
+        Preferences(defaults: defaults).geminiAPIMonthlyTokenBudget = 0
+
+        XCTAssertNil(Preferences(defaults: defaults).geminiAPIMonthlyTokenBudget)
+        XCTAssertNil(Preferences.storedGeminiAPIMonthlyTokenBudget(defaults: defaults))
+    }
 }
 
 /// Settings shows whose account each reading comes from. Not decoration: the app
@@ -580,6 +628,40 @@ final class ProviderGlyphTests: XCTestCase {
     /// The raw value is what archived readings were written under.
     func testTheRawValueSurvivesTheRename() {
         XCTAssertEqual(ProviderGlyph.antigravity.rawValue, "gemini")
+    }
+
+    /// `gemini` was taken by the arch before the sparkle needed a name, and it
+    /// is an archive key, so the sparkle got a second one rather than the two
+    /// marks trading meanings under stored readings.
+    func testTheSparkHasItsOwnRawValue() {
+        XCTAssertEqual(ProviderGlyph.geminiSpark.rawValue, "gemini-spark")
+    }
+
+    /// The dispatch is one line and pointing it at the arch would be silent —
+    /// both marks fill the box and both are one closed loop. What separates
+    /// them is where the ink reaches the edge: the spark has a point at each of
+    /// the four edge midpoints, while the arch touches the top at its apex and
+    /// is open along the bottom.
+    func testTheSparkResolvesToTheSparkleAndNotTheArch() throws {
+        let spark = ProviderGlyph.geminiSpark.outline
+        XCTAssertEqual(spark.count, 1)
+        let points = try XCTUnwrap(spark.first)
+
+        let left = try XCTUnwrap(points.min { $0.x < $1.x })
+        XCTAssertEqual(left.x, 0, accuracy: 0.01)
+        XCTAssertEqual(left.y, 0.5, accuracy: 0.01)
+
+        let right = try XCTUnwrap(points.max { $0.x < $1.x })
+        XCTAssertEqual(right.x, 1, accuracy: 0.01)
+        XCTAssertEqual(right.y, 0.5, accuracy: 0.01)
+
+        let top = try XCTUnwrap(points.min { $0.y < $1.y })
+        XCTAssertEqual(top.y, 0, accuracy: 0.01)
+        XCTAssertEqual(top.x, 0.5, accuracy: 0.01)
+
+        let bottom = try XCTUnwrap(points.max { $0.y < $1.y })
+        XCTAssertEqual(bottom.y, 1, accuracy: 0.01)
+        XCTAssertEqual(bottom.x, 0.5, accuracy: 0.01)
     }
 }
 

--- a/Tests/ResetCopyTests.swift
+++ b/Tests/ResetCopyTests.swift
@@ -138,4 +138,9 @@ final class WindowSummaryTests: XCTestCase {
         XCTAssertEqual(LimitWindow(id: "w", label: "Requests", used: 8).summary, "8 used")
         XCTAssertEqual(LimitWindow(id: "w", label: "Requests", remaining: 3).summary, "3 left")
     }
+
+    /// Only the number shortens; the wording around it does not.
+    func testALargeCountKeepsItsWording() {
+        XCTAssertEqual(LimitWindow(id: "w", label: "Tokens", used: 651_061).summary, "651k used")
+    }
 }

--- a/Tests/SnapshotTests.swift
+++ b/Tests/SnapshotTests.swift
@@ -49,6 +49,20 @@ final class SnapshotTests: XCTestCase {
         XCTAssertEqual(s.headlineText, "2")
     }
 
+    /// Token counts are seven digits wide and the ring is 44 pt; requests and
+    /// credits are small enough to stay verbatim.
+    func testLargeCountsAreCompacted() {
+        XCTAssertEqual(LimitWindow.compact(9_999), "9999")
+        XCTAssertEqual(LimitWindow.compact(651_061), "651k")
+        XCTAssertEqual(LimitWindow.compact(1_128_771), "1.1M")
+        XCTAssertEqual(LimitWindow.compact(2_000_000), "2.0M")
+    }
+
+    func testACountOnlyHeadlineIsCompacted() {
+        let s = snapshot([LimitWindow(id: "month", label: "Tokens this month", used: 651_061)])
+        XCTAssertEqual(s.headlineText, "651k")
+    }
+
     func testOnlyOfficialNumbersAreShownUnqualified() {
         XCTAssertEqual(Fidelity.official.qualifier, "")
         XCTAssertEqual(Fidelity.derived.qualifier, "~")


### PR DESCRIPTION
## Summary

A bare `GEMINI_API_KEY` is billed per token and has no usage endpoint, so this adds a `gemini-api` ring ("Gemini API", Gemini sparkle glyph) that sums the per-call token counts three local tools already record for that key:

- **Gemini CLI** — `~/.gemini/tmp/<project>/chats/session-*.jsonl` (`tokens.total` per `gemini` record; records are appended twice and deduped by `id`, `$set`/`$rewindTo` ignored)
- **OpenCode** — `~/.local/share/opencode/opencode.db`, `message.data` with `providerID == "google"` (`tokens.total`, or the component sum for aborted rows)
- **Hermes** — `~/.hermes/state.db`, `session_model_usage` with `billing_provider == "gemini"` (`input + cache_read + cache_write + output`; reasoning already sits inside output)

The key itself is never read. Windows: current local month (headline) and today, plus one row per tool that has state on disk. Fidelity is `.derived`; setting a monthly token budget in Settings turns the count into a ring fraction and flips it to `.manual`. Gemini CLI session-file mtime drives busy/idle. Counts ≥ 10k render compact (`651k`, `1.1M`).

The sparkle gets a new glyph key `gemini-spark` because the raw value `gemini` already names the Antigravity arch in archived snapshots. Design notes and the rejected Cloud Monitoring path are in `TASKS.md`.

Deliberately not done: version bump / release note (maintainer's release step), USD estimates, any network call.

Stacked on #35 (`fix-adhoc-signing-check`), whose commit this branch includes so contributors can build; rebases cleanly once #35 lands.

## Test plan

- [x] `make test` — 605 tests, 0 failures (52 new: readers against inline JSONL and WAL SQLite fixtures mirroring the real schemas, snapshot builder, budget round-trip, monitor, glyph geometry)
- [x] Readers' SQL executed read-only against real `opencode.db` and `state.db`
- [x] `make run` — Gemini API ring (sparkle) next to Antigravity (arch) and the budget field in Settings, verified visually by the author

🤖 Generated with [Claude Code](https://claude.com/claude-code)

