### PR TITLE
Let the pill be nudged along its edge with an ⌥-drag

### DIFF
--- a/Sources/App/AppDelegate.swift
+++ b/Sources/App/AppDelegate.swift
@@ -81,6 +81,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             // this, every launch on any other edge opens with a flash of the
             // right-hand one and then crossfades away from it.
             controller.model.edge = preferences.notchEdge
+            controller.model.alongOffset = preferences.offset(for: preferences.notchEdge)
 
             let updater = Updater()
             self.updater = updater
@@ -143,8 +144,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
             preferences.$notchEdge
                 .receive(on: RunLoop.main)
-                .sink { [weak controller] in controller?.apply(edge: $0) }
+                .sink { [weak controller, weak preferences] edge in
+                    // Read before `apply(edge:)` moves the panel, so the new
+                    // edge's own remembered nudge is what it lands at rather
+                    // than the old edge's carried over onto it.
+                    controller?.model.alongOffset = preferences?.offset(for: edge) ?? 0
+                    controller?.apply(edge: edge)
+                }
                 .store(in: &cancellables)
+
+            controller.onReposition = { [weak preferences] offset in
+                preferences?.setOffset(offset, for: preferences?.notchEdge ?? .right)
+            }
 
             preferences.$disconnectedProviders
                 .receive(on: RunLoop.main)

--- a/Sources/Notch/NotchGeometry.swift
+++ b/Sources/Notch/NotchGeometry.swift
@@ -61,7 +61,23 @@ enum NotchGeometry {
     static func panelFrame(
         for screen: ScreenDescribing,
         panelSize: CGSize,
-        edge: NotchEdge = .right
+        edge: NotchEdge = .right,
+        // A user-chosen nudge along the edge, from `NotchViewModel.alongOffset`
+        // — zero is the centred default this file always drew before the nudge
+        // existed. Vertical edges read it as AppKit's y running *down* the
+        // screen (dragging the pill down increases it); horizontal edges read
+        // it as x running right, which needs no such flip.
+        alongOffset: CGFloat = 0,
+        // The padding `panelSize` carries on *each* end beyond the visible
+        // pill, reserved for a hover card that is not there right now —
+        // `NotchViewModel.slack`. Clamping the offset by the padded size
+        // would have left the pill only a sliver of room to move in on most
+        // screens, since that padding is sized for the tallest possible card
+        // and can be most of the panel. Clamping by the pill's own extent
+        // instead — `panelSize` shrunk by this on each end — lets it travel
+        // almost the full edge; the padding is free to run past the bezel,
+        // since nothing is drawn there until a card actually opens.
+        slack: CGFloat = 0
     ) -> CGRect {
         let full = screen.frameValue
         let usable = screen.visibleFrameValue
@@ -71,9 +87,13 @@ enum NotchGeometry {
         let origin: CGPoint
         switch edge {
         case .right:
-            origin = CGPoint(x: usable.maxX - width, y: full.midY - height / 2)
+            let y = clamp(full.midY - height / 2 - alongOffset,
+                          min: full.minY - slack, max: full.maxY - height + slack)
+            origin = CGPoint(x: usable.maxX - width, y: y)
         case .left:
-            origin = CGPoint(x: usable.minX, y: full.midY - height / 2)
+            let y = clamp(full.midY - height / 2 - alongOffset,
+                          min: full.minY - slack, max: full.maxY - height + slack)
+            origin = CGPoint(x: usable.minX, y: y)
         case .top:
             // AppKit's y grows upward, so the top edge is `maxY`.
             //
@@ -83,9 +103,13 @@ enum NotchGeometry {
             // is nothing to merge with, covering the menu bar buys nothing, so
             // it stays below it.
             let top = screen.hardwareNotch == nil ? usable.maxY : full.maxY
-            origin = CGPoint(x: full.midX - width / 2, y: top - height)
+            let x = clamp(full.midX - width / 2 + alongOffset,
+                          min: full.minX - slack, max: full.maxX - width + slack)
+            origin = CGPoint(x: x, y: top - height)
         case .bottom:
-            origin = CGPoint(x: full.midX - width / 2, y: usable.minY)
+            let x = clamp(full.midX - width / 2 + alongOffset,
+                          min: full.minX - slack, max: full.maxX - width + slack)
+            origin = CGPoint(x: x, y: usable.minY)
         }
 
         return CGRect(
@@ -94,6 +118,15 @@ enum NotchGeometry {
             width: width,
             height: height
         )
+    }
+
+    /// Keeps a dragged offset from pushing the visible pill off the screen it
+    /// is on. A plain `ClosedRange` clamp would trap if the pill were ever
+    /// taller or wider than the screen, which a very small display could
+    /// make true.
+    private static func clamp(_ value: CGFloat, min lo: CGFloat, max hi: CGFloat) -> CGFloat {
+        guard lo <= hi else { return lo }
+        return Swift.min(Swift.max(value, lo), hi)
     }
 
     /// The notch follows the screen with the menu bar.

--- a/Sources/Notch/NotchPanel.swift
+++ b/Sources/Notch/NotchPanel.swift
@@ -12,6 +12,13 @@ final class NotchPanel: NSPanel {
     /// A left click on the visible chrome. Handled here for the same reason the
     /// menu is: the hit test lands on a SwiftUI subview that may consume it.
     var onClick: (() -> Void)?
+    /// ⌥-drag on the chrome, reported as the raw pointer delta since the last
+    /// event — not a cumulative offset, so the caller decides what "along the
+    /// edge" means for the current one. Chosen over a plain click-and-hold
+    /// threshold so an ordinary click never risks being read as a tiny nudge.
+    var onDrag: ((CGFloat, CGFloat) -> Void)?
+    /// The ⌥-drag ended. Where to persist the offset the drags above moved to.
+    var onDragEnd: (() -> Void)?
 
     override func sendEvent(_ event: NSEvent) {
         guard event.type == .rightMouseDown,
@@ -28,7 +35,30 @@ final class NotchPanel: NSPanel {
         guard let view = contentView, view.hitTest(event.locationInWindow) != nil else {
             return super.mouseDown(with: event)
         }
-        onClick?()
+        guard event.modifierFlags.contains(.option), onDrag != nil else {
+            onClick?()
+            return
+        }
+        trackOptionDrag()
+    }
+
+    /// Blocks on this window's own event stream until the button lifts, the
+    /// standard AppKit pattern for a custom drag started from `mouseDown`.
+    /// Never falls through to `onClick` on release: an ⌥-drag is a distinct
+    /// gesture from the start, not a click that grew into one, so there is
+    /// nothing to reinterpret once the button comes up.
+    private func trackOptionDrag() {
+        while let event = nextEvent(matching: [.leftMouseDragged, .leftMouseUp]) {
+            switch event.type {
+            case .leftMouseDragged:
+                onDrag?(event.deltaX, event.deltaY)
+            case .leftMouseUp:
+                onDragEnd?()
+                return
+            default:
+                return
+            }
+        }
     }
 
     init(contentRect: NSRect) {

--- a/Sources/Notch/NotchViewModel.swift
+++ b/Sources/Notch/NotchViewModel.swift
@@ -40,6 +40,12 @@ final class NotchViewModel: ObservableObject {
     /// Which screen edge the notch is welded to. Everything geometric reads
     /// this through `placement` rather than assuming an axis.
     @Published var edge: NotchEdge = .right
+    /// A user-chosen nudge along that edge, in screen points from the centred
+    /// default — set live while ⌥-dragging the pill, and by
+    /// `NotchGeometry.panelFrame` from there. Reset to whatever was stored for
+    /// the new edge whenever `edge` changes; this type does not own that
+    /// persistence, only the live value.
+    @Published var alongOffset: CGFloat = 0
     /// The display's own notch, when this edge has to share the bezel with one.
     ///
     /// Set by the window controller from the screen the panel is on, because

--- a/Sources/Notch/NotchWindowController.swift
+++ b/Sources/Notch/NotchWindowController.swift
@@ -23,6 +23,10 @@ final class NotchWindowController {
     var onRefreshProvider: ((String) -> Void)?
     /// Open the settings window, asked for by clicking the handle.
     var onOpenSettings: (() -> Void)?
+    /// An ⌥-drag on the pill settled at a new `model.alongOffset`. The
+    /// controller only holds the live value; persisting it per edge is
+    /// Preferences' job, the same division `apply(edge:)` already keeps.
+    var onReposition: ((CGFloat) -> Void)?
 
     private var panel: NotchPanel?
     private var hostingView: NotchHostingView<NotchRootView>?
@@ -100,7 +104,10 @@ final class NotchWindowController {
         guard let screen = NotchGeometry.preferredScreen(from: NSScreen.screens) else { return }
         model.adopt(screen: screen)
         let size = model.panelSize(cellCount: cellCount ?? model.snapshots.count)
-        let frame = NotchGeometry.panelFrame(for: screen, panelSize: size, edge: model.edge)
+        let frame = NotchGeometry.panelFrame(
+            for: screen, panelSize: size, edge: model.edge,
+            alongOffset: model.alongOffset, slack: model.slack
+        )
         lastVisibleFrame = screen.visibleFrame
 
         if let panel {
@@ -110,6 +117,11 @@ final class NotchWindowController {
             let hosting = NotchHostingView(rootView: NotchRootView(model: model))
             panel.contextMenuProvider = { [weak self] in self?.contextMenu() }
             panel.onClick = { [weak self] in self?.handleClick() }
+            panel.onDrag = { [weak self] dx, dy in self?.dragged(dx: dx, dy: dy) }
+            panel.onDragEnd = { [weak self] in
+                guard let self else { return }
+                self.onReposition?(self.model.alongOffset)
+            }
 
             // The hosting view goes *inside* a plain container rather than
             // being the content view itself.
@@ -142,6 +154,22 @@ final class NotchWindowController {
             Log.usage.debug("panel \(NSStringFromRect(panel.frame), privacy: .public) on screen \(NSStringFromRect(screen.frame), privacy: .public)")
         }
         updateInteractiveRects()
+    }
+
+    /// Feeds a raw pointer delta from an ⌥-drag into `model.alongOffset` and
+    /// re-places the panel at once, so the pill tracks the cursor rather than
+    /// catching up once the button lifts.
+    ///
+    /// Both deltas are used as `NSEvent` reports them, unflipped: `deltaY`
+    /// positive is the pointer moving *down* the screen, `deltaX` positive is
+    /// it moving *right*. `NotchGeometry` is written to match — it subtracts
+    /// the offset from a vertical edge's y (which AppKit grows *up*, so
+    /// subtracting more moves the pill down) and adds it to a horizontal
+    /// edge's x — so no sign flip belongs here; adding one would make the
+    /// pill run away from the cursor instead of following it.
+    private func dragged(dx: CGFloat, dy: CGFloat) {
+        model.alongOffset += model.edge.isVertical ? dy : dx
+        relocate()
     }
 
     // MARK: - Hit regions

--- a/Sources/Settings/Preferences.swift
+++ b/Sources/Settings/Preferences.swift
@@ -26,6 +26,21 @@ final class Preferences: ObservableObject {
         didSet { defaults.set(notchEdge.rawValue, forKey: Keys.edge) }
     }
 
+    /// Where along that edge the notch sits, nudged from the centred default
+    /// by ⌥-dragging the pill. One value per edge — moving it on the right
+    /// should not silently relocate it on the top too — so this is read and
+    /// written through `offset(for:)`/`setOffset(_:for:)` rather than exposed
+    /// as a single published value the way the other settings are.
+    func offset(for edge: NotchEdge) -> CGFloat {
+        CGFloat(defaults.double(forKey: Self.offsetKey(for: edge)))
+    }
+
+    func setOffset(_ offset: CGFloat, for edge: NotchEdge) {
+        defaults.set(Double(offset), forKey: Self.offsetKey(for: edge))
+    }
+
+    private static func offsetKey(for edge: NotchEdge) -> String { "notchOffset.\(edge.rawValue)" }
+
     /// Where the app itself shows up: Dock, menu bar, or nowhere.
     @Published var appPresence: AppPresence {
         didSet { defaults.set(appPresence.rawValue, forKey: Keys.presence) }

--- a/Tests/NotchGeometryTests.swift
+++ b/Tests/NotchGeometryTests.swift
@@ -34,6 +34,79 @@ final class NotchGeometryTests: XCTestCase {
     }
 }
 
+/// `alongOffset` is how a ⌥-drag on the pill (`NotchWindowController.dragged`)
+/// nudges it off the centred default. These pin down the sign convention —
+/// get it wrong and the pill runs away from the cursor instead of following
+/// it — and the clamp that keeps a drag from pushing it off the screen.
+final class PanelOffsetTests: XCTestCase {
+    private let screen = FakeScreen(
+        frameValue: CGRect(x: 0, y: 0, width: 1800, height: 1169),
+        visibleFrameValue: CGRect(x: 0, y: 0, width: 1800, height: 1132)
+    )
+
+    func testZeroOffsetChangesNothing() {
+        let size = CGSize(width: 334, height: 484)
+        let centred = NotchGeometry.panelFrame(for: screen, panelSize: size, edge: .right)
+        let explicit = NotchGeometry.panelFrame(for: screen, panelSize: size, edge: .right, alongOffset: 0)
+        XCTAssertEqual(centred, explicit)
+    }
+
+    /// A positive offset on a side edge moves the pill *down* — the direction
+    /// `NotchWindowController.dragged` feeds it in when the pointer moves
+    /// down, since `NSEvent`'s raw delta and AppKit's y-grows-up frame origin
+    /// disagree about which way is positive.
+    func testPositiveOffsetMovesASideEdgePanelDown() {
+        let size = CGSize(width: 334, height: 484)
+        let centred = NotchGeometry.panelFrame(for: screen, panelSize: size, edge: .right)
+        let nudged = NotchGeometry.panelFrame(for: screen, panelSize: size, edge: .right, alongOffset: 100)
+        XCTAssertEqual(nudged.midY, centred.midY - 100, accuracy: 0.5)
+        // Still flush against the right-hand bezel — only the along axis moved.
+        XCTAssertEqual(nudged.maxX, centred.maxX, accuracy: 0.001)
+    }
+
+    /// A positive offset on a top/bottom edge moves the pill *right* — no sign
+    /// flip needed there, since `NSEvent.deltaX` and AppKit's x already agree.
+    func testPositiveOffsetMovesATopEdgePanelRight() {
+        let size = CGSize(width: 484, height: 120)
+        let centred = NotchGeometry.panelFrame(for: screen, panelSize: size, edge: .top)
+        let nudged = NotchGeometry.panelFrame(for: screen, panelSize: size, edge: .top, alongOffset: 100)
+        XCTAssertEqual(nudged.midX, centred.midX + 100, accuracy: 0.5)
+        XCTAssertEqual(nudged.maxY, centred.maxY, accuracy: 0.001)
+    }
+
+    /// `slack` is the padding `panelSize` carries beyond the visible pill,
+    /// reserved for a hover card that may not be open. Clamping by the full
+    /// panel — as if that padding had to stay on screen too — left almost no
+    /// room to drag on a panel sized for the worst-case card. Clamping by the
+    /// pill's own extent instead should let it travel nearly the whole edge.
+    func testAnExtremeOffsetKeepsTheVisiblePillOnScreenRatherThanThePadding() {
+        let slack = 400.0
+        let size = CGSize(width: 334, height: 900)   // mostly hover-card padding
+        let frame = NotchGeometry.panelFrame(
+            for: screen, panelSize: size, edge: .right, alongOffset: 10_000, slack: slack
+        )
+        let pillTop = frame.maxY - slack
+        let pillBottom = frame.minY + slack
+        XCTAssertLessThanOrEqual(pillTop, screen.frameValue.maxY + 0.5)
+        XCTAssertGreaterThanOrEqual(pillBottom, screen.frameValue.minY - 0.5)
+    }
+
+    /// Without `slack`'s allowance, the same drag would have clamped to
+    /// keeping the *entire* padded panel on screen — which the real bug
+    /// report was about: a handful of points of travel on a panel sized for
+    /// four providers' worth of hover card.
+    func testSlackWidensTheDraggableRangeBeyondClampingTheWholePanel() {
+        let size = CGSize(width: 334, height: 900)
+        let withoutSlack = NotchGeometry.panelFrame(
+            for: screen, panelSize: size, edge: .right, alongOffset: 10_000, slack: 0
+        )
+        let withSlack = NotchGeometry.panelFrame(
+            for: screen, panelSize: size, edge: .right, alongOffset: 10_000, slack: 400
+        )
+        XCTAssertLessThan(withSlack.minY, withoutSlack.minY)
+    }
+}
+
 /// A hairline of wallpaper down the right-hand side is all it takes for the
 /// notch to read as floating instead of welded to the bezel, and a fractional
 /// panel frame is how that happens.


### PR DESCRIPTION
## Summary

The notch is always centred on its edge, with no way to move it — which collides with any other menu-bar-adjacent app anchored to the same spot (this is what prompted the change).

- ⌥-drag on the pill now nudges it along the edge live.
- The offset is clamped so it can't be dragged off screen, and is remembered per edge (right/left/top/bottom) across restarts.
- A plain click, without ⌥, behaves exactly as before — open/pin/refresh a provider/open Settings.

## Why the clamp needed its own logic

`panelSize` budgets enough room on each end for the tallest possible hover card, so the panel itself is close to the full screen height/width on most screens. Clamping the drag by that padded size left only a handful of points of travel. The clamp now uses `NotchViewModel.slack` — the padding `panelSize` carries beyond the visible pill — so only the pill itself has to stay on screen; the invisible hover-card padding is free to run past the bezel.

## Test plan

- [x] `make test` — all 557 tests pass, including new coverage in `NotchGeometryTests.swift` for the offset's sign convention (down/right is positive) and for the slack-based clamp.
- [x] Manually verified on a MacBook: ⌥-drag on all four edges, offset persists across a relaunch and is independent per edge, plain clicks still open/pin/refresh as before.