### PR TITLE
feat: add a reset time format preference

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ At rest it is a small pill on the screen edge that unfolds when the pointer
 reaches it — configurable in Settings to always show, or to hide entirely.
 Settings live in an orb below the notch: an arc at rest, a gear on hover.
 
+In Settings → Appearance → Reset time, choose **Time remaining** for countdowns
+like "Resets in 3 Days 3h". **Automatic** keeps the reset date and time, with
+minutes shown when less than an hour remains.
+
 The app itself can show a Dock icon, a menu bar icon, or neither.
 
 ## Updates

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ reaches it — configurable in Settings to always show, or to hide entirely.
 Settings live in an orb below the notch: an arc at rest, a gear on hover.
 
 In Settings → Appearance → Reset time, choose **Time remaining** for countdowns
-like "Resets in 3 Days 3h". **Automatic** keeps the reset date and time, with
+like "Resets in 3 Days 3h". **Reset date** keeps the reset date and time, with
 minutes shown when less than an hour remains.
 
 The app itself can show a Dock icon, a menu bar icon, or neither.

--- a/Sources/App/AppDelegate.swift
+++ b/Sources/App/AppDelegate.swift
@@ -81,6 +81,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             // this, every launch on any other edge opens with a flash of the
             // right-hand one and then crossfades away from it.
             controller.model.edge = preferences.notchEdge
+            controller.model.resetTimeFormat = preferences.resetTimeFormat
 
             let updater = Updater()
             self.updater = updater
@@ -144,6 +145,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             preferences.$notchEdge
                 .receive(on: RunLoop.main)
                 .sink { [weak controller] in controller?.apply(edge: $0) }
+                .store(in: &cancellables)
+
+            preferences.$resetTimeFormat
+                .receive(on: RunLoop.main)
+                .sink { [weak controller] in controller?.model.resetTimeFormat = $0 }
                 .store(in: &cancellables)
 
             preferences.$disconnectedProviders

--- a/Sources/Features/TooltipCard.swift
+++ b/Sources/Features/TooltipCard.swift
@@ -232,6 +232,7 @@ private struct LimitWindowRow: View {
     let window: LimitWindow
     let fidelity: Fidelity
     let now: Date
+    let resetTimeFormat: ResetTimeFormat
 
     private var band: UsageBand { UsageBand.band(for: window.usedFraction ?? 0) }
     private var trackWidth: CGFloat { NotchLayout.cardWidth - 2 * NotchLayout.cardPadding }
@@ -242,7 +243,7 @@ private struct LimitWindowRow: View {
 
     /// Blank rather than invented: some providers never say when the window rolls.
     private var resetText: String {
-        window.resetsAt.map { ResetCopy.text(for: $0, now: now) } ?? ""
+        window.resetsAt.map { ResetCopy.text(for: $0, now: now, format: resetTimeFormat) } ?? ""
     }
 
     var body: some View {
@@ -271,6 +272,7 @@ private struct LimitWindowRow: View {
 private struct ProviderTooltip: View {
     let snapshot: ProviderSnapshot
     let now: Date
+    let resetTimeFormat: ResetTimeFormat
 
     /// Only worth saying when the numbers are not current. A remembered reading
     /// has to be dated, or it quietly passes itself off as live.
@@ -301,7 +303,8 @@ private struct ProviderTooltip: View {
                     .padding(.top, NotchLayout.headerToBlock)
             } else {
                 ForEach(Array(snapshot.windows.enumerated()), id: \.element.id) { index, window in
-                    LimitWindowRow(window: window, fidelity: snapshot.fidelity, now: now)
+                    LimitWindowRow(window: window, fidelity: snapshot.fidelity, now: now,
+                                   resetTimeFormat: resetTimeFormat)
                         .padding(.top, index == 0 ? NotchLayout.headerToBlock : NotchLayout.blockSpacing)
                 }
             }
@@ -433,6 +436,7 @@ struct TooltipCard: View {
     /// How many sessions this screen has room to list. Solved from the display
     /// rather than fixed, so a big screen hides nothing.
     var sessionCap: Int = NotchLayout.defaultSessionCap
+    var resetTimeFormat: ResetTimeFormat = .automatic
 
     /// The same figure the hover region uses, so what is drawn and what is
     /// reachable can never drift apart.
@@ -454,7 +458,7 @@ struct TooltipCard: View {
             // drifts while the card resizes around them.
             ZStack(alignment: .topLeading) {
                 VStack(alignment: .leading, spacing: 0) {
-                    ProviderTooltip(snapshot: snapshot, now: now)
+                    ProviderTooltip(snapshot: snapshot, now: now, resetTimeFormat: resetTimeFormat)
                     if let activity {
                         SessionList(summary: activity, now: now, cap: sessionCap)
                     }

--- a/Sources/Model/ResetCopy.swift
+++ b/Sources/Model/ResetCopy.swift
@@ -1,11 +1,48 @@
 import Foundation
 
+enum ResetTimeFormat: String, CaseIterable, Identifiable {
+    case automatic
+    case remaining
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .automatic: return "Automatic"
+        case .remaining: return "Time remaining"
+        }
+    }
+
+    var explanation: String {
+        switch self {
+        case .automatic:
+            return "Minutes under an hour; otherwise the reset date and time."
+        case .remaining:
+            return "Time until usage resets, such as 3 Days 3h or 3h 20m."
+        }
+    }
+}
+
 /// "Resets in 51 min" under an hour, "Resets Thu 12:00 AM" within the week,
 /// "Resets Sep 28" beyond it.
 enum ResetCopy {
-    static func text(for resetsAt: Date, now: Date = Date(), calendar: Calendar = .current) -> String {
+    static func text(for resetsAt: Date, now: Date = Date(), calendar: Calendar = .current,
+                     format: ResetTimeFormat = .automatic) -> String {
         let seconds = resetsAt.timeIntervalSince(now)
         guard seconds > 0 else { return "Resetting…" }
+
+        if format == .remaining {
+            let minutes = max(1, Int((seconds / 60).rounded()))
+            let hours = minutes / 60
+            let days = hours / 24
+            if days > 0 {
+                return "Resets in \(days) \(days == 1 ? "Day" : "Days") \(hours % 24)h"
+            }
+            if hours > 0 {
+                return "Resets in \(hours)h \(minutes % 60)m"
+            }
+            return "Resets in \(minutes) min"
+        }
 
         // Rounding, not truncation, so 50m40s reads as 51 rather than 50. A
         // value that rounds up to 60 falls through to the absolute form, so

--- a/Sources/Model/ResetCopy.swift
+++ b/Sources/Model/ResetCopy.swift
@@ -8,7 +8,7 @@ enum ResetTimeFormat: String, CaseIterable, Identifiable {
 
     var title: String {
         switch self {
-        case .automatic: return "Automatic"
+        case .automatic: return "Reset date"
         case .remaining: return "Time remaining"
         }
     }

--- a/Sources/Notch/NotchRootView.swift
+++ b/Sources/Notch/NotchRootView.swift
@@ -43,7 +43,8 @@ struct NotchRootView: View {
                         activity: model.activity(for: snapshot.id),
                         now: model.now,
                         direction: model.edge.tooltipDirection,
-                        sessionCap: model.sessionCap
+                        sessionCap: model.sessionCap,
+                        resetTimeFormat: model.resetTimeFormat
                     )
                         // Deliberately *no* `.id` here: the card is one object
                         // that travels and resizes between cells, which reads

--- a/Sources/Notch/NotchViewModel.swift
+++ b/Sources/Notch/NotchViewModel.swift
@@ -17,6 +17,7 @@ final class NotchViewModel: ObservableObject {
     @Published var hoveredIndex: Int?
     /// Ticked on refresh so the "Resets in N min" copy stays honest.
     @Published var now: Date = Date()
+    @Published var resetTimeFormat: ResetTimeFormat = .automatic
 
     /// Whether the notch is open or folded away to its pill.
     @Published var isExpanded = false

--- a/Sources/Settings/Preferences.swift
+++ b/Sources/Settings/Preferences.swift
@@ -26,6 +26,10 @@ final class Preferences: ObservableObject {
         didSet { defaults.set(notchEdge.rawValue, forKey: Keys.edge) }
     }
 
+    @Published var resetTimeFormat: ResetTimeFormat {
+        didSet { defaults.set(resetTimeFormat.rawValue, forKey: Keys.resetTimeFormat) }
+    }
+
     /// Where the app itself shows up: Dock, menu bar, or nowhere.
     @Published var appPresence: AppPresence {
         didSet { defaults.set(appPresence.rawValue, forKey: Keys.presence) }
@@ -59,6 +63,7 @@ final class Preferences: ObservableObject {
         static let visibility = "notchVisibility"
         static let presence = "appPresence"
         static let edge = "notchEdge"
+        static let resetTimeFormat = "resetTimeFormat"
         static let lastSeenVersion = "lastSeenVersion"
     }
 
@@ -113,6 +118,8 @@ final class Preferences: ObservableObject {
         // side of a Mac that no system chrome claims by default.
         self.notchEdge = defaults.string(forKey: Keys.edge)
             .flatMap(NotchEdge.init(rawValue:)) ?? .right
+        self.resetTimeFormat = defaults.string(forKey: Keys.resetTimeFormat)
+            .flatMap(ResetTimeFormat.init(rawValue:)) ?? .automatic
         // Absent means nothing has been shown yet, which is true of a fresh
         // install — so the current release reads as new to it.
         self.lastSeenVersion = defaults.string(forKey: Keys.lastSeenVersion)

--- a/Sources/Settings/SettingsView.swift
+++ b/Sources/Settings/SettingsView.swift
@@ -54,6 +54,16 @@ struct SettingsView: View {
             // read as three unrelated settings, and "Where Codenotch appears"
             // was a header long enough to look like a warning.
             Section("Appearance") {
+                Picker("Reset time", selection: $preferences.resetTimeFormat) {
+                    ForEach(ResetTimeFormat.allCases) { Text($0.title).tag($0) }
+                }
+                .pickerStyle(.segmented)
+
+                Text(preferences.resetTimeFormat.explanation)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+
                 Picker("Show", selection: $preferences.notchVisibility) {
                     ForEach(NotchVisibility.allCases) { Text($0.title).tag($0) }
                 }

--- a/Tests/ResetCopyTests.swift
+++ b/Tests/ResetCopyTests.swift
@@ -48,6 +48,40 @@ final class ResetCopyTests: XCTestCase {
     func testPastResetsReadAsResetting() {
         XCTAssertEqual(ResetCopy.text(for: now.addingTimeInterval(-5), now: now), "Resetting…")
     }
+
+    func testRemainingFormatAndRoundingBoundaries() {
+        let cases: [(TimeInterval, String)] = [
+            (-5, "Resetting…"), (0, "Resetting…"),
+            (1, "Resets in 1 min"),
+            (50 * 60 + 40, "Resets in 51 min"),
+            (59 * 60 + 40, "Resets in 1h 0m"),
+            (3 * 3600 + 20 * 60, "Resets in 3h 20m"),
+            (24 * 3600 - 20, "Resets in 1 Day 0h"),
+            (27 * 3600, "Resets in 1 Day 3h"),
+            (75 * 3600, "Resets in 3 Days 3h"),
+            (26 * 86400, "Resets in 26 Days 0h")
+        ]
+        for (seconds, expected) in cases {
+            XCTAssertEqual(ResetCopy.text(for: now.addingTimeInterval(seconds), now: now,
+                                          format: .remaining), expected)
+        }
+    }
+
+    @MainActor
+    func testResetTimePreferencePersistsAndFallsBackToAutomatic() throws {
+        let name = "ResetCopyTests.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: name))
+        defer { defaults.removePersistentDomain(forName: name) }
+
+        let preferences = Preferences(defaults: defaults)
+        XCTAssertEqual(preferences.resetTimeFormat, .automatic)
+        preferences.resetTimeFormat = .remaining
+        XCTAssertEqual(Preferences(defaults: defaults).resetTimeFormat, .remaining)
+        preferences.resetTimeFormat = .automatic
+        XCTAssertEqual(Preferences(defaults: defaults).resetTimeFormat, .automatic)
+        defaults.set("unknown", forKey: "resetTimeFormat")
+        XCTAssertEqual(Preferences(defaults: defaults).resetTimeFormat, .automatic)
+    }
 }
 
 /// A weekday only identifies a day inside the coming week. Codex's monthly


### PR DESCRIPTION
Reset times currently switch from a countdown under an hour to a weekday or date for longer waits. Users who prefer knowing how much time remains have to work that out themselves.

This change adds a Reset time preference under Settings → Appearance:

- Choose Time remaining to show countdowns such as "Resets in 3 Days 3h" or "Resets in 3h 20m".
- Keep Reset date as the default, preserving the existing display, including minutes when less than an hour remains.
- Save the preference across app restarts and apply changes immediately to usage tooltips.
- Reuse the existing 30-second refresh to keep countdowns current.

Validation:

- Added coverage for countdown formatting, rounding across hour and day boundaries, expired resets, preference persistence, and unknown stored values.
- Full suite: 554 tests passed on Apple silicon.
- Rebuilt and launched the app locally after the final label change to Reset date.
- `git diff --check` passed.

The full suite was run from a temporary source copy after Xcode stalled while reading the working directory, using local signing overrides because the maintainer's certificate was unavailable:

```sh
make test 'DEV_SIGN=CODE_SIGN_IDENTITY="-" DEVELOPMENT_TEAM="" CODE_SIGN_STYLE=Automatic'
```
