### PR TITLE
fix: ad-hoc signing fallback never triggers in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ DEST    := platform=macOS,arch=arm64
 # changes nothing: project.yml's stable identity is what keeps a keychain
 # "Always Allow" grant alive across rebuilds, and forcing ad-hoc there would
 # throw that away and bring the prompt back on every `make run`.
-ifeq (,$(shell security find-identity -v -p codesigning 2>/dev/null | grep -c "Developer ID Application"))
+ifeq (0,$(shell security find-identity -v -p codesigning 2>/dev/null | grep -c "Developer ID Application"))
 DEV_SIGN := CODE_SIGN_IDENTITY="-" DEVELOPMENT_TEAM="" CODE_SIGN_STYLE=Automatic
 endif
 


### PR DESCRIPTION
## Summary
- `grep -c` always prints a count (`0` on no match), never an empty string, so `ifeq (,$(shell security find-identity -v -p codesigning ... | grep -c "Developer ID Application"))` was never true — the ad-hoc signing fallback for contributors without a Developer ID cert never fired.
- Fixes #45.

## Fix
Compare the `grep -c` output against the literal `0` instead of empty string.

## Test plan
- [x] `security find-identity -v -p codesigning` shows `0 valid identities found` on this machine
- [x] Before fix: `make run` fails with `error: No signing certificate "Developer ID Application" found...`
- [x] After fix: plain `make run` (no manual `DEV_SIGN` override) succeeds and launches Codenotch.app