### PR TITLE
Add Scripts/sign-local.sh so local keychain grants persist

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,19 @@ certificate and an App Store Connect notary profile, and is only ever run by
 the maintainer to cut an official release. See
 [CONTRIBUTING.md](CONTRIBUTING.md).
 
+A Debug build is ad-hoc signed, which means it has no stable code identity, so
+macOS cannot match it to a saved keychain "Always Allow" — the prompt to read a
+tool's token returns on every launch. To make the grant stick during local
+development, sign the built app with a stable self-signed identity:
+
+```sh
+Scripts/sign-local.sh   # signs /Applications/Codenotch.app (pass a path to override)
+```
+
+It creates a reusable `Codenotch Local Signing` certificate in your login
+keychain (no Apple Developer account needed) and re-signs the app. Grant the
+keychain prompt once more after signing; it will not ask again.
+
 Run with `CODENOTCH_DEMO=1` to see fixed sample data instead of live readings.
 
 ## Architecture

--- a/Scripts/sign-local.sh
+++ b/Scripts/sign-local.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+#
+# Sign a local Debug build with a STABLE self-signed identity, so the macOS
+# keychain "Always Allow" grant persists across launches.
+#
+# Why this exists: `make run`/`make build` produce an ad-hoc-signed app. An
+# ad-hoc build has no stable code identity, so the keychain access-control
+# list cannot match it to a saved "Always Allow" grant — and the prompt to
+# read Claude Code's (or another tool's) token returns on *every* launch. A
+# stable self-signed identity fixes that: the grant binds to it and sticks.
+#
+# This is for local development only. It needs no Apple Developer account and
+# does not notarize — official releases are Developer ID signed by
+# `make release`. The certificate lives in your login keychain and is reused
+# on subsequent runs.
+#
+# Usage:
+#   Scripts/sign-local.sh [path/to/Codenotch.app]
+# Default target is the app in /Applications.
+
+set -euo pipefail
+
+APP="${1:-/Applications/Codenotch.app}"
+CN="Codenotch Local Signing"
+
+if [ ! -d "$APP" ]; then
+  echo "error: $APP not found — build and install it first (make run)." >&2
+  exit 1
+fi
+
+if ! security find-identity -p codesigning | grep -q "$CN"; then
+  echo "Creating self-signed code-signing certificate '$CN'…"
+  DIR=$(mktemp -d)
+  trap 'rm -rf "$DIR"' EXIT
+  cat > "$DIR/ext.cnf" <<EOF
+[req]
+distinguished_name = dn
+x509_extensions    = v3
+prompt             = no
+[dn]
+CN = $CN
+[v3]
+basicConstraints     = critical,CA:false
+keyUsage             = critical,digitalSignature
+extendedKeyUsage     = critical,codeSigning
+EOF
+  openssl req -x509 -newkey rsa:2048 -sha256 -days 3650 -nodes \
+    -keyout "$DIR/key.pem" -out "$DIR/cert.pem" -config "$DIR/ext.cnf"
+  # -legacy: OpenSSL 3 otherwise writes a PKCS#12 that `security` cannot
+  # import ("MAC verification failed"). Harmless on OpenSSL that ignores it.
+  openssl pkcs12 -export -legacy -inkey "$DIR/key.pem" -in "$DIR/cert.pem" \
+    -out "$DIR/id.p12" -passout pass:codenotch -name "$CN" 2>/dev/null || \
+  openssl pkcs12 -export -inkey "$DIR/key.pem" -in "$DIR/cert.pem" \
+    -out "$DIR/id.p12" -passout pass:codenotch -name "$CN"
+  # -T grants /usr/bin/codesign access to the key; -A avoids a prompt per use.
+  security import "$DIR/id.p12" -k "$HOME/Library/Keychains/login.keychain-db" \
+    -P codenotch -T /usr/bin/codesign -A
+fi
+
+# Quit a running instance so the bundle can be replaced in place.
+osascript -e 'quit app "Codenotch"' 2>/dev/null || true
+sleep 1
+
+codesign --force --deep --sign "$CN" "$APP"
+codesign -dv "$APP" 2>&1 | grep -E 'Authority|Identifier' || true
+
+echo
+echo "Signed with '$CN'. Relaunch Codenotch and grant the keychain prompt one"
+echo "more time (new identity) — it will not ask again on later launches."


### PR DESCRIPTION
Small contributor-DX helper, independent of #25.

### Problem
`make run`/`make build` produce an **ad-hoc-signed** app. An ad-hoc build has no stable code identity, so the macOS keychain access-control list can't match it to a saved **Always Allow** — and the prompt to read Claude Code's (or another tool's) token comes back on **every launch**. Since building locally is the only way to run a Debug build, anyone hacking on Codenotch hits this.

### Fix
`Scripts/sign-local.sh` creates a reusable **self-signed** `Codenotch Local Signing` identity in the login keychain (no Apple Developer account, no notarization — official releases are still Developer ID signed by `make release`) and re-signs the built app. The keychain grant then binds to a stable identity and sticks.

```sh
Scripts/sign-local.sh            # signs /Applications/Codenotch.app
Scripts/sign-local.sh path/to/Codenotch.app
```

Documented under **Building** in the README. Notable detail: OpenSSL 3 needs `-legacy` on the `pkcs12 -export` or `security import` fails with "MAC verification failed" — the script handles both.

### Testing
Verified on macOS 15: after signing, the keychain "Always Allow" for `Claude Code-credentials-<hash>` persists across relaunches (previously re-prompted every launch). Syntax-checked with `bash -n`. Happy to adjust naming/placement.