### PR TITLE
Name a scoped weekly window after its model

### DIFF
--- a/Sources/Providers/ClaudeOAuthProvider.swift
+++ b/Sources/Providers/ClaudeOAuthProvider.swift
@@ -241,6 +241,32 @@ struct UsageResponse: Decodable {
         let kind: String
         let percent: Double
         let resetsAt: Date?
+        /// Set on `weekly_scoped`: the model or surface the window covers. The
+        /// kind is the same for every such window; the scope carries the name.
+        let scope: Scope?
+
+        /// `weekly_scoped` appears once per scoped model, so the kind alone
+        /// would collide. The scope name keeps each window its own row.
+        var windowID: String {
+            guard let name = scope?.name else { return kind }
+            return "\(kind):\(name.lowercased())"
+        }
+        var label: String { scope?.name ?? UsageResponse.label(forKind: kind) }
+    }
+    struct Scope: Decodable {
+        struct Model: Decodable {
+            let displayName: String?
+        }
+        let model: Model?
+        let surface: String?
+
+        /// What the window is scoped to, worded as the endpoint words it —
+        /// "Fable" for a per-model window, the surface otherwise.
+        var name: String? {
+            if let name = model?.displayName, !name.isEmpty { return name }
+            if let surface, !surface.isEmpty { return surface.capitalized }
+            return nil
+        }
     }
     struct Window: Decodable {
         let utilization: Double
@@ -258,8 +284,8 @@ struct UsageResponse: Decodable {
         var windows = (limits ?? []).compactMap { limit -> LimitWindow? in
             guard let resetsAt = limit.resetsAt else { return nil }
             return LimitWindow(
-                id: limit.kind,
-                label: UsageResponse.label(forKind: limit.kind),
+                id: limit.windowID,
+                label: limit.label,
                 usedFraction: limit.percent / 100,
                 resetsAt: resetsAt
             )

--- a/Tests/UsageResponseTests.swift
+++ b/Tests/UsageResponseTests.swift
@@ -72,6 +72,39 @@ final class UsageResponseTests: XCTestCase {
         XCTAssertTrue(try decode(json).limitWindows().isEmpty)
     }
 
+    /// `weekly_scoped` is one kind shared by every per-model window; the name
+    /// lives in `scope.model.display_name`, and that is what the row shows.
+    /// Two scoped windows keep separate rows instead of colliding on the kind.
+    func testScopedWeeklyWindowShowsItsModelName() throws {
+        let json = """
+        { "limits": [
+            { "kind": "weekly_all", "group": "weekly", "percent": 30, "severity": "normal",
+              "resets_at": "2026-09-13T02:00:00.227124+00:00", "scope": null, "is_active": false },
+            { "kind": "weekly_scoped", "group": "weekly", "percent": 37, "severity": "normal",
+              "resets_at": "2026-09-13T02:00:00.227355+00:00",
+              "scope": { "model": { "id": null, "display_name": "Fable" }, "surface": null },
+              "is_active": true },
+            { "kind": "weekly_scoped", "group": "weekly", "percent": 4, "severity": "normal",
+              "resets_at": "2026-09-13T02:00:00.227355+00:00",
+              "scope": { "model": { "id": null, "display_name": "Opus" }, "surface": null },
+              "is_active": false } ] }
+        """
+        let windows = try decode(json).limitWindows()
+        XCTAssertEqual(windows.map(\.id), ["weekly_all", "weekly_scoped:fable", "weekly_scoped:opus"])
+        XCTAssertEqual(windows.map(\.label), ["All models", "Fable", "Opus"])
+        XCTAssertEqual(windows[1].usedFraction ?? -1, 0.37, accuracy: 0.0001)
+    }
+
+    /// A scoped window that names no model keeps the generic wording rather
+    /// than an empty label.
+    func testScopedWindowWithoutAScopeKeepsTheKindWording() throws {
+        let json = """
+        { "limits": [ { "kind": "weekly_scoped", "percent": 1,
+                        "resets_at": "2026-09-13T02:00:00.227355+00:00", "scope": null } ] }
+        """
+        XCTAssertEqual(try decode(json).limitWindows().map(\.label), ["Scoped"])
+    }
+
     /// Older responses without `limits` still render from the named windows.
     func testFallsBackToTheNamedWindows() throws {
         let json = """


### PR DESCRIPTION
## What

Claude's usage endpoint now returns a third limit of kind `weekly_scoped`, carrying a `scope` object (`scope.model.display_name`, e.g. "Fable", or a `surface`). Codenotch rendered it as a generic "Scoped" row, so a per-model weekly ring was indistinguishable from the account-wide one.

This decodes `Limit.scope`, labels the window by the scope's name ("Fable"), and gives it the id `weekly_scoped:<name>` so two scoped windows never collide. Untouched: `session` / `weekly_all` ordering and the headline id.

## Tests

Two new cases in `Tests/UsageResponseTests.swift`: a scoped window is named after its model, and an unscoped `weekly_scoped` still falls back to "Scoped".

Honest caveat: I could not run `make test` here (the CI-less build box signs ad-hoc over ssh and the XCTest bundle would not resolve the app module under those overrides). The change is built and running on my Mac as a Release ad-hoc build, where the tooltip shows the model name. If you have a local `make test`, that is the check to run.

## Why upstream

The scoped window is what a Max plan with a per-model cap shows every day; without this the ring is labelled by its kind, not by what it meters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D66oSpJGN2dn3Q4E4Bv88x
