### PR TITLE
Do not draw a ring for a directory with no token

### DIFF
--- a/Sources/Providers/ClaudeProfile.swift
+++ b/Sources/Providers/ClaudeProfile.swift
@@ -37,21 +37,57 @@ struct ClaudeProfile: Equatable, Hashable {
     /// Code has actually used, slugs in alphabetical order so the rings never
     /// swap places between launches.
     ///
-    /// "Actually used" is judged by the files Claude Code writes on its first
-    /// run — an empty directory, or a stray one someone made by hand, would
-    /// otherwise put a permanent "sign in" ring in the notch for an account
-    /// that does not exist.
+    /// "Actually used" is judged twice over. The files Claude Code writes on
+    /// its first run rule out an empty directory or a stray one someone made
+    /// by hand; a token filed under the directory's own service name rules out
+    /// everything else that has learned to live at `~/.claude-<slug>`.
+    ///
+    /// The second test is what keeps plugins out. `claude-mem` keeps its state
+    /// in `~/.claude-mem` and writes every one of the first-run names above, so
+    /// the filename rules pass it and it is not an account: Claude Code has
+    /// never signed in there and never will, so the ring could only ever read
+    /// "Sign in to Claude Code in ~/.claude-mem to read your usage" — advice
+    /// that cannot be followed, for a limit that does not exist. Filenames
+    /// alone cannot tell the two apart, and a denylist of plugin names would
+    /// only postpone the next one. The credential can: no token, no account,
+    /// no ring.
+    ///
+    /// `hasCredential` is injected so discovery stays testable — the real one
+    /// reads the login keychain, which a test has no business touching. It only
+    /// enumerates attributes and takes a persistent reference, neither of which
+    /// needs authorization, so this costs no extra prompt per candidate.
     static func discover(home: URL = homeDirectory,
-                         fileManager: FileManager = .default) -> [ClaudeProfile] {
+                         fileManager: FileManager = .default,
+                         hasCredential: (ClaudeProfile) -> Bool = Self.hasKeychainCredential)
+    -> [ClaudeProfile] {
         let names = (try? fileManager.contentsOfDirectory(atPath: home.path)) ?? []
         let extras = names.compactMap { name -> ClaudeProfile? in
             guard let slug = slug(fromDirectoryName: name) else { return nil }
             let directory = home.appendingPathComponent(name)
             guard isProfileDirectory(directory, fileManager: fileManager) else { return nil }
-            return ClaudeProfile(slug: slug, configDirectory: directory)
+            let candidate = ClaudeProfile(slug: slug, configDirectory: directory)
+            guard hasCredential(candidate) else {
+                Log.usage.debug("ignoring \(candidate.displayPath, privacy: .public): looks like a profile but has no token under \(candidate.keychainService, privacy: .public)")
+                return nil
+            }
+            return candidate
         }
         return [ClaudeProfile.default(home: home)]
             + extras.sorted { $0.slug! < $1.slug! }
+    }
+
+    /// Whether Claude Code has ever filed a token for this profile's directory.
+    ///
+    /// Asks across `keychainServices` rather than the primary name alone, so a
+    /// profile whose token was written under either spelling still counts.
+    ///
+    /// Deliberately not a check on whether that token is *valid*. An expired
+    /// one still means the account exists and the ring is worth drawing — the
+    /// provider degrades it to `credentialExpired` and shows the last reading
+    /// with its age, which is the right answer for a profile that has not been
+    /// used since the token last rotated.
+    static func hasKeychainCredential(_ profile: ClaudeProfile) -> Bool {
+        KeychainItem.newest(services: profile.keychainServices) != nil
     }
 
     /// `.claude-work` → `work`; anything else → nil. The bare `.claude` is the

--- a/Tests/ClaudeProfileTests.swift
+++ b/Tests/ClaudeProfileTests.swift
@@ -20,6 +20,14 @@ final class ClaudeProfileTests: XCTestCase {
         return root
     }
 
+    /// Discovery asks whether Claude Code ever filed a token for the directory.
+    /// Every test below that is about the *filename* rules says yes, so the two
+    /// conditions stay separately testable.
+    private let signedIn: (ClaudeProfile) -> Bool = { _ in true }
+
+    /// Nothing in the home directory has a token.
+    private let signedOut: (ClaudeProfile) -> Bool = { _ in false }
+
     // MARK: - Identity
 
     /// The default keeps the id it has always had, so archived readings and
@@ -111,7 +119,7 @@ final class ClaudeProfileTests: XCTestCase {
             ".claude-work": ["settings.json"],
             ".claude-alpha": ["history.jsonl"]
         ])
-        let found = ClaudeProfile.discover(home: home)
+        let found = ClaudeProfile.discover(home: home, hasCredential: signedIn)
         XCTAssertEqual(found.map(\.id), ["claude", "claude-alpha", "claude-work"])
         XCTAssertEqual(found[2].configDirectory.path, home.appendingPathComponent(".claude-work").path)
     }
@@ -124,7 +132,7 @@ final class ClaudeProfileTests: XCTestCase {
             ".claude-empty": [],
             ".claude-notes": ["README.md"]
         ])
-        XCTAssertEqual(ClaudeProfile.discover(home: home).map(\.id), ["claude"])
+        XCTAssertEqual(ClaudeProfile.discover(home: home, hasCredential: signedIn).map(\.id), ["claude"])
     }
 
     /// Any one of the files Claude Code writes on first run is enough — they
@@ -135,7 +143,7 @@ final class ClaudeProfileTests: XCTestCase {
             ".claude-b": ["projects"],
             ".claude-c": [".claude.json"]
         ])
-        XCTAssertEqual(ClaudeProfile.discover(home: home).map(\.id),
+        XCTAssertEqual(ClaudeProfile.discover(home: home, hasCredential: signedIn).map(\.id),
                        ["claude", "claude-a", "claude-b", "claude-c"])
     }
 
@@ -144,14 +152,39 @@ final class ClaudeProfileTests: XCTestCase {
         let home = try home([".claude": ["settings.json"]])
         FileManager.default.createFile(atPath: home.appendingPathComponent(".claude-work").path,
                                        contents: Data("not a directory".utf8))
-        XCTAssertEqual(ClaudeProfile.discover(home: home).map(\.id), ["claude"])
+        XCTAssertEqual(ClaudeProfile.discover(home: home, hasCredential: signedIn).map(\.id), ["claude"])
     }
 
     /// `~/.claude` has always been read whether or not it exists yet, and a
     /// fresh Mac with no Claude Code still gets the ring that says so.
     func testTheDefaultIsAlwaysPresent() throws {
         let home = try home([:])
-        XCTAssertEqual(ClaudeProfile.discover(home: home).map(\.id), ["claude"])
+        XCTAssertEqual(ClaudeProfile.discover(home: home, hasCredential: signedIn).map(\.id), ["claude"])
+    }
+
+    /// A plugin is not an account. `claude-mem` keeps its state in
+    /// `~/.claude-mem` and writes the same first-run names Claude Code does,
+    /// so the filename rules pass it and it drew a permanent "sign in to
+    /// ~/.claude-mem" ring for a limit that does not exist. No token under the
+    /// directory's own service name, no ring.
+    func testADirectoryWithNoTokenIsNotAnAccount() throws {
+        let home = try home([
+            ".claude": ["settings.json"],
+            ".claude-mem": ["sessions", "settings.json"]
+        ])
+        XCTAssertEqual(ClaudeProfile.discover(home: home, hasCredential: signedOut).map(\.id),
+                       ["claude"])
+        XCTAssertEqual(ClaudeProfile.discover(home: home, hasCredential: signedIn).map(\.id),
+                       ["claude", "claude-mem"],
+                       "the filename rules are unchanged — only the credential decides")
+    }
+
+    /// The default is read whether or not it has a token: it is the one ring
+    /// that has always been there to say "sign in".
+    func testTheDefaultSurvivesHavingNoToken() throws {
+        let home = try home([".claude": ["settings.json"]])
+        XCTAssertEqual(ClaudeProfile.discover(home: home, hasCredential: signedOut).map(\.id),
+                       ["claude"])
     }
 
     // MARK: - What the rest of the app derives from the id


### PR DESCRIPTION
ClaudeProfile.discover accepted any ~/.claude-<slug> directory that held one
of Claude Code's first-run filenames. claude-mem keeps its state in
~/.claude-mem and writes those same names, so it was discovered as an account
and drew a permanent "Sign in to Claude Code in ~/.claude-mem to read your
usage" ring — advice that cannot be followed, for a limit that does not exist.

Filenames cannot distinguish a plugin's data directory from a config
directory, and a denylist of plugin names would only postpone the next one.
Claude Code files a token under a service name derived from the config
directory's path, which ClaudeProfile already computes, so ask whether that
token exists: no token, no account, no ring.

The check is injected as hasCredential so the filename rules stay testable
without touching the login keychain. It tests existence, not validity — an
expired token still means the account is real, and the provider already
degrades that to credentialExpired and shows the last reading with its age.
The default profile is unaffected: ~/.claude is added unconditionally and
still gets the ring that says to sign in.

Closes #42