### PR TITLE
Build on CI, and fix the ad-hoc signing guard that never fired

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,56 @@
+# Builds and tests on a GitHub-hosted macOS runner, so a fork can be built
+# without a local Xcode install. The app is ad-hoc signed: the Makefile's
+# DEV_SIGN fallback fires because no Developer ID certificate exists on a
+# runner, which is the same path any contributor takes.
+name: build
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build:
+    # macos-26 carries the macOS 26 SDK that project.yml's deployment target
+    # needs. macos-latest points here too, but is pinned so a runner-image
+    # rollover cannot silently drop the SDK out from under the build.
+    runs-on: macos-26
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Toolchain
+        run: |
+          xcode-select -p
+          xcodebuild -version
+          swift --version
+
+      - name: Install XcodeGen
+        run: brew install xcodegen
+
+      - name: Test
+        run: make test
+
+      - name: Build
+        run: make build
+
+      # Zipped with ditto rather than handed to upload-artifact directly:
+      # upload-artifact walks the directory and does not preserve the symlinks
+      # and permissions inside a .app, which produces an artifact that unpacks
+      # into a bundle macOS refuses to launch.
+      - name: Package
+        run: |
+          APP="$(xcodebuild -project Codenotch.xcodeproj -scheme Codenotch \
+                   -destination 'platform=macOS,arch=arm64' -configuration Debug \
+                   -showBuildSettings 2>/dev/null \
+                 | awk -F' = ' '/ BUILT_PRODUCTS_DIR/ {print $2; exit}')/Codenotch.app"
+          test -d "$APP" || { echo "no app at $APP"; exit 1; }
+          codesign -dv "$APP" 2>&1 || true
+          ditto -c -k --sequesterRsrc --keepParent "$APP" Codenotch.zip
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: Codenotch-adhoc-${{ github.sha }}
+          path: Codenotch.zip
+          if-no-files-found: error

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,12 @@ DEST    := platform=macOS,arch=arm64
 # changes nothing: project.yml's stable identity is what keeps a keychain
 # "Always Allow" grant alive across rebuilds, and forcing ad-hoc there would
 # throw that away and bring the prompt back on every `make run`.
-ifeq (,$(shell security find-identity -v -p codesigning 2>/dev/null | grep -c "Developer ID Application"))
+# `grep -c` prints a count on stdout whether or not it matched, so this is
+# tested against "0" and not against empty: comparing to empty never fired,
+# DEV_SIGN was never set on anyone's machine, and every contributor got a
+# signing failure from project.yml's hardcoded Developer ID instead of the
+# ad-hoc fallback CONTRIBUTING.md promises.
+ifeq (0,$(shell security find-identity -v -p codesigning 2>/dev/null | grep -c "Developer ID Application"))
 DEV_SIGN := CODE_SIGN_IDENTITY="-" DEVELOPMENT_TEAM="" CODE_SIGN_STYLE=Automatic
 endif
 


### PR DESCRIPTION
project.yml pins CODE_SIGN_IDENTITY to "Developer ID Application" with the
maintainer's team id and CODE_SIGNING_REQUIRED=YES, and the Makefile is meant
to override that with ad-hoc signing on any machine without that certificate.
The guard tested the wrong thing: `grep -c` writes a count to stdout whether
or not it matched, so $(shell ...) is "0" rather than empty and `ifeq (,...)`
never held. DEV_SIGN was empty everywhere, including on the maintainer's own
machine where it is supposed to be, so nobody was getting the fallback and a
contributor's first `make test` failed on a certificate they cannot have.
Compare against "0" instead.

With that working, .github/workflows/build.yml runs gen, test and build on a
macos-26 runner and uploads the ad-hoc signed app. That makes the project
buildable from a fork with no local Xcode, which is a 15GB install for anyone
who only wants to verify a small change. Pinned to macos-26 rather than
macos-latest because project.yml's deployment target needs the macOS 26 SDK,
and packaged with ditto because upload-artifact does not preserve the symlinks
inside a .app.
