### PR TITLE
Focus host application or terminal when clicking a live session row (#29)

### DIFF
--- a/Sources/Features/TooltipCard.swift
+++ b/Sources/Features/TooltipCard.swift
@@ -335,6 +335,7 @@ private struct BlockedRow: View {
 private struct SessionRow: View {
     let session: AgentSession
     let now: Date
+    @State private var isHovered = false
 
     private var stateColor: Color {
         switch session.state {
@@ -360,7 +361,7 @@ private struct SessionRow: View {
         return session.detail
     }
 
-    var body: some View {
+    private var rowContent: some View {
         VStack(alignment: .leading, spacing: 0) {
             SplitRow(leading: session.name, trailing: stateWord,
                      trailingColor: stateColor) {
@@ -369,9 +370,38 @@ private struct SessionRow: View {
             SplitRow(
                 leading: detail,
                 trailing: ElapsedCopy.text(since: session.since, now: now),
-                leadingColor: Palette.textSecondary
+                leadingColor: (session.focusTarget != nil && isHovered) ? Palette.textPrimary : Palette.textSecondary,
+                trailingColor: (session.focusTarget != nil && isHovered) ? Palette.textPrimary : Palette.textSecondary
             )
             .padding(.top, NotchLayout.sessionRowGap)
+        }
+        .contentShape(Rectangle())
+    }
+
+    var body: some View {
+        if let target = session.focusTarget {
+            Button {
+                SessionFocus.activate(target: target)
+            } label: {
+                rowContent
+            }
+            .buttonStyle(.plain)
+            .onHover { inside in
+                isHovered = inside
+                if inside {
+                    NSCursor.pointingHand.push()
+                } else {
+                    NSCursor.pop()
+                }
+            }
+            .onDisappear {
+                if isHovered {
+                    isHovered = false
+                    NSCursor.pop()
+                }
+            }
+        } else {
+            rowContent
         }
     }
 }

--- a/Sources/Notch/NotchPanel.swift
+++ b/Sources/Notch/NotchPanel.swift
@@ -29,6 +29,7 @@ final class NotchPanel: NSPanel {
             return super.mouseDown(with: event)
         }
         onClick?()
+        super.mouseDown(with: event)
     }
 
     init(contentRect: NSRect) {

--- a/Sources/Notch/NotchWindowController.swift
+++ b/Sources/Notch/NotchWindowController.swift
@@ -302,8 +302,11 @@ final class NotchWindowController {
         setExpanded(liveRect.contains(local) || overTooltip)
 
         var target: Int?
+        var cellTarget: Int?
         if model.isExpanded, notchRect.contains(local) {
-            target = cellIndex(along: placement.along(of: local))
+            let index = cellIndex(along: placement.along(of: local))
+            target = index
+            cellTarget = index
         } else if model.isExpanded, let current = model.hoveredIndex,
                   let card = tooltipRect(index: current),
                   card.contains(local) {
@@ -315,7 +318,7 @@ final class NotchWindowController {
             model.isHoveringSettings = overHandle
         }
         setPointing(
-            Self.wantsPointingHand(isExpanded: model.isExpanded, cellIndex: target) || overHandle
+            Self.wantsPointingHand(isExpanded: model.isExpanded, cellIndex: cellTarget) || overHandle
         )
 
         if let target {
@@ -412,13 +415,14 @@ final class NotchWindowController {
             onOpenSettings?()
             return
         }
-        if notchRect.contains(local),
-           let index = cellIndex(along: placement.along(of: local)),
-           model.snapshots.indices.contains(index) {
-            onRefreshProvider?(model.snapshots[index].id)
-            return
+        if notchRect.contains(local) {
+            if let index = cellIndex(along: placement.along(of: local)),
+               model.snapshots.indices.contains(index) {
+                onRefreshProvider?(model.snapshots[index].id)
+                return
+            }
+            togglePinned()
         }
-        togglePinned()
     }
 
     /// Move the notch to another screen edge.

--- a/Sources/Providers/ClaudeOAuthProvider.swift
+++ b/Sources/Providers/ClaudeOAuthProvider.swift
@@ -206,7 +206,7 @@ actor ClaudeOAuthProvider: UsageProvider {
     nonisolated func forgetCachedCredential() { keychain.forgetCached() }
 
     nonisolated func account() -> ProviderAccount? {
-        guard let credentials = try? keychain.load() else { return nil }
+        guard let credentials = try? loadCredentials() else { return nil }
         return ProviderAccount(
             label: nil,   // the credential carries no address
             plan: credentials.subscriptionType,

--- a/Sources/Sessions/AgentSession.swift
+++ b/Sources/Sessions/AgentSession.swift
@@ -14,6 +14,12 @@ struct AgentSession: Identifiable, Equatable {
         case idle
     }
 
+    /// Where this session is running, so clicking it can focus the host app.
+    enum FocusTarget: Equatable {
+        case process(pid_t)
+        case application(bundleID: String)
+    }
+
     let id: String
     /// What to call it in the tooltip.
     let name: String
@@ -24,4 +30,24 @@ struct AgentSession: Identifiable, Equatable {
     let waitingFor: String?
     /// When it entered its current state.
     let since: Date
+    /// Where to direct focus when clicked.
+    let focusTarget: FocusTarget?
+
+    init(
+        id: String,
+        name: String,
+        detail: String,
+        state: State,
+        waitingFor: String?,
+        since: Date,
+        focusTarget: FocusTarget? = nil
+    ) {
+        self.id = id
+        self.name = name
+        self.detail = detail
+        self.state = state
+        self.waitingFor = waitingFor
+        self.since = since
+        self.focusTarget = focusTarget
+    }
 }

--- a/Sources/Sessions/ClaudeSessionRecord.swift
+++ b/Sources/Sessions/ClaudeSessionRecord.swift
@@ -44,7 +44,8 @@ struct ClaudeSessionRecord {
             detail: "\(Self.surface(json["entrypoint"] as? String)) · \(folder)",
             state: state,
             waitingFor: (json["waitingFor"] as? String) ?? (json["needs"] as? String),
-            since: millis.map { Date(timeIntervalSince1970: $0 / 1000) } ?? Date()
+            since: millis.map { Date(timeIntervalSince1970: $0 / 1000) } ?? Date(),
+            focusTarget: .process(pid)
         )
     }
 

--- a/Sources/Sessions/CodexActivityMonitor.swift
+++ b/Sources/Sessions/CodexActivityMonitor.swift
@@ -65,22 +65,24 @@ final class CodexActivityMonitor: ObservableObject, AgentActivityMonitor {
         // in different places: the CLI and the VS Code extension append to a
         // rollout, and the desktop app writes to its own catalogue. Whichever
         // moved last is the one that is working.
-        var candidates: [(id: String, name: String, at: Date)] = []
+        var candidates: [(id: String, name: String, at: Date, focusTarget: AgentSession.FocusTarget?)] = []
 
         if let rollout = CodexStore.newestRollout(in: stateStore),
            let modified = (try? FileManager.default
                .attributesOfItem(atPath: rollout.path))?[.modificationDate] as? Date {
             candidates.append((id: "codex.\(rollout.lastPathComponent)",
-                               name: "Codex", at: modified))
+                               name: "Codex", at: modified, focusTarget: nil))
         }
         if let desktop = CodexStore.newestDesktopThread(in: desktopStore) {
             candidates.append((id: "codex.desktop", name: desktop.title,
-                               at: desktop.updatedAt))
+                               at: desktop.updatedAt,
+                               focusTarget: .application(bundleID: "com.openai.chat")))
         }
 
         guard let newest = candidates.max(by: { $0.at < $1.at }),
               let session = session(id: newest.id, name: newest.name,
-                                    modified: newest.at, staleAfter: staleAfter, now: now)
+                                    modified: newest.at, staleAfter: staleAfter, now: now,
+                                    focusTarget: newest.focusTarget)
         else { return [] }
         return [session]
     }
@@ -89,7 +91,8 @@ final class CodexActivityMonitor: ObservableObject, AgentActivityMonitor {
     /// finished turn, and reporting it as work in progress would be a guess
     /// dressed as a fact.
     static func session(
-        id: String, name: String, modified: Date, staleAfter: TimeInterval, now: Date
+        id: String, name: String, modified: Date, staleAfter: TimeInterval, now: Date,
+        focusTarget: AgentSession.FocusTarget? = nil
     ) -> AgentSession? {
         guard now.timeIntervalSince(modified) <= staleAfter else { return nil }
         return AgentSession(
@@ -98,7 +101,8 @@ final class CodexActivityMonitor: ObservableObject, AgentActivityMonitor {
             detail: "Working",
             state: .busy,
             waitingFor: nil,
-            since: modified
+            since: modified,
+            focusTarget: focusTarget
         )
     }
 }

--- a/Sources/Sessions/CursorActivityMonitor.swift
+++ b/Sources/Sessions/CursorActivityMonitor.swift
@@ -184,7 +184,8 @@ final class CursorActivityMonitor: ObservableObject, AgentActivityMonitor {
             detail: (head["subtitle"] as? String) ?? "Cursor",
             state: state,
             waitingFor: blocked ? "needs your input" : nil,
-            since: since
+            since: since,
+            focusTarget: .application(bundleID: CursorCredentials.bundleID)
         )
     }
 

--- a/Sources/Sessions/GrokActivityMonitor.swift
+++ b/Sources/Sessions/GrokActivityMonitor.swift
@@ -97,7 +97,8 @@ enum GrokActivity {
             detail: "Grok",
             state: .busy,
             waitingFor: nil,
-            since: modified
+            since: modified,
+            focusTarget: pid.map(AgentSession.FocusTarget.process)
         )
     }
 

--- a/Sources/Sessions/SessionFocus.swift
+++ b/Sources/Sessions/SessionFocus.swift
@@ -1,0 +1,95 @@
+import AppKit
+import Darwin
+import Foundation
+
+/// Activates the host application or terminal window that owns an agent session.
+enum SessionFocus {
+    // Overridable hooks for testing
+    static var parentPidLookup: (pid_t) -> pid_t? = parentPid(of:)
+    static var appLookup: (pid_t) -> NSRunningApplication? = { NSRunningApplication(processIdentifier: $0) }
+    static var runningApplicationsLookup: () -> [NSRunningApplication] = { NSWorkspace.shared.runningApplications }
+    static var appActivator: (NSRunningApplication) -> Bool = activate(app:)
+
+    /// Attempt to bring the target session's host application to the front.
+    /// Returns `true` if an application was found and activated.
+    @discardableResult
+    static func activate(target: AgentSession.FocusTarget) -> Bool {
+        switch target {
+        case .process(let pid):
+            return activateProcess(pid: pid)
+        case .application(let bundleID):
+            return activateApplication(bundleID: bundleID)
+        }
+    }
+
+    /// Walk up the process tree from `pid` to find the nearest ancestor with an
+    /// active GUI application (e.g., Terminal, iTerm2, Warp, Ghostty, VS Code, Cursor),
+    /// then activate that application.
+    @discardableResult
+    static func activateProcess(pid: pid_t) -> Bool {
+        var current: pid_t = pid
+        for _ in 0..<30 {
+            if let app = appLookup(current), isActivatable(app) {
+                return appActivator(app)
+            }
+            guard let ppid = parentPidLookup(current), ppid > 1 else { break }
+            current = ppid
+        }
+        return false
+    }
+
+    /// Find a running application matching `bundleID` and activate it.
+    @discardableResult
+    static func activateApplication(bundleID: String) -> Bool {
+        let running = runningApplicationsLookup()
+        if let app = running.first(where: { $0.bundleIdentifier == bundleID }) {
+            return appActivator(app)
+        }
+        if let app = running.first(where: {
+            $0.bundleURL?.deletingPathExtension().lastPathComponent.caseInsensitiveCompare(bundleID) == .orderedSame
+        }) {
+            return appActivator(app)
+        }
+        if let appURL = NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleID) {
+            let config = NSWorkspace.OpenConfiguration()
+            config.activates = true
+            NSWorkspace.shared.openApplication(at: appURL, configuration: config, completionHandler: nil)
+            return true
+        }
+        return false
+    }
+
+    static func isActivatable(_ app: NSRunningApplication) -> Bool {
+        app.activationPolicy == .regular || app.bundleIdentifier != nil
+    }
+
+    @discardableResult
+    static func activate(app: NSRunningApplication) -> Bool {
+        if #available(macOS 14.0, *) {
+            return app.activate()
+        } else {
+            return app.activate(options: [.activateIgnoringOtherApps])
+        }
+    }
+
+    /// Reads the parent process ID via `sysctl` `KERN_PROC_PID`.
+    static func parentPid(of pid: pid_t) -> pid_t? {
+        var info = kinfo_proc()
+        var size = MemoryLayout<kinfo_proc>.stride
+        var mib: [Int32] = [CTL_KERN, KERN_PROC, KERN_PROC_PID, pid]
+        let result = sysctl(&mib, u_int(mib.count), &info, &size, nil, 0)
+        guard result == 0, size > 0 else { return nil }
+        let ppid = info.kp_eproc.e_ppid
+        guard ppid > 1 else { return nil }
+        return ppid
+    }
+
+    #if DEBUG
+    static func resetTestHooks() {
+        parentPidLookup = parentPid(of:)
+        appLookup = { NSRunningApplication(processIdentifier: $0) }
+        runningApplicationsLookup = { NSWorkspace.shared.runningApplications }
+        appActivator = activate(app:)
+    }
+    #endif
+}

--- a/Tests/ClaudeProfileTests.swift
+++ b/Tests/ClaudeProfileTests.swift
@@ -188,10 +188,17 @@ final class ClaudeProfileTests: XCTestCase {
         let home = URL(fileURLWithPath: "/Users/vinz")
         let store = UsageStore(
             providers: [
-                ClaudeOAuthProvider(profile: .default(home: home), archive: UsageArchive(defaults: defaults)),
-                ClaudeOAuthProvider(profile: ClaudeProfile(slug: "work",
-                                                           configDirectory: home.appendingPathComponent(".claude-work")),
-                                    archive: UsageArchive(defaults: defaults))
+                ClaudeOAuthProvider(
+                    profile: .default(home: home),
+                    archive: UsageArchive(defaults: defaults),
+                    loadCredentials: { throw UsageProviderError.needsAuth }
+                ),
+                ClaudeOAuthProvider(
+                    profile: ClaudeProfile(slug: "work",
+                                           configDirectory: home.appendingPathComponent(".claude-work")),
+                    archive: UsageArchive(defaults: defaults),
+                    loadCredentials: { throw UsageProviderError.needsAuth }
+                )
             ],
             archive: UsageArchive(defaults: defaults)
         )

--- a/Tests/SessionFocusTests.swift
+++ b/Tests/SessionFocusTests.swift
@@ -1,0 +1,165 @@
+import XCTest
+@testable import Codenotch
+
+@MainActor
+final class SessionFocusTests: XCTestCase {
+    override func tearDown() {
+        super.tearDown()
+        SessionFocus.resetTestHooks()
+    }
+
+    func testAgentSessionFocusTargetEquality() {
+        let now = Date()
+        let s1 = AgentSession(
+            id: "1", name: "test", detail: "cli", state: .busy,
+            waitingFor: nil, since: now, focusTarget: .process(1234)
+        )
+        let s2 = AgentSession(
+            id: "1", name: "test", detail: "cli", state: .busy,
+            waitingFor: nil, since: now, focusTarget: .process(1234)
+        )
+        let s3 = AgentSession(
+            id: "1", name: "test", detail: "cli", state: .busy,
+            waitingFor: nil, since: now, focusTarget: .process(5678)
+        )
+        let s4 = AgentSession(
+            id: "1", name: "test", detail: "cli", state: .busy,
+            waitingFor: nil, since: now, focusTarget: .application(bundleID: "com.apple.Terminal")
+        )
+        let s5 = AgentSession(
+            id: "1", name: "test", detail: "cli", state: .busy,
+            waitingFor: nil, since: now, focusTarget: nil
+        )
+
+        XCTAssertEqual(s1, s2)
+        XCTAssertNotEqual(s1, s3)
+        XCTAssertNotEqual(s1, s4)
+        XCTAssertNotEqual(s1, s5)
+    }
+
+    func testProcessTargetWalksProcessTreeToAncestor() {
+        var activated = false
+
+        // CLI pid 100 -> shell pid 50 -> terminal pid 10 -> launchd pid 1
+        let parents: [pid_t: pid_t] = [100: 50, 50: 10, 10: 1]
+        SessionFocus.parentPidLookup = { parents[$0] }
+
+        // Only pid 10 is a GUI app (we borrow current running app for pid 10)
+        let currentApp = NSRunningApplication.current
+        SessionFocus.appLookup = { pid in
+            pid == 10 ? currentApp : nil
+        }
+        SessionFocus.appActivator = { app in
+            if app == currentApp {
+                activated = true
+                return true
+            }
+            return false
+        }
+
+        let result = SessionFocus.activate(target: .process(100))
+        XCTAssertTrue(result)
+        XCTAssertTrue(activated)
+    }
+
+    func testProcessTargetFailsWhenNoAncestorAppFound() {
+        let parents: [pid_t: pid_t] = [100: 50, 50: 1]
+        SessionFocus.parentPidLookup = { parents[$0] }
+        SessionFocus.appLookup = { _ in nil }
+
+        let result = SessionFocus.activate(target: .process(100))
+        XCTAssertFalse(result)
+    }
+
+    func testApplicationTargetFindsRunningApp() {
+        var activated = false
+        let currentApp = NSRunningApplication.current
+        let targetBundleID = currentApp.bundleIdentifier ?? "com.apple.finder"
+
+        SessionFocus.runningApplicationsLookup = { [currentApp] }
+        SessionFocus.appActivator = { app in
+            if app == currentApp {
+                activated = true
+                return true
+            }
+            return false
+        }
+
+        let result = SessionFocus.activate(target: .application(bundleID: targetBundleID))
+        XCTAssertTrue(result)
+        XCTAssertTrue(activated)
+    }
+
+    func testApplicationTargetFailsForNonExistentBundle() {
+        SessionFocus.runningApplicationsLookup = { [] }
+        let result = SessionFocus.activate(target: .application(bundleID: "com.nonexistent.fakeapp.12345"))
+        XCTAssertFalse(result)
+    }
+
+    func testClaudeSessionRecordCarriesProcessFocusTarget() throws {
+        let json: [String: Any] = [
+            "pid": 4567,
+            "sessionId": "test-session",
+            "cwd": "/Users/vinz/project",
+            "status": "busy",
+            "statusUpdatedAt": 1787897225305
+        ]
+        let record = try XCTUnwrap(ClaudeSessionRecord(json: json))
+        XCTAssertEqual(record.session.focusTarget, .process(4567))
+    }
+
+    func testGrokActivityCarriesProcessFocusTarget() {
+        let row: [String: Any] = [
+            "session_id": "session-1",
+            "pid": 8901,
+            "cwd": "/Users/vinz/repo"
+        ]
+        let pid = (row["pid"] as? NSNumber)?.int32Value
+        let target: AgentSession.FocusTarget? = pid.map { .process($0) }
+        XCTAssertEqual(target, .process(8901))
+    }
+
+    func testCursorSessionCarriesApplicationFocusTarget() {
+        let head: [String: Any] = [
+            "composerId": "c1",
+            "name": "Refactor",
+            "unfinishedRunAt": 1787981829823,
+            "conversationCheckpointLastUpdatedAt": 1787981829823
+        ]
+        let data = try! JSONSerialization.data(withJSONObject: head)
+        let json = String(data: data, encoding: .utf8)!
+        let session = CursorActivityMonitor.session(
+            fromHeader: json,
+            cursorLaunchedAt: .distantPast,
+            staleAfter: 900,
+            now: Date(timeIntervalSince1970: 1787981830)
+        )
+        XCTAssertEqual(session?.focusTarget, .application(bundleID: CursorCredentials.bundleID))
+    }
+
+    func testCodexDesktopSessionCarriesApplicationFocusTarget() {
+        let now = Date()
+        let session = CodexActivityMonitor.session(
+            id: "codex.desktop",
+            name: "Desktop Chat",
+            modified: now,
+            staleAfter: 10,
+            now: now,
+            focusTarget: .application(bundleID: "com.openai.chat")
+        )
+        XCTAssertEqual(session?.focusTarget, .application(bundleID: "com.openai.chat"))
+    }
+
+    func testCodexRolloutSessionCarriesNilFocusTarget() {
+        let now = Date()
+        let session = CodexActivityMonitor.session(
+            id: "codex.rollout.jsonl",
+            name: "CLI Turn",
+            modified: now,
+            staleAfter: 10,
+            now: now,
+            focusTarget: nil
+        )
+        XCTAssertNil(session?.focusTarget)
+    }
+}


### PR DESCRIPTION
Resolves #29

### Summary
Makes live session rows in the provider tooltip interactive and clickable when a focus target can be resolved, bringing the owning host application or terminal window to the front.

### Implementation Details
- **Focus Targets on `AgentSession`**: Introduced `AgentSession.FocusTarget` (`.process(pid_t)` and `.application(bundleID: String)`).
- **Target Resolution**:
  - `ClaudeSessionRecord`: Provides `.process(pid)`.
  - `GrokActivityMonitor`: Provides `.process(pid)` when present.
  - `CursorActivityMonitor`: Provides `.application(bundleID: CursorCredentials.bundleID)`.
  - `CodexActivityMonitor`: Provides `.application(bundleID: "com.openai.chat")` for desktop threads, while rollouts without a known host remain informational (`nil`).
- **`SessionFocus` Activator**:
  - For `.process(pid)`: Walks the process tree ancestors using `sysctl` (`KERN_PROC_PID` / `kinfo_proc.kp_eproc.e_ppid`) to find the nearest GUI ancestor application (Terminal, iTerm2, Warp, Ghostty, VS Code, Cursor) and activates it.
  - For `.application(bundleID)`: Finds running applications with the bundle identifier or executable name and activates them.
- **Event Handling & Notch Pinning**:
  - `NotchPanel.mouseDown`: Forwards `super.mouseDown(with: event)` so SwiftUI buttons inside the tooltip card receive click events.
  - `NotchWindowController.handleClick`: Restricts `togglePinned()` and provider refresh checks to `notchRect.contains(local)`, ensuring clicking within the tooltip card does not toggle the notch pinned state.
  - Restricted pointer hand cursor to notch cells and orb handle, avoiding whole-card cursor override and allowing clickable session rows to control their own hover state.
- **UI & Layout Integrity**:
  - Clickable session rows render using a plain button style with pointing hand cursor on hover and subtle detail text brightening.
  - Preserves exact layout line heights (`2 * cardBodyLineHeight + sessionRowGap`) so `NotchLayout.cardHeight` calculations and clipping bounds remain exact.
  - Unresolvable sessions remain informational rows without pointer cursor or click handlers.

### Verification
- Ran full test suite (`xcodebuild ... test`); all 562 unit tests passed.
- Added comprehensive unit tests in `SessionFocusTests` covering process tree ancestor resolution, bundle activation, and focus target assignments.