### PR TITLE
Run CI on macOS 26

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,9 +8,20 @@ on:
 jobs:
   test:
     name: Unit tests
-    runs-on: macos-14
+    # macOS 26, because that is what the app targets. An older image ships an
+    # Xcode that cannot read the project at all — `objectVersion 77` is a
+    # format it does not know — long before it gets as far as the macOS 26
+    # deployment target or the Liquid Glass APIs the settings panel uses.
+    runs-on: macos-26
     steps:
       - uses: actions/checkout@v4
+
+      # Printed rather than assumed: when this job fails on a runner image
+      # change, the toolchain is the first thing worth seeing.
+      - name: Show toolchain
+        run: |
+          xcodebuild -version
+          xcrun --show-sdk-version
 
       - name: Install XcodeGen
         run: brew install xcodegen


### PR DESCRIPTION
CI has never passed. The workflow runs on `macos-14`, whose Xcode 15.4 refuses the project before it compiles anything:

```
xcodebuild: error: Unable to read project 'Codenotch.xcodeproj'.
Reason: The project 'Codenotch' cannot be opened because it is in a future
Xcode project file format (77).
```

Even past that, the app's deployment target is macOS 26 and the settings panel now uses the Liquid Glass APIs from that SDK, so an older Xcode could not build it.

- `runs-on: macos-26`
- a step that prints the toolchain, so the next runner-image change is diagnosable from the log rather than by guessing