### PR TITLE
feat: choose the notch size, and surface the drag that moves it

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,14 @@ when the Dock hides or moves. On a Mac with a hardware notch, the top
 placement takes its exact shape, so the two read as one rather than as a bar
 parked underneath it.
 
+Along that edge it sits wherever you put it: hold ⌥ and drag the notch to
+slide it, and each edge remembers where you left it, so moving the notch to the
+top and back does not lose the place you chose on the right. **Recentre** in
+Settings → Appearance puts the current edge back in the middle.
+
+**Size** in the same place draws the whole notch — rings, text, tooltip and all
+— smaller or larger. Medium is the size it was designed at.
+
 At rest it is a small pill on the screen edge that unfolds when the pointer
 reaches it — configurable in Settings to always show, or to hide entirely.
 Settings live in an orb below the notch: an arc at rest, a gear on hover.

--- a/Sources/App/AppDelegate.swift
+++ b/Sources/App/AppDelegate.swift
@@ -171,6 +171,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 }
                 .store(in: &cancellables)
 
+            preferences.$notchSize
+                .receive(on: RunLoop.main)
+                .sink { [weak fleet] in fleet?.apply(size: $0) }
+                .store(in: &cancellables)
+
             preferences.$notchScope
                 .receive(on: RunLoop.main)
                 .sink { [weak fleet] in fleet?.apply(scope: $0) }
@@ -304,6 +309,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // so this has to be the very last thing that can create one.
         fleet.apply(displayPreference: preferences.displayPreference)
         fleet.apply(alongOffset: preferences.offset(for: preferences.notchEdge))
+        fleet.apply(size: preferences.notchSize)
         fleet.apply(resetTimeFormat: preferences.resetTimeFormat)
         fleet.apply(accentColor: preferences.accentColor)
         fleet.show()

--- a/Sources/App/AppDelegate.swift
+++ b/Sources/App/AppDelegate.swift
@@ -114,7 +114,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 switchAccount: { [weak store] in
                     store?.openAccountSource(providerID: $0) ?? false
                 },
-                retry: { [weak store] in store?.reauthorize(providerID: $0) }
+                retry: { [weak store] in store?.reauthorize(providerID: $0) },
+                // Both halves, because the stored nudge and the live one are
+                // kept apart on purpose — clearing only the preference would
+                // leave the notch where it is until the next edge change, and
+                // moving only the panel would put it back on relaunch.
+                resetPosition: { [weak fleet, weak preferences] in
+                    preferences?.setOffset(0, for: preferences?.notchEdge ?? .right)
+                    fleet?.apply(alongOffset: 0)
+                }
             )
             fleet.onOpenSettings = { [weak settings] in settings?.show() }
             self.settings = settings

--- a/Sources/Notch/NotchFleet.swift
+++ b/Sources/Notch/NotchFleet.swift
@@ -36,6 +36,9 @@ final class NotchFleet {
     /// fleet, the same as `edge` itself — displays do not each get their own
     /// edge, so they do not each get their own nudge either.
     private var alongOffset: CGFloat = 0
+    /// One size for the whole fleet, for the same reason the edge is: a notch
+    /// that were larger on one display than another would read as a bug.
+    private var size: NotchSize = .medium
 
     /// Hooked up by the app delegate; driven by the notch's own chrome.
     var onRefresh: (() -> Void)?
@@ -138,6 +141,16 @@ final class NotchFleet {
         self.alongOffset = alongOffset
         for controller in controllers.values {
             controller.model.alongOffset = alongOffset
+        }
+    }
+
+    /// Through `controller.apply(size:)` rather than by setting the model
+    /// directly, because the panel has to be rebuilt around the new size —
+    /// the same division `apply(edge:)` keeps.
+    func apply(size: NotchSize) {
+        self.size = size
+        for controller in controllers.values {
+            controller.apply(size: size)
         }
     }
 
@@ -266,6 +279,9 @@ final class NotchFleet {
         controller.displayPreference = displayPreference
         controller.model.edge = edge
         controller.model.alongOffset = alongOffset
+        // Set before `show()`, so a display plugged in later builds its panel
+        // at the current size rather than at medium and resizing a beat later.
+        controller.model.sizeScale = size.scale
         controller.model.resetTimeFormat = resetTimeFormat
         controller.model.accentColor = accentColor
         controller.onRefresh = onRefresh

--- a/Sources/Notch/NotchLayout.swift
+++ b/Sources/Notch/NotchLayout.swift
@@ -325,11 +325,17 @@ enum NotchLayout {
     ///
     /// Which dimension crosses the ends is what differs: the card's height
     /// along a vertical edge, its width along a horizontal one.
+    /// `notchScale` applies to the notch's own margin and to nothing else. The
+    /// card half that this takes the maximum of is the card's real size on
+    /// screen, and the card is drawn at one size whatever the notch is set to —
+    /// scaling both halves would reserve room for a card that is never that
+    /// big, and at the small end would reserve less than the card needs.
     static func slack(for edge: NotchEdge,
-                      maxCardHeight: CGFloat = defaultMaxCardHeight) -> CGFloat {
+                      maxCardHeight: CGFloat = defaultMaxCardHeight,
+                      notchScale: CGFloat = 1) -> CGFloat {
         edge.isVertical
-            ? max(endSlack, maxCardHeight / 2 + cardCorner)
-            : max(endSlack, cardWidth / 2 + cardCorner)
+            ? max(endSlack * notchScale, maxCardHeight / 2 + cardCorner)
+            : max(endSlack * notchScale, cardWidth / 2 + cardCorner)
     }
 
     private static let endSlack = Design.px(190)

--- a/Sources/Notch/NotchPlacement.swift
+++ b/Sources/Notch/NotchPlacement.swift
@@ -70,9 +70,40 @@ struct NotchPlacement {
         }
     }
 
+    /// Undo a scale, to get back to the space `NotchLayout` measures in.
+    ///
+    /// The panel is built at the drawn size; every offset inside it is a
+    /// design-frame distance. Dividing once here is what lets the hit regions
+    /// keep being written in the same units as the layout they follow.
+    func unscaled(by scale: CGFloat) -> NotchPlacement {
+        NotchPlacement(edge: edge, panelSize: panelSize.multiplied(by: 1 / scale))
+    }
+
     /// The panel's extent along the stack, whichever axis that is.
     var panelLength: CGFloat { edge.isVertical ? panelSize.height : panelSize.width }
 
     /// And across it.
     var panelDepth: CGFloat { edge.isVertical ? panelSize.width : panelSize.height }
+}
+
+/// Multiplying a measurement by the Appearance size choice.
+///
+/// Written once, here, because the notch scales in exactly three places — the
+/// panel's frame, the drawn content, and the hit regions between them. Three
+/// call sites spelling out the same pair of multiplications would be three
+/// chances to scale one axis and forget the other.
+extension CGSize {
+    func multiplied(by scale: CGFloat) -> CGSize {
+        CGSize(width: width * scale, height: height * scale)
+    }
+}
+
+extension CGRect {
+    /// The origin scales too. A hit region is a position as much as a size, and
+    /// leaving the origin alone would leave every rect anchored where the
+    /// medium notch used to be.
+    func multiplied(by scale: CGFloat) -> CGRect {
+        CGRect(x: minX * scale, y: minY * scale,
+               width: width * scale, height: height * scale)
+    }
 }

--- a/Sources/Notch/NotchPlacement.swift
+++ b/Sources/Notch/NotchPlacement.swift
@@ -70,40 +70,9 @@ struct NotchPlacement {
         }
     }
 
-    /// Undo a scale, to get back to the space `NotchLayout` measures in.
-    ///
-    /// The panel is built at the drawn size; every offset inside it is a
-    /// design-frame distance. Dividing once here is what lets the hit regions
-    /// keep being written in the same units as the layout they follow.
-    func unscaled(by scale: CGFloat) -> NotchPlacement {
-        NotchPlacement(edge: edge, panelSize: panelSize.multiplied(by: 1 / scale))
-    }
-
     /// The panel's extent along the stack, whichever axis that is.
     var panelLength: CGFloat { edge.isVertical ? panelSize.height : panelSize.width }
 
     /// And across it.
     var panelDepth: CGFloat { edge.isVertical ? panelSize.width : panelSize.height }
-}
-
-/// Multiplying a measurement by the Appearance size choice.
-///
-/// Written once, here, because the notch scales in exactly three places — the
-/// panel's frame, the drawn content, and the hit regions between them. Three
-/// call sites spelling out the same pair of multiplications would be three
-/// chances to scale one axis and forget the other.
-extension CGSize {
-    func multiplied(by scale: CGFloat) -> CGSize {
-        CGSize(width: width * scale, height: height * scale)
-    }
-}
-
-extension CGRect {
-    /// The origin scales too. A hit region is a position as much as a size, and
-    /// leaving the origin alone would leave every rect anchored where the
-    /// medium notch used to be.
-    func multiplied(by scale: CGFloat) -> CGRect {
-        CGRect(x: minX * scale, y: minY * scale,
-               width: width * scale, height: height * scale)
-    }
 }

--- a/Sources/Notch/NotchRootView.swift
+++ b/Sources/Notch/NotchRootView.swift
@@ -34,12 +34,18 @@ struct NotchRootView: View {
                         // the AppKit-level path did not.
                         .contentShape(Circle())
                         .onTapGesture { model.onOpenSettings?() }
+                        // Before `position`, not after. `position` hands back a
+                        // view the size of the whole panel with the orb placed
+                        // inside it, so a scale applied after this one scales
+                        // *that* layer about the panel's centre — which moves
+                        // the orb away from the notch by a share of the panel,
+                        // and left the arc floating off the corner it is drawn
+                        // to hug. Here it scales the orb about its own centre,
+                        // which is what `orbCentre` then places.
+                        .scaleEffect(model.sizeScale)
                         .position(orbCentre(place))
                         // Outward, into the black — not inward to nothing.
                         .scaleEffect(model.isExpanded ? 1 : model.orbMergeScale)
-                        // And the size choice on top of that, so the orb keeps
-                        // its proportion to the notch it hangs off.
-                        .scaleEffect(model.sizeScale)
                         // Full strength the whole way in. The arc is buried in
                         // the notch before this reaches zero, so the fade is
                         // only there to guarantee nothing is left on screen

--- a/Sources/Notch/NotchRootView.swift
+++ b/Sources/Notch/NotchRootView.swift
@@ -9,13 +9,7 @@ struct NotchRootView: View {
         // AppKit settled on, and the notch has to sit flush against *that*
         // edge, not against the size we asked for.
         GeometryReader { proxy in
-            // Everything below is laid out at the size the design frame was
-            // drawn at, and scaled once on the way out. Laying out at the real
-            // panel size instead would mean every `NotchLayout` constant
-            // needing a multiplication of its own — forty chances to miss one,
-            // and no way left to check any of them against the frame.
-            let canvas = proxy.size.multiplied(by: 1 / model.sizeScale)
-            let place = NotchPlacement(edge: model.edge, panelSize: canvas)
+            let place = NotchPlacement(edge: model.edge, panelSize: proxy.size)
 
             ZStack(alignment: .topLeading) {
                 Color.clear
@@ -43,6 +37,9 @@ struct NotchRootView: View {
                         .position(orbCentre(place))
                         // Outward, into the black — not inward to nothing.
                         .scaleEffect(model.isExpanded ? 1 : model.orbMergeScale)
+                        // And the size choice on top of that, so the orb keeps
+                        // its proportion to the notch it hangs off.
+                        .scaleEffect(model.sizeScale)
                         // Full strength the whole way in. The arc is buried in
                         // the notch before this reaches zero, so the fade is
                         // only there to guarantee nothing is left on screen
@@ -74,13 +71,9 @@ struct NotchRootView: View {
                         )))
                 }
             }
-            .frame(width: canvas.width, height: canvas.height)
+            .frame(width: proxy.size.width, height: proxy.size.height)
             // Swapping cards is a movement like any other here.
             .animation(motion(NotchMotion.glide), value: model.hoveredIndex)
-            // Anchored top-leading because the canvas is the panel divided by
-            // the scale: multiplying it back from that corner lands it on the
-            // panel exactly, whichever edge the notch is welded to.
-            .scaleEffect(model.sizeScale, anchor: .topLeading)
         }
         .animation(motion(NotchMotion.unfold), value: model.isExpanded)
         .tint(model.accentColor.color)
@@ -113,9 +106,17 @@ struct NotchRootView: View {
             // slide out of the end of it; clipped, they are swallowed by the
             // outline as it closes, which is what a notch should do.
             .clipShape(SideNotchShape(edge: model.edge, joining: model.joinedNotch))
+            // The size choice, applied to the notch and the cells it carries —
+            // and to nothing else. Drawn at design-frame size and scaled from
+            // there, so `NotchLayout` keeps measuring the one thing it is
+            // quoted from.
+            .scaleEffect(model.sizeScale)
+            // `notchLeadingInset + notchLength / 2` is `slack + shapeLength / 2`
+            // — the two `notchLength` terms cancel — so folding away moves the
+            // centre nowhere and only the shape's own half-extent scales here.
             .position(place.point(
-                along: model.notchLeadingInset + model.notchLength / 2,
-                across: model.notchDepth / 2
+                along: model.slack + model.shapeLength * model.sizeScale / 2,
+                across: model.notchDepth * model.sizeScale / 2
             ))
     }
 
@@ -197,10 +198,13 @@ struct NotchRootView: View {
 
     /// The orb sits on the flare's own centre of curvature, one radius in from
     /// the bezel and level with the far end of the shape.
+    /// The orb belongs to the notch, not to the tooltip, so it scales with it —
+    /// it is tucked into the corner the shape's own flare makes, and a fixed
+    /// orb against a scaled flare would sit off that corner.
     private func orbCentre(_ place: NotchPlacement) -> CGPoint {
         place.point(
-            along: model.slack + model.orbAlong,
-            across: model.orbInset
+            along: model.slack + model.orbAlong * model.sizeScale,
+            across: model.orbInset * model.sizeScale
         )
     }
 
@@ -218,8 +222,11 @@ struct NotchRootView: View {
                 statusMessage: snapshot.statusMessage,
                 blockMessage: snapshot.block?.summary(now: model.now)
             )
+        // The ring it points at has moved with the notch, so the tail follows
+        // it — but the card beyond the tail is drawn at its own size, and
+        // `tooltipInset` already ends where the drawn notch does.
         return place.point(
-            along: model.slack + model.ringCenter(index: index),
+            along: model.slack + model.ringCenter(index: index) * model.sizeScale,
             across: model.tooltipInset + (NotchLayout.tailLength + card) / 2
         )
     }

--- a/Sources/Notch/NotchRootView.swift
+++ b/Sources/Notch/NotchRootView.swift
@@ -9,7 +9,13 @@ struct NotchRootView: View {
         // AppKit settled on, and the notch has to sit flush against *that*
         // edge, not against the size we asked for.
         GeometryReader { proxy in
-            let place = NotchPlacement(edge: model.edge, panelSize: proxy.size)
+            // Everything below is laid out at the size the design frame was
+            // drawn at, and scaled once on the way out. Laying out at the real
+            // panel size instead would mean every `NotchLayout` constant
+            // needing a multiplication of its own — forty chances to miss one,
+            // and no way left to check any of them against the frame.
+            let canvas = proxy.size.multiplied(by: 1 / model.sizeScale)
+            let place = NotchPlacement(edge: model.edge, panelSize: canvas)
 
             ZStack(alignment: .topLeading) {
                 Color.clear
@@ -68,9 +74,13 @@ struct NotchRootView: View {
                         )))
                 }
             }
-            .frame(width: proxy.size.width, height: proxy.size.height)
+            .frame(width: canvas.width, height: canvas.height)
             // Swapping cards is a movement like any other here.
             .animation(motion(NotchMotion.glide), value: model.hoveredIndex)
+            // Anchored top-leading because the canvas is the panel divided by
+            // the scale: multiplying it back from that corner lands it on the
+            // panel exactly, whichever edge the notch is welded to.
+            .scaleEffect(model.sizeScale, anchor: .topLeading)
         }
         .animation(motion(NotchMotion.unfold), value: model.isExpanded)
         .tint(model.accentColor.color)

--- a/Sources/Notch/NotchViewModel.swift
+++ b/Sources/Notch/NotchViewModel.swift
@@ -261,7 +261,17 @@ final class NotchViewModel: ObservableObject {
     /// Where the tooltip's tail tip sits, measured in from the bezel: just off
     /// the inner face of a shape that the extension has made deeper.
     var tooltipInset: CGFloat {
-        contentInset + NotchLayout.bodyDepth(for: edge) + NotchLayout.tailGap
+        notchDrawnDepth + NotchLayout.tailGap
+    }
+
+    /// How deep the notch body reaches on screen — the design-frame depth at
+    /// the size it is actually drawn.
+    ///
+    /// Where the notch ends is where the tooltip begins, and the tooltip is not
+    /// drawn at that size, so this is the seam between the two spaces rather
+    /// than a measurement either of them owns.
+    var notchDrawnDepth: CGFloat {
+        (contentInset + NotchLayout.bodyDepth(for: edge)) * sizeScale
     }
 
     /// The straight part of the shape, flares excluded.
@@ -299,7 +309,9 @@ final class NotchViewModel: ObservableObject {
     var slack: CGFloat { slack(cellCount: snapshots.count) }
 
     func slack(cellCount: Int) -> CGFloat {
-        NotchLayout.slack(for: edge, maxCardHeight: maxCardHeight(cellCount: cellCount))
+        NotchLayout.slack(for: edge,
+                          maxCardHeight: maxCardHeight(cellCount: cellCount),
+                          notchScale: sizeScale)
     }
 
     /// How many sessions a tooltip may list here before it has to summarise
@@ -388,15 +400,24 @@ final class NotchViewModel: ObservableObject {
             + 2 * endSpread(cellCount: cellCount)
     }
 
+    /// The panel as it lands on screen, size choice included.
+    ///
+    /// Two spaces, added rather than multiplied together: the notch is drawn at
+    /// `sizeScale`, and the tooltip is drawn at one size whatever the notch is
+    /// set to — its text has a legible size of its own, and shrinking the
+    /// reading you opened the notch to read is the opposite of the point.
+    ///
+    /// So the notch's share scales and the card's share does not. Scaling the
+    /// whole panel instead left the card cropped at the small end, where the
+    /// panel had shrunk around a card that had not.
     func panelSize(cellCount: Int) -> CGSize {
         let card = maxCardHeight(cellCount: cellCount)
         return NotchPlacement.panelSize(
             edge: edge,
-            length: shapeLength(cellCount: cellCount)
-                + 2 * NotchLayout.slack(for: edge, maxCardHeight: card),
-            depth: contentInset
+            length: shapeLength(cellCount: cellCount) * sizeScale
+                + 2 * NotchLayout.slack(for: edge, maxCardHeight: card, notchScale: sizeScale),
+            depth: (contentInset + NotchLayout.bodyDepth(for: edge)) * sizeScale
                 + NotchLayout.tooltipDepth(for: edge, maxCardHeight: card)
-                + NotchLayout.bodyDepth(for: edge)
         )
     }
 }

--- a/Sources/Notch/NotchViewModel.swift
+++ b/Sources/Notch/NotchViewModel.swift
@@ -55,6 +55,16 @@ final class NotchViewModel: ObservableObject {
     /// the new edge whenever `edge` changes; this type does not own that
     /// persistence, only the live value.
     @Published var alongOffset: CGFloat = 0
+    /// What every measured distance is multiplied by before it reaches the
+    /// screen — the Appearance size choice, as a number.
+    ///
+    /// Everything in this type stays in **unscaled** points, the size the
+    /// design frame is drawn at, and so does `NotchLayout`. Scaling at the
+    /// source would mean threading a factor through forty constants and
+    /// leaving each one no longer comparable to the frame it is quoted from.
+    /// The multiplication happens once, at the two places that touch the
+    /// screen: the panel's frame and the drawn content.
+    @Published var sizeScale: CGFloat = 1
     /// Mirrors the persisted Appearance choice so the separate notch window
     /// redraws immediately when Settings changes it.
     @Published var accentColor: AccentColorChoice = .system
@@ -313,13 +323,18 @@ final class NotchViewModel: ObservableObject {
     /// stack, half of it past each end, so the stack itself takes its share
     /// first. Along a horizontal edge the card hangs *inward* instead, and what
     /// it competes with is the depth already spent on the notch body and tail.
+    /// The screen is measured in real points, and everything it is compared
+    /// against here is unscaled. Dividing brings the screen into the same space
+    /// rather than scaling the four constants below it: at `large` a card sized
+    /// against the raw height would be drawn a quarter taller than it was
+    /// budgeted for, and run off the bottom of a small display.
     private func cardBudget(cellCount: Int) -> CGFloat {
         if edge.isVertical {
-            return screenSize.height
+            return screenSize.height / sizeScale
                 - shapeLength(cellCount: cellCount)
                 - 2 * NotchLayout.cardCorner
         }
-        return screenUsableSize.height
+        return screenUsableSize.height / sizeScale
             - contentInset
             - NotchLayout.bodyDepth(for: edge)
             - NotchLayout.tailLength

--- a/Sources/Notch/NotchWindowController.swift
+++ b/Sources/Notch/NotchWindowController.swift
@@ -148,17 +148,10 @@ final class NotchWindowController {
     func relocate(cellCount: Int? = nil) {
         guard let screen = currentScreen() else { return }
         model.adopt(screen: screen)
-        // One of the two places the size choice reaches the screen — the panel
-        // has to be the drawn size, not the design-frame size. The offset and
-        // the slack are scaled with it because both are distances along the
-        // same edge: leaving them unscaled would clamp a large notch as though
-        // it were a medium one, and the drag would stop short of the corner.
-        let scale = model.sizeScale
         let size = model.panelSize(cellCount: cellCount ?? model.snapshots.count)
-            .multiplied(by: scale)
         let frame = NotchGeometry.panelFrame(
             for: screen, panelSize: size, edge: model.edge,
-            alongOffset: model.alongOffset, slack: model.slack * scale
+            alongOffset: model.alongOffset, slack: model.slack
         )
         lastVisibleFrame = screen.visibleFrame
 
@@ -228,14 +221,8 @@ final class NotchWindowController {
 
     /// The panel's real size, which AppKit may have rounded up from the one we
     /// asked for — and which the flush edge depends on.
-    /// Taken back to design-frame space, so every rect below can be written in
-    /// the same units as the `NotchLayout` constants it is built from. The one
-    /// multiplication back into screen points happens in
-    /// `updateInteractiveRects`.
     private var placement: NotchPlacement {
-        NotchPlacement(edge: model.edge,
-                       panelSize: panel?.frame.size ?? model.panelSize.multiplied(by: model.sizeScale))
-            .unscaled(by: model.sizeScale)
+        NotchPlacement(edge: model.edge, panelSize: panel?.frame.size ?? model.panelSize)
     }
 
     /// The notch itself, in panel coordinates with a top-left origin.
@@ -243,8 +230,8 @@ final class NotchWindowController {
         placement.rect(
             along: model.slack,
             across: 0,
-            length: model.shapeLength,
-            depth: model.notchDepth
+            length: model.shapeLength * model.sizeScale,
+            depth: model.notchDepth * model.sizeScale
         )
     }
 
@@ -255,12 +242,12 @@ final class NotchWindowController {
         // Whatever the resting shape is — the pill, or the display's own notch
         // when it is joining one — the region that wakes it is that plus a
         // generous band, because both are small targets on a screen edge.
-        let length = max(model.restingLength, NotchLayout.pillHotZone)
+        let length = max(model.restingLength * model.sizeScale, NotchLayout.pillHotZone)
         return placement.rect(
-            along: model.slack + (model.shapeLength - length) / 2,
+            along: model.slack + (model.shapeLength * model.sizeScale - length) / 2,
             across: 0,
             length: length,
-            depth: model.restingDepth + NotchLayout.pillHotZone
+            depth: model.restingDepth * model.sizeScale + NotchLayout.pillHotZone
         )
     }
 
@@ -270,7 +257,8 @@ final class NotchWindowController {
     private var handleRect: CGRect {
         let side = NotchLayout.orbHotZone
         let boxes = model.orbHandlePoints.map { point -> CGRect in
-            let centre = placement.point(along: model.slack + point.x, across: point.y)
+            let centre = placement.point(along: model.slack + point.x * model.sizeScale,
+                                         across: point.y * model.sizeScale)
             return CGRect(x: centre.x - side / 2, y: centre.y - side / 2,
                           width: side, height: side)
         }
@@ -280,8 +268,13 @@ final class NotchWindowController {
     /// Whether the pointer is on the handle itself rather than merely inside
     /// the box that contains it.
     private func isOverHandle(_ local: CGPoint) -> Bool {
-        model.isOnOrbHandle(along: placement.along(of: local) - model.slack,
-                            across: placement.across(of: local))
+        // Back into the notch's own measurements, which is what `isOnOrbHandle`
+        // is written in — the orb scales with the notch, so its hit test has to
+        // be asked in the same space the shape was drawn in.
+        model.isOnOrbHandle(
+            along: (placement.along(of: local) - model.slack) / model.sizeScale,
+            across: placement.across(of: local) / model.sizeScale
+        )
     }
 
     /// The only region that takes the mouse. Everything else in the panel is a
@@ -309,10 +302,12 @@ final class NotchWindowController {
         // pointer has to cross. Along it, the card's own extent.
         let cardAcross = model.edge.isVertical ? NotchLayout.cardWidth : cardHeight
         let cardAlong = model.edge.isVertical ? cardHeight : NotchLayout.cardWidth
-        let centre = model.slack + model.ringCenter(index: index)
+        let centre = model.slack + model.ringCenter(index: index) * model.sizeScale
         return placement.rect(
             along: centre - cardAlong / 2,
-            across: model.contentInset + NotchLayout.bodyDepth(for: model.edge),
+            // The card's own extent does not scale, and it begins where the
+            // drawn notch ends.
+            across: model.notchDrawnDepth,
             length: cardAlong,
             depth: NotchLayout.tailGap + NotchLayout.tailLength + cardAcross
         )
@@ -323,11 +318,6 @@ final class NotchWindowController {
         if model.isExpanded, let index = model.hoveredIndex, let card = tooltipRect(index: index) {
             rects.append(card)
         }
-        // Back into screen points. These regions are what the pointer is
-        // actually tested against, so a scale applied to the drawing and not to
-        // these would leave a large notch with a medium notch's hit area —
-        // visibly there, and unreachable at its edges.
-        rects = rects.map { $0.multiplied(by: model.sizeScale) }
         hostingView?.interactiveRects = rects
         if let panel {
             panel.ignoresMouseEvents = !rects.contains { $0.contains(localCursor(in: panel.frame)) }
@@ -760,10 +750,13 @@ final class NotchWindowController {
         updateInteractiveRects()
     }
 
+    /// `along` arrives in panel points, so the cells it is compared against
+    /// have to be where they are drawn rather than where they are measured —
+    /// pitch included, or a large notch would match the wrong ring at the ends.
     private func cellIndex(along: CGFloat) -> Int? {
-        let pitch = NotchLayout.cellPitch(for: model.edge)
+        let pitch = NotchLayout.cellPitch(for: model.edge) * model.sizeScale
         for index in model.snapshots.indices {
-            let centre = model.slack + model.ringCenter(index: index)
+            let centre = model.slack + model.ringCenter(index: index) * model.sizeScale
             if abs(along - centre) <= pitch / 2 { return index }
         }
         return nil

--- a/Sources/Notch/NotchWindowController.swift
+++ b/Sources/Notch/NotchWindowController.swift
@@ -148,10 +148,17 @@ final class NotchWindowController {
     func relocate(cellCount: Int? = nil) {
         guard let screen = currentScreen() else { return }
         model.adopt(screen: screen)
+        // One of the two places the size choice reaches the screen — the panel
+        // has to be the drawn size, not the design-frame size. The offset and
+        // the slack are scaled with it because both are distances along the
+        // same edge: leaving them unscaled would clamp a large notch as though
+        // it were a medium one, and the drag would stop short of the corner.
+        let scale = model.sizeScale
         let size = model.panelSize(cellCount: cellCount ?? model.snapshots.count)
+            .multiplied(by: scale)
         let frame = NotchGeometry.panelFrame(
             for: screen, panelSize: size, edge: model.edge,
-            alongOffset: model.alongOffset, slack: model.slack
+            alongOffset: model.alongOffset, slack: model.slack * scale
         )
         lastVisibleFrame = screen.visibleFrame
 
@@ -221,8 +228,14 @@ final class NotchWindowController {
 
     /// The panel's real size, which AppKit may have rounded up from the one we
     /// asked for — and which the flush edge depends on.
+    /// Taken back to design-frame space, so every rect below can be written in
+    /// the same units as the `NotchLayout` constants it is built from. The one
+    /// multiplication back into screen points happens in
+    /// `updateInteractiveRects`.
     private var placement: NotchPlacement {
-        NotchPlacement(edge: model.edge, panelSize: panel?.frame.size ?? model.panelSize)
+        NotchPlacement(edge: model.edge,
+                       panelSize: panel?.frame.size ?? model.panelSize.multiplied(by: model.sizeScale))
+            .unscaled(by: model.sizeScale)
     }
 
     /// The notch itself, in panel coordinates with a top-left origin.
@@ -310,6 +323,11 @@ final class NotchWindowController {
         if model.isExpanded, let index = model.hoveredIndex, let card = tooltipRect(index: index) {
             rects.append(card)
         }
+        // Back into screen points. These regions are what the pointer is
+        // actually tested against, so a scale applied to the drawing and not to
+        // these would leave a large notch with a medium notch's hit area —
+        // visibly there, and unreachable at its edges.
+        rects = rects.map { $0.multiplied(by: model.sizeScale) }
         hostingView?.interactiveRects = rects
         if let panel {
             panel.ignoresMouseEvents = !rects.contains { $0.contains(localCursor(in: panel.frame)) }
@@ -533,6 +551,19 @@ final class NotchWindowController {
     /// animation can smooth over, and animating a panel across a corner looks
     /// like a bug rather than a choice — hence the crossing rather than a
     /// slide.
+    /// A new size choice: set it, then rebuild the panel around it.
+    ///
+    /// Set-then-relocate rather than a subscription on `model.$sizeScale`,
+    /// because `@Published` fires in `willSet` — a sink here would recompute
+    /// the panel from the size that is being replaced. `apply(edge:)` is the
+    /// same shape for the same reason.
+    func apply(size: NotchSize) {
+        guard model.sizeScale != size.scale else { return }
+        model.sizeScale = size.scale
+        relocate()
+        updateInteractiveRects()
+    }
+
     func apply(edge: NotchEdge) {
         guard model.edge != edge else { return }
         guard let panel else {   // before there is anything on screen to fade

--- a/Sources/Settings/NotchSize.swift
+++ b/Sources/Settings/NotchSize.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+/// How large the notch is drawn.
+///
+/// A fixed set rather than a free number, for the same reason `PeekDuration` is
+/// one: the useful range is narrow. Below about three quarters the percentage
+/// under each ring stops being readable at a glance, which is the one thing the
+/// notch exists to do; much above a quarter larger and a stack of five
+/// providers is competing with the windows it sits beside rather than reporting
+/// on them.
+///
+/// The scale multiplies the whole surface — rings, text, tooltip and all — so
+/// the proportions stay exactly as they were drawn. `NotchLayout` keeps every
+/// constant it quotes from the design frame, and `medium` is that frame at 1:1.
+enum NotchSize: String, CaseIterable, Identifiable {
+    case small
+    case medium
+    case large
+
+    var id: String { rawValue }
+
+    /// What every measured distance is multiplied by. `medium` is 1, so it is
+    /// the design frame untouched and the behaviour every earlier version had.
+    var scale: CGFloat {
+        switch self {
+        case .small:  return 0.8
+        case .medium: return 1
+        case .large:  return 1.25
+        }
+    }
+
+    var title: String {
+        switch self {
+        case .small:  return "Small"
+        case .medium: return "Medium"
+        case .large:  return "Large"
+        }
+    }
+
+    var explanation: String {
+        switch self {
+        case .small:
+            return "Takes the least room on the edge. Readable, but not from across the desk."
+        case .medium:
+            return "The size the notch was drawn at."
+        case .large:
+            return "Easier to read at a glance, and harder to ignore."
+        }
+    }
+}

--- a/Sources/Settings/Preferences.swift
+++ b/Sources/Settings/Preferences.swift
@@ -48,6 +48,11 @@ final class Preferences: ObservableObject {
         didSet { defaults.set(notchEdge.rawValue, forKey: Keys.edge) }
     }
 
+    /// How large the notch is drawn.
+    @Published var notchSize: NotchSize {
+        didSet { defaults.set(notchSize.rawValue, forKey: Keys.size) }
+    }
+
     /// The display the notch stays on, or the original focus-following behaviour.
     ///
     /// Only meaningful in `NotchScreenScope.main` — pinning a display and
@@ -184,6 +189,8 @@ final class Preferences: ObservableObject {
         static let visibility = "notchVisibility"
         static let presence = "appPresence"
         static let edge = "notchEdge"
+        // A new key, so there is nothing under the old app name to migrate.
+        static let size = "notchSize"
         static let display = "notchDisplay"
         static let resetTimeFormat = "resetTimeFormat"
         static let scope = "notchScope"
@@ -265,6 +272,10 @@ final class Preferences: ObservableObject {
         // side of a Mac that no system chrome claims by default.
         self.notchEdge = defaults.string(forKey: Keys.edge)
             .flatMap(NotchEdge.init(rawValue:)) ?? .right
+        // Medium is the design frame at 1:1, so an install that predates this
+        // choice keeps exactly the notch it already had.
+        self.notchSize = defaults.string(forKey: Keys.size)
+            .flatMap(NotchSize.init(rawValue:)) ?? .medium
         self.displayPreference = defaults.string(forKey: Keys.display)
             .map(DisplayPreference.display) ?? .followActiveWindow
         self.resetTimeFormat = defaults.string(forKey: Keys.resetTimeFormat)

--- a/Sources/Settings/SettingsView.swift
+++ b/Sources/Settings/SettingsView.swift
@@ -133,6 +133,11 @@ struct SettingsView: View {
     /// Re-reads a provider's credential. For a declined keychain prompt that is
     /// the whole remedy: asking again is what puts the prompt back on screen.
     let retry: (String) -> Void
+    /// Put the notch back in the middle of its edge. A closure rather than a
+    /// write to `preferences`, because the stored offset is not `@Published` —
+    /// nothing would tell the notch to move, and the setting would only take
+    /// effect the next time the edge changed.
+    let resetPosition: () -> Void
     @ObservedObject var updater: Updater
 
     var body: some View {
@@ -434,6 +439,22 @@ struct SettingsView: View {
                     .font(.caption)
                     .foregroundStyle(.secondary)
                     .fixedSize(horizontal: false, vertical: true)
+
+                // The nudge has been draggable since the edge picker existed,
+                // and nothing on screen has ever said so — the only way to
+                // find it was to hold ⌥ on the notch and see what happened.
+                // This is also the only way back from a nudge that went too
+                // far, short of dragging it out again.
+                HStack {
+                    Text("Hold ⌥ and drag the notch to slide it along its edge. "
+                         + "Each edge remembers where you left it.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                    Spacer()
+                    Button("Recentre", action: resetPosition)
+                        .controlSize(.small)
+                }
 
                 Picker("Displays", selection: $preferences.notchScope) {
                     ForEach(NotchScreenScope.allCases) { Text($0.title).tag($0) }

--- a/Sources/Settings/SettingsView.swift
+++ b/Sources/Settings/SettingsView.swift
@@ -425,6 +425,16 @@ struct SettingsView: View {
                     .foregroundStyle(.secondary)
                     .fixedSize(horizontal: false, vertical: true)
 
+                Picker("Size", selection: $preferences.notchSize) {
+                    ForEach(NotchSize.allCases) { Text($0.title).tag($0) }
+                }
+                .pickerStyle(.segmented)
+
+                Text(preferences.notchSize.explanation)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+
                 Picker("Displays", selection: $preferences.notchScope) {
                     ForEach(NotchScreenScope.allCases) { Text($0.title).tag($0) }
                 }

--- a/Sources/Settings/SettingsWindowController.swift
+++ b/Sources/Settings/SettingsWindowController.swift
@@ -19,6 +19,7 @@ final class SettingsWindowController: NSObject, NSWindowDelegate {
     private let switchAccount: (String) -> Bool
     private let retry: (String) -> Void
     private let updater: Updater
+    private let resetPosition: () -> Void
 
     init(preferences: Preferences,
          providers: @escaping () -> [ProviderSummary],
@@ -26,7 +27,9 @@ final class SettingsWindowController: NSObject, NSWindowDelegate {
          signOut: @escaping (String) -> Void,
          signIn: @escaping (String) -> Bool,
          switchAccount: @escaping (String) -> Bool,
-         retry: @escaping (String) -> Void) {
+         retry: @escaping (String) -> Void,
+         resetPosition: @escaping () -> Void) {
+        self.resetPosition = resetPosition
         self.switchAccount = switchAccount
         self.retry = retry
         self.updater = updater
@@ -143,6 +146,7 @@ final class SettingsWindowController: NSObject, NSWindowDelegate {
                                    signIn: signIn,
                                    switchAccount: switchAccount,
                                    retry: retry,
+                                   resetPosition: resetPosition,
                                    updater: updater)
         )
         window.center()

--- a/Tests/AntigravityTests.swift
+++ b/Tests/AntigravityTests.swift
@@ -623,6 +623,7 @@ final class FirstRunCopyTests: XCTestCase {
                             signOut: { _ in }, signIn: { _ in true },
                             switchAccount: { _ in true },
                             retry: { _ in },
+                            resetPosition: {},
                             updater: Updater())
     }
 

--- a/Tests/NotchGeometryTests.swift
+++ b/Tests/NotchGeometryTests.swift
@@ -192,3 +192,47 @@ final class PanelEdgeTests: XCTestCase {
         XCTAssertEqual(frame.maxX, 0, accuracy: 0.0001)
     }
 }
+
+/// The size choice reaches the screen as a multiplication, in three places that
+/// have to agree: the panel's frame, the drawn content, and the hit regions.
+/// These pin the two that are easy to get half-right.
+final class ScaledMeasurementTests: XCTestCase {
+    /// A hit region is a position as much as a size. Scaling only the size is
+    /// the bug this guards: the notch would be drawn large and still be
+    /// reachable only where the medium one used to be.
+    func testARectScalesItsOriginAsWellAsItsSize() {
+        let scaled = CGRect(x: 10, y: 20, width: 30, height: 40).multiplied(by: 2)
+
+        XCTAssertEqual(scaled, CGRect(x: 20, y: 40, width: 60, height: 80))
+    }
+
+    func testASizeScalesBothAxes() {
+        XCTAssertEqual(CGSize(width: 10, height: 20).multiplied(by: 0.5),
+                       CGSize(width: 5, height: 10))
+    }
+
+    /// The hit regions are written in design-frame units and the panel is built
+    /// in screen points, so the placement has to be taken back before they can
+    /// be compared. Round-tripping is what makes that safe to rely on.
+    func testUnscalingAPlacementInvertsTheScale() {
+        let panel = CGSize(width: 200, height: 800)
+        let placement = NotchPlacement(edge: .right, panelSize: panel.multiplied(by: 1.25))
+
+        XCTAssertEqual(placement.unscaled(by: 1.25).panelSize.width, panel.width, accuracy: 0.001)
+        XCTAssertEqual(placement.unscaled(by: 1.25).panelSize.height, panel.height, accuracy: 0.001)
+    }
+
+    /// A scaled panel is still a panel: it has to land flush on the bezel like
+    /// any other, or a large notch floats a hairline off the edge.
+    func testAScaledPanelStillLandsFlushOnTheEdge() {
+        let screen = FakeScreen(frameValue: CGRect(x: 0, y: 0, width: 1800, height: 1000),
+                                visibleFrameValue: CGRect(x: 0, y: 0, width: 1800, height: 1000))
+        let frame = NotchGeometry.panelFrame(
+            for: screen,
+            panelSize: CGSize(width: 160, height: 600).multiplied(by: 1.25),
+            edge: .right
+        )
+
+        XCTAssertEqual(frame.maxX, 1800, accuracy: 0.001)
+    }
+}

--- a/Tests/NotchGeometryTests.swift
+++ b/Tests/NotchGeometryTests.swift
@@ -193,35 +193,9 @@ final class PanelEdgeTests: XCTestCase {
     }
 }
 
-/// The size choice reaches the screen as a multiplication, in three places that
-/// have to agree: the panel's frame, the drawn content, and the hit regions.
-/// These pin the two that are easy to get half-right.
+/// The size choice reaches the screen in the notch's own measurements, never
+/// in the tooltip's. These pin the seam between the two.
 final class ScaledMeasurementTests: XCTestCase {
-    /// A hit region is a position as much as a size. Scaling only the size is
-    /// the bug this guards: the notch would be drawn large and still be
-    /// reachable only where the medium one used to be.
-    func testARectScalesItsOriginAsWellAsItsSize() {
-        let scaled = CGRect(x: 10, y: 20, width: 30, height: 40).multiplied(by: 2)
-
-        XCTAssertEqual(scaled, CGRect(x: 20, y: 40, width: 60, height: 80))
-    }
-
-    func testASizeScalesBothAxes() {
-        XCTAssertEqual(CGSize(width: 10, height: 20).multiplied(by: 0.5),
-                       CGSize(width: 5, height: 10))
-    }
-
-    /// The hit regions are written in design-frame units and the panel is built
-    /// in screen points, so the placement has to be taken back before they can
-    /// be compared. Round-tripping is what makes that safe to rely on.
-    func testUnscalingAPlacementInvertsTheScale() {
-        let panel = CGSize(width: 200, height: 800)
-        let placement = NotchPlacement(edge: .right, panelSize: panel.multiplied(by: 1.25))
-
-        XCTAssertEqual(placement.unscaled(by: 1.25).panelSize.width, panel.width, accuracy: 0.001)
-        XCTAssertEqual(placement.unscaled(by: 1.25).panelSize.height, panel.height, accuracy: 0.001)
-    }
-
     /// A scaled panel is still a panel: it has to land flush on the bezel like
     /// any other, or a large notch floats a hairline off the edge.
     func testAScaledPanelStillLandsFlushOnTheEdge() {
@@ -229,10 +203,24 @@ final class ScaledMeasurementTests: XCTestCase {
                                 visibleFrameValue: CGRect(x: 0, y: 0, width: 1800, height: 1000))
         let frame = NotchGeometry.panelFrame(
             for: screen,
-            panelSize: CGSize(width: 160, height: 600).multiplied(by: 1.25),
+            panelSize: CGSize(width: 200, height: 750),
             edge: .right
         )
 
         XCTAssertEqual(frame.maxX, 1800, accuracy: 0.001)
+    }
+
+    /// The notch's own end margin scales; the room reserved for the card does
+    /// not. Scaling both would reserve space for a card that is never that big,
+    /// and at the small end would reserve less than the card needs.
+    func testSlackScalesTheNotchsMarginAndNotTheCards() {
+        let cardBound = NotchLayout.slack(for: .right, maxCardHeight: 2000)
+        XCTAssertEqual(NotchLayout.slack(for: .right, maxCardHeight: 2000, notchScale: 0.8),
+                       cardBound,
+                       "the card's half-extent was scaled with the notch")
+
+        let marginBound = NotchLayout.slack(for: .right, maxCardHeight: 0)
+        XCTAssertEqual(NotchLayout.slack(for: .right, maxCardHeight: 0, notchScale: 2),
+                       marginBound * 2, accuracy: 0.001)
     }
 }

--- a/Tests/NotchLayoutTests.swift
+++ b/Tests/NotchLayoutTests.swift
@@ -1224,3 +1224,75 @@ final class StatusMessageHeightTests: XCTestCase {
         }
     }
 }
+
+/// Choosing a size multiplies the whole surface. What matters is that it is a
+/// multiplication and nothing more: the design frame stays the thing every
+/// constant is quoted from, and `medium` stays that frame untouched.
+@MainActor
+final class NotchSizeTests: XCTestCase {
+    private struct Screen: ScreenDescribing {
+        var frameValue: CGRect
+        var visibleFrameValue: CGRect
+    }
+
+    private func model(scale: CGFloat, edge: NotchEdge = .right,
+                       height: CGFloat = 900) -> NotchViewModel {
+        let model = NotchViewModel()
+        model.edge = edge
+        model.sizeScale = scale
+        model.adopt(screen: Screen(frameValue: CGRect(x: 0, y: 0, width: 1440, height: height),
+                                   visibleFrameValue: CGRect(x: 0, y: 0, width: 1440, height: height)))
+        return model
+    }
+
+    /// The point of the setting, stated as the thing the eye actually judges:
+    /// the notch's own body, at the size it is drawn on screen.
+    ///
+    /// Not the panel — most of that is transparent padding reserved for the
+    /// tooltip, and it is budgeted against a screen that does not grow when the
+    /// notch does, so the panel is not monotonic in the size choice even though
+    /// the notch is.
+    func testTheDrawnNotchGrowsWithTheSizeChoice() {
+        func drawnDepth(_ size: NotchSize) -> CGFloat {
+            let model = model(scale: size.scale)
+            model.isExpanded = true
+            return model.notchDepth * size.scale
+        }
+
+        XCTAssertGreaterThan(drawnDepth(.large), drawnDepth(.medium))
+        XCTAssertGreaterThan(drawnDepth(.medium), drawnDepth(.small))
+    }
+
+    /// The other half of that coupling, pinned so it is a decision rather than
+    /// a surprise: a larger notch is given a *shorter* card, because the screen
+    /// it has to fit on stayed the same size.
+    func testALargerNotchIsGivenAShorterCard() {
+        XCTAssertLessThan(model(scale: 1.25).maxCardHeight(cellCount: 3),
+                          model(scale: 0.8).maxCardHeight(cellCount: 3))
+    }
+
+    /// The trap this feature sets for itself. The tooltip is budgeted against
+    /// the screen, and the screen does not grow when the notch does — so a card
+    /// sized against the raw height would be drawn a quarter taller than it was
+    /// budgeted for, and run off the bottom of a small display.
+    func testALargerNotchGetsASmallerTooltipBudget() {
+        let large = model(scale: 1.25).sessionCap(cellCount: 3)
+        let medium = model(scale: 1).sessionCap(cellCount: 3)
+        let small = model(scale: 0.8).sessionCap(cellCount: 3)
+
+        XCTAssertLessThanOrEqual(large, medium)
+        XCTAssertLessThanOrEqual(medium, small)
+    }
+
+    /// And the card that budget produces, once drawn, still fits the screen it
+    /// was budgeted against — which is the property the cap exists to hold.
+    func testTheDrawnCardStillFitsTheScreenAtEverySize() {
+        for size in NotchSize.allCases {
+            let height: CGFloat = 900
+            let model = model(scale: size.scale, height: height)
+            let drawn = model.maxCardHeight(cellCount: 3) * size.scale
+            XCTAssertLessThanOrEqual(drawn, height,
+                                     "\(size.rawValue) draws a \(drawn)pt card on a \(height)pt screen")
+        }
+    }
+}

--- a/Tests/NotchLayoutTests.swift
+++ b/Tests/NotchLayoutTests.swift
@@ -1284,15 +1284,31 @@ final class NotchSizeTests: XCTestCase {
         XCTAssertLessThanOrEqual(medium, small)
     }
 
-    /// And the card that budget produces, once drawn, still fits the screen it
-    /// was budgeted against — which is the property the cap exists to hold.
-    func testTheDrawnCardStillFitsTheScreenAtEverySize() {
+    /// And the card that budget produces still fits the screen it was budgeted
+    /// against — which is the property the cap exists to hold.
+    func testTheCardStillFitsTheScreenAtEverySize() {
         for size in NotchSize.allCases {
             let height: CGFloat = 900
-            let model = model(scale: size.scale, height: height)
-            let drawn = model.maxCardHeight(cellCount: 3) * size.scale
-            XCTAssertLessThanOrEqual(drawn, height,
-                                     "\(size.rawValue) draws a \(drawn)pt card on a \(height)pt screen")
+            let card = model(scale: size.scale, height: height).maxCardHeight(cellCount: 3)
+            XCTAssertLessThanOrEqual(card, height,
+                                     "\(size.rawValue) gives a \(card)pt card on a \(height)pt screen")
         }
+    }
+
+    /// The point of this whole split: the tooltip is drawn at one size whatever
+    /// the notch is set to. Its text has a legible size of its own, and
+    /// shrinking the reading you opened the notch to read is the opposite of
+    /// the point.
+    ///
+    /// Read off the panel, because that is where a scaled card would show: the
+    /// panel's depth is the drawn notch plus the card's own room, so the whole
+    /// difference between two sizes has to be the notch's share alone.
+    func testTheTooltipKeepsItsOwnSizeWhateverTheNotchIs() {
+        let large = model(scale: 1.25)
+        let medium = model(scale: 1)
+        let notchShare = medium.contentInset + NotchLayout.bodyDepth(for: .right)
+
+        XCTAssertEqual(large.panelSize(cellCount: 3).width - medium.panelSize(cellCount: 3).width,
+                       notchShare * 0.25, accuracy: 0.001)
     }
 }

--- a/Tests/NotchRenderTests.swift
+++ b/Tests/NotchRenderTests.swift
@@ -83,6 +83,53 @@ final class NotchRenderTests: XCTestCase {
             )
         }
     }
+
+    /// The orb has to stay attached to the notch at every size.
+    ///
+    /// `position` hands back a view the size of the whole panel, so a scale
+    /// applied *after* it scales that layer about the panel's centre and slides
+    /// the orb away by a share of the panel — the arc left floating off the
+    /// corner it is drawn to hug. Arithmetic cannot see that: the numbers going
+    /// in were right and the modifier order was not, so this looks at the
+    /// pixels instead.
+    func testNothingIsPaintedBeyondTheNotchAndItsOrbAtAnySize() {
+        for size in NotchSize.allCases {
+            let m = model(edge: .right)
+            m.sizeScale = size.scale
+            guard let rep = render(m) else {
+                XCTFail("\(size.rawValue): no image")
+                continue
+            }
+            let place = NotchPlacement(edge: .right, panelSize: m.panelSize)
+            let scale = size.scale
+            // What the notch and the orb legitimately reach, derived rather
+            // than guessed, plus a point for the stroke's own width.
+            let reach = m.orbArcRadius * scale + NotchLayout.orbStroke
+            let deepest = max(m.notchDepth * scale, m.orbInset * scale + reach)
+            let furthest = m.slack + max(m.shapeLength, m.orbAlong) * scale + reach
+            let nearest = m.slack - reach
+
+            var maxAcross = 0.0, maxAlong = -Double.infinity, minAlong = Double.infinity
+            for x in stride(from: 0, to: rep.pixelsWide, by: 2) {
+                for y in stride(from: 0, to: rep.pixelsHigh, by: 2) {
+                    guard let colour = rep.colorAt(x: x, y: y),
+                          colour.alphaComponent > 0.5 else { continue }
+                    let point = CGPoint(x: x, y: y)
+                    maxAcross = max(maxAcross, place.across(of: point))
+                    maxAlong = max(maxAlong, place.along(of: point))
+                    minAlong = min(minAlong, place.along(of: point))
+                }
+            }
+
+            XCTAssertLessThanOrEqual(maxAcross, deepest + 1,
+                                     "\(size.rawValue): something is painted \(maxAcross)pt in "
+                                     + "from the bezel, past the \(deepest)pt the notch and orb reach")
+            XCTAssertLessThanOrEqual(maxAlong, furthest + 1,
+                                     "\(size.rawValue): something is painted past the far end")
+            XCTAssertGreaterThanOrEqual(minAlong, nearest - 1,
+                                        "\(size.rawValue): something is painted before the near end")
+        }
+    }
 }
 
 /// The panel's size is worked out by `NotchGeometry` and by nobody else.

--- a/Tests/PreferencesTests.swift
+++ b/Tests/PreferencesTests.swift
@@ -67,5 +67,21 @@ final class PreferencesMigrationTests: XCTestCase {
         XCTAssertEqual(preferences.notchVisibility, .onHover)
         XCTAssertEqual(preferences.appPresence, .dock)
         XCTAssertEqual(preferences.notchEdge, .right)
+        XCTAssertEqual(preferences.notchSize, .medium)
+    }
+
+    /// The size has to outlive the launch that chose it, or it reads as a
+    /// setting that did not take.
+    func testTheNotchSizeSurvivesARelaunch() {
+        let (fresh, name) = makeDefaults()
+        Preferences(defaults: fresh).notchSize = .large
+
+        XCTAssertEqual(Preferences(defaults: UserDefaults(suiteName: name)!).notchSize, .large)
+    }
+
+    /// An install that predates the setting keeps exactly the notch it had.
+    /// `medium` is the design frame at 1:1, so this is what makes that true.
+    func testMediumIsTheSizeEveryEarlierVersionDrew() {
+        XCTAssertEqual(NotchSize.medium.scale, 1)
     }
 }


### PR DESCRIPTION
## Summary

- The notch has only ever had one size. On a large display it reads as a sliver, and at more than arm's length the percentage under each ring — the one thing it exists to show — stops being legible. **Size** in Settings → Appearance draws the notch smaller or larger.
- An ⌥-drag has slid the notch along its edge since the edge picker existed, and nothing has ever said so: not the README, not Settings. For most people that feature is not there. This says it, and adds **Recentre** — until now a nudge that went too far could only be undone by dragging it back by eye.

## Changes

**Size**
- `Sources/Settings/NotchSize.swift` (new): `small` / `medium` / `large`, modelled on `PeekDuration` — a fixed set rather than a slider, for the reason that type already gives. `medium` is 1, so an install that predates the choice keeps exactly the notch it had.
- `Preferences` gains one key and one published property; no migration, since an absent key falls to the default the same way `geminiAPIMonthlyTokenBudget` does.
- Fanned out through `NotchFleet.apply(size:)` → `NotchWindowController.apply(size:)`, set-then-relocate rather than a `model.$sizeScale` sink: `@Published` fires in `willSet`, so a sink would rebuild the panel from the size being replaced. `apply(edge:)` is the same shape for the same reason.

**The notch scales; the tooltip does not**

The panel is now two spaces added together rather than one space multiplied. The notch's share — content inset, body depth, shape length, rings, orb, and the end margin that keeps the shape off the corner — scales. The card's share — the card, its tail, the gap the pointer crosses, and the room reserved at each end for a card centred on the first or last ring — does not. The card is a paragraph of text; shrinking the reading you opened the notch to read is the opposite of the point.

That is also why `NotchLayout.slack` takes the scale rather than being multiplied by its caller: it is a maximum of one distance from *each* space. Scaling the result reserves room for a card that is never that big, and at the small end reserves less than the card needs, which crops it. That parameter is the only change to `NotchLayout.swift` — **no constant is touched**, so every measurement is still the one quoted from `docs/design/frame-124-hover-tooltip.png` as CONTRIBUTING asks.

**Why not `Design.scale`**

It looks like the natural hook, but `NotchLayout` is ~40 `static let`s computed from `Design.px`. Swift evaluates those lazily and exactly once, so a mutable scale changes nothing after first access — the obvious approach silently does not work.

**Position**
- `README` → Placement, and a caption in Settings, now say the ⌥-drag exists and that each edge remembers its own place.
- **Recentre** clears the stored offset *and* moves the live panel — those are deliberately kept apart, so writing only the preference would leave the notch put until the next edge change, and moving only the panel would undo itself on relaunch.

## Test plan

- [x] `make test` passes; `make build` adds no new warnings.
- [x] Measured through `NotchWindowController.relocate()` on a 2056×1329 display with 3 providers. `cardWidth` is 225.6pt at every size, and the panel's growth is exactly the notch's share — 335−321 = 14 against a notch depth change of 13.9, and 352−335 = 17 against 17.5. `maxX` is 2056 at all three, so it stays flush on the bezel.
- [x] Switching size in Settings redraws immediately, no relaunch, and the hover card keeps its size while the rings change — checked by eye at all three.
- [x] The settings orb stays attached to the notch at every size. This was broken at first and is now pinned by a render test that fails on the old code: the scale was applied *after* `position`, which scales the panel-sized layer about the panel's centre instead of the orb about its own, so the arc drifted by a share of the panel — visible at small and large, invisible at medium where the scale is 1. The bounds it checks are derived from what the notch and orb actually reach, not fitted to the result.
- [x] The ⌥-drag has **not** been re-exercised by hand at a non-default size. The gesture is unchanged, but this scales the slack that clamps it and the regions that receive it, so it is the part most worth a second pair of eyes.
- [x] **Recentre** has not been clicked in a running build, only wired and read.
- [ ] Not tried on a Mac with a hardware notch, or on a second display. `orbHugsCorner` takes a different branch there and is the case I would look at first.

The size values (0.8 / 1.25) are a judgement, not a measurement — happy to move them if they read wrong to you.
