### PR TITLE
fix: fall back to ad-hoc signing without a valid development identity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,9 @@ jobs:
       - name: Install XcodeGen
         run: brew install xcodegen
 
+      - name: Check local signing detection
+        run: bash Scripts/test-signing.sh
+
       # Unsigned on purpose: no identity exists on a runner, and the tests
       # read fixtures rather than keychains — see `make test-ci`.
       - name: Run unit tests

--- a/Makefile
+++ b/Makefile
@@ -30,12 +30,11 @@ HAS_DEVELOPER_ID := $(shell security find-identity -v -p codesigning 2>/dev/null
 # over ad-hoc for exactly the reason the maintainer's identity is: it is
 # stable, so a keychain "Always Allow" grant survives the next rebuild, and
 # working on the credential-reading paths does not mean re-granting after every
-# build. Its team is read out of the certificate itself, since manual signing
-# will not proceed without one; with nothing parsed, ad-hoc is the fallback and
-# needs no Apple account.
-DEV_TEAM := $(shell security find-certificate -c "Apple Development" -p 2>/dev/null \
-	| openssl x509 -noout -subject 2>/dev/null \
-	| sed -n 's/.*OU *= *\([A-Z0-9]*\).*/\1/p')
+# build. Read its team from a valid signing identity: a certificate can remain
+# in the keychain without its private key, and choosing it would fail the
+# build. With nothing parsed, ad-hoc is the fallback and needs no Apple account.
+DEV_TEAM := $(shell security find-identity -v -p codesigning 2>/dev/null \
+	| sed -n 's/.*"Apple Development: .* (\([A-Z0-9]*\))".*/\1/p' | head -1)
 
 ifeq (,$(HAS_DEVELOPER_ID))
 ifeq (,$(DEV_TEAM))

--- a/Scripts/test-signing.sh
+++ b/Scripts/test-signing.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+# Exercise the Makefile without touching a keychain or invoking Xcode. A
+# certificate-only fixture catches the case that broke contributor builds.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+fixture_dir=$(mktemp -d)
+trap 'rm -rf "$fixture_dir"' EXIT
+
+cat > "$fixture_dir/security" <<'EOF'
+#!/bin/bash
+case "$1" in
+    find-identity) printf '%s\n' "$SIGNING_IDENTITIES" ;;
+    find-certificate) printf '%s\n' 'certificate without a private key' ;;
+esac
+EOF
+cat > "$fixture_dir/openssl" <<'EOF'
+#!/bin/bash
+cat > /dev/null
+printf '%s\n' 'subject=OU = ORPHAN1234, CN = Apple Development: Contributor'
+EOF
+chmod +x "$fixture_dir/security" "$fixture_dir/openssl"
+export PATH="$fixture_dir:$PATH"
+
+check_signing() {
+    local label="$1" expected="$2" target output
+    for target in build test run; do
+        output=$(make -n "$target")
+        if [[ "$output" != *"$expected"* ]]; then
+            printf 'FAIL: %s (%s)\n%s\n' "$label" "$target" "$output"
+            exit 1
+        fi
+    done
+    printf 'PASS: %s\n' "$label"
+}
+
+export SIGNING_IDENTITIES='    0 valid identities found'
+check_signing 'certificate without a valid identity uses ad-hoc' \
+    'Debug CODE_SIGN_IDENTITY="-" DEVELOPMENT_TEAM="" CODE_SIGN_STYLE=Automatic'
+
+SIGNING_IDENTITIES='  1) AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA "Apple Development: Contributor (TEAM123456)"
+     1 valid identities found'
+check_signing 'valid development identity supplies its team' \
+    'Debug CODE_SIGN_IDENTITY="Apple Development" CODE_SIGN_STYLE=Manual DEVELOPMENT_TEAM="TEAM123456"'
+
+SIGNING_IDENTITIES='  1) AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA "Apple Development: Contributor (TEAM123456)"
+  2) BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB "Apple Development: Another Contributor (TEAM654321)"
+     2 valid identities found'
+check_signing 'multiple development identities select one team' \
+    'Debug CODE_SIGN_IDENTITY="Apple Development" CODE_SIGN_STYLE=Manual DEVELOPMENT_TEAM="TEAM123456" PROVISIONING_PROFILE_SPECIFIER=""'
+
+SIGNING_IDENTITIES='  1) AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA "Developer ID Application: Maintainer (6WFPL8B9FB)"
+  2) BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB "Apple Development: Contributor (TEAM123456)"
+     2 valid identities found'
+check_signing 'Developer ID preserves project signing settings' 'Debug  '


### PR DESCRIPTION
A contributor can have an Apple Development certificate in their keychain while `security find-identity -v -p codesigning` reports zero valid identities. The Makefile extracted a team from that certificate and selected manual signing, causing local builds to fail because no usable certificate/private-key pair was available.

Read the development team from the first valid Apple Development signing identity instead, so this case falls back to ad-hoc signing. Existing Developer ID precedence is preserved.

Adds a shell regression check to CI covering the certificate-only case, valid development signing, multiple development identities, and Developer ID precedence across build/test/run dry runs.

Validation:
- Regression check fails against the original Makefile and passes with the fix.
- `make build` succeeds on the affected Mac; `codesign` confirms ad-hoc signing.
- `make test`: 753 tests passed, zero failures.
- `make run` succeeds and launches the local build.

Valid-certificate paths were checked with mocked identity output; the affected Mac has no valid signing identities.
