### PR TITLE
fix: keep the settings button onscreen when dragging the notch

### DIFF
--- a/Sources/Notch/NotchGeometry.swift
+++ b/Sources/Notch/NotchGeometry.swift
@@ -90,7 +90,10 @@ enum NotchGeometry {
         // instead — `panelSize` shrunk by this on each end — lets it travel
         // almost the full edge; the padding is free to run past the bezel,
         // since nothing is drawn there until a card actually opens.
-        slack: CGFloat = 0
+        slack: CGFloat = 0,
+        // The settings handle hangs past the body's trailing end. That part
+        // of the padding must stay on screen even when the hover card may not.
+        trailingExtent: CGFloat = 0
     ) -> CGRect {
         let full = screen.frameValue
         let usable = screen.visibleFrameValue
@@ -101,11 +104,11 @@ enum NotchGeometry {
         switch edge {
         case .right:
             let y = clamp(full.midY - height / 2 - alongOffset,
-                          min: full.minY - slack, max: full.maxY - height + slack)
+                          min: full.minY - slack + trailingExtent, max: full.maxY - height + slack)
             origin = CGPoint(x: usable.maxX - width, y: y)
         case .left:
             let y = clamp(full.midY - height / 2 - alongOffset,
-                          min: full.minY - slack, max: full.maxY - height + slack)
+                          min: full.minY - slack + trailingExtent, max: full.maxY - height + slack)
             origin = CGPoint(x: usable.minX, y: y)
         case .top:
             // AppKit's y grows upward, so the top edge is `maxY`.
@@ -117,11 +120,11 @@ enum NotchGeometry {
             // it stays below it.
             let top = screen.hardwareNotch == nil ? usable.maxY : full.maxY
             let x = clamp(full.midX - width / 2 + alongOffset,
-                          min: full.minX - slack, max: full.maxX - width + slack)
+                          min: full.minX - slack, max: full.maxX - width + slack - trailingExtent)
             origin = CGPoint(x: x, y: top - height)
         case .bottom:
             let x = clamp(full.midX - width / 2 + alongOffset,
-                          min: full.minX - slack, max: full.maxX - width + slack)
+                          min: full.minX - slack, max: full.maxX - width + slack - trailingExtent)
             origin = CGPoint(x: x, y: usable.minY)
         }
 

--- a/Sources/Notch/NotchViewModel.swift
+++ b/Sources/Notch/NotchViewModel.swift
@@ -181,6 +181,12 @@ final class NotchViewModel: ObservableObject {
         return cornerCentreAlong + NotchLayout.orbCornerOffset(corner: drawnCornerRadius)
     }
 
+    /// Reserve the full hit area even while only the resting arc is visible,
+    /// so revealing the settings button cannot put it beyond the screen.
+    var trailingExtent: CGFloat {
+        max(0, orbAlong - shapeLength + NotchLayout.orbHotZone / 2).rounded(.up)
+    }
+
     /// Where the bar's far corner actually turns, along the stack.
     ///
     /// Inset from the bar's end by the *flare* as well as by the corner's own

--- a/Sources/Notch/NotchWindowController.swift
+++ b/Sources/Notch/NotchWindowController.swift
@@ -151,7 +151,8 @@ final class NotchWindowController {
         let size = model.panelSize(cellCount: cellCount ?? model.snapshots.count)
         let frame = NotchGeometry.panelFrame(
             for: screen, panelSize: size, edge: model.edge,
-            alongOffset: model.alongOffset, slack: model.slack
+            alongOffset: model.alongOffset, slack: model.slack,
+            trailingExtent: model.trailingExtent
         )
         lastVisibleFrame = screen.visibleFrame
 

--- a/Tests/NotchGeometryTests.swift
+++ b/Tests/NotchGeometryTests.swift
@@ -82,6 +82,33 @@ final class PanelOffsetTests: XCTestCase {
         visibleFrameValue: CGRect(x: 0, y: 0, width: 1800, height: 1132)
     )
 
+    @MainActor
+    func testDraggingToTheTrailingEndKeepsTheSettingsHandleOnScreen() {
+        let secondary = FakeScreen(
+            frameValue: CGRect(x: -1800, y: -200, width: 1800, height: 1169),
+            visibleFrameValue: CGRect(x: -1800, y: -200, width: 1800, height: 1132)
+        )
+        for display in [screen, secondary] {
+            for edge in NotchEdge.allCases {
+                let model = NotchViewModel()
+                model.edge = edge
+                let frame = NotchGeometry.panelFrame(
+                    for: display, panelSize: model.panelSize, edge: edge,
+                    alongOffset: 10_000, slack: model.slack,
+                    trailingExtent: model.trailingExtent
+                )
+                let handleEnd = model.slack + model.orbAlong + NotchLayout.orbHotZone / 2
+                if edge.isVertical {
+                    XCTAssertGreaterThanOrEqual(frame.maxY - handleEnd,
+                                                display.frameValue.minY - 0.5)
+                } else {
+                    XCTAssertLessThanOrEqual(frame.minX + handleEnd,
+                                             display.frameValue.maxX + 0.5)
+                }
+            }
+        }
+    }
+
     func testZeroOffsetChangesNothing() {
         let size = CGSize(width: 334, height: 484)
         let centred = NotchGeometry.panelFrame(for: screen, panelSize: size, edge: .right)


### PR DESCRIPTION
Dragging a left- or right-edge notch fully down lets the settings button extend below the screen, leaving it clipped and difficult to click. The drag clamp accounted for the notch body but treated the padding containing the settings handle as disposable hover-card space.

Reserve the settings handle’s full hit area beyond the body when clamping the panel position. The same trailing-end allowance applies to horizontal edges, where the handle can otherwise extend past the right edge. The default remains unchanged for callers without a trailing extent.

Validation:
- `make test`: 754 tests passed, zero failures.
- Added a regression test covering all four edges and a screen with a nonzero origin.
- Local build succeeded; the reporter confirmed the updated app fixes the clipping after manually testing it.

The local test/build run included the signing workaround in #58. This PR contains only the settings-handle geometry fix and its test.
