### PR TITLE
Support multiple Codex accounts with isolated profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,31 @@ Any `~/.claude-<slug>` directory Claude Code has run against is found at launch;
 the default `~/.claude` always comes first, the rest in alphabetical order, so the
 rings never swap places.
 
+Codex accounts work the same way: `~/.codex` stays the **Codex** ring, and each
+used `~/.codex-<slug>` directory adds a **Codex (slug)** ring with its own limits,
+activity and Settings row. Profiles are discovered at launch, default first,
+then alphabetically. To connect a second account, sign in through Codex CLI
+using a separate home directory:
+
+```sh
+mkdir -p "$HOME/.codex-work"
+CODEX_HOME="$HOME/.codex-work" codex -c 'cli_auth_credentials_store="file"' login
+```
+
+Choose the second account during sign-in, then restart Codenotch. Run that
+account's CLI sessions with `CODEX_HOME="$HOME/.codex-work" codex` as well.
+Repeat with another name, such as `.codex-personal`, for more accounts.
+Settings shows each account's email and profile directory; each ring can be
+reordered or switched off independently. Switching one off forgets only its
+Codenotch readings and leaves the Codex login intact.
+
+Codenotch reads each profile's `auth.json`; keychain-only or API-key-only
+logins cannot provide these ChatGPT account limits. It never copies, refreshes
+or writes Codex credentials. If a login expires, use that profile's Codex CLI
+to renew it. Directories outside the `~/.codex-<slug>` convention are not
+discovered automatically, and adding a profile requires restarting Codenotch,
+just as it does for Claude.
+
 ## When a session ends
 
 The notch opens itself for five seconds when an agent stops working, or stops

--- a/Sources/App/AppDelegate.swift
+++ b/Sources/App/AppDelegate.swift
@@ -32,6 +32,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// provider and a session monitor of its own, keyed by the same id, so a
     /// work login's sessions spin the work ring and nobody else's.
     private let claudeProfiles = ClaudeProfile.discover()
+    private let codexProfiles = CodexProfile.discover()
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         // Set here, not in the Info.plist: this call is applied at launch and
@@ -79,9 +80,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             // it drew every provider from the archive and only dropped the
             // switched-off ones once the binding below delivered.
             Log.usage.info("claude profiles: \(self.claudeProfiles.map(\.displayPath).joined(separator: ", "), privacy: .public)")
+            Log.usage.info("codex profiles: \(self.codexProfiles.map(\.displayPath).joined(separator: ", "), privacy: .public)")
             let store = UsageStore(
                 providers: claudeProfiles.map { ClaudeOAuthProvider(profile: $0) }
-                    + [CursorLocalProvider(), CodexLocalProvider(), AntigravityProvider(),
+                    + [CursorLocalProvider()]
+                    + codexProfiles.map { CodexLocalProvider(profile: $0) }
+                    + [AntigravityProvider(),
                        GLMProvider(), GrokLocalProvider(), OpenCodeProvider(),
                        GitHubCopilotProvider(),
                        // A closure, not the value: the provider is an actor and
@@ -263,13 +267,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // still working without you switching to it.
         var monitors: [String: any AgentActivityMonitor] = [
             "cursor": CursorActivityMonitor(),
-            "codex": CodexActivityMonitor(),
             "gemini": AntigravityActivityMonitor(),
             "grok": GrokActivityMonitor(),
             "gemini-api": GeminiCLIActivityMonitor()
         ]
         for profile in claudeProfiles {
             monitors[profile.id] = ClaudeSessionMonitor(directory: profile.sessionsDirectory)
+        }
+        for profile in codexProfiles {
+            monitors[profile.id] = CodexActivityMonitor(profile: profile)
         }
         for (id, monitor) in monitors {
             monitor.sessionsPublisher

--- a/Sources/Model/UsageModel.swift
+++ b/Sources/Model/UsageModel.swift
@@ -215,6 +215,9 @@ struct ProviderSnapshot: Identifiable, Equatable {
             return "Sign in to Claude Code in ~/.claude-\(slug) to read your usage"
         case "cursor":     return "Sign in to Cursor in the editor"
         case "codex":      return "Sign in to Codex to read your usage"
+        case _ where CodexProfile.slug(fromProviderID: id) != nil:
+            let slug = CodexProfile.slug(fromProviderID: id)!
+            return "Sign in to Codex in ~/.codex-\(slug) to read your usage"
         case "gemini":     return "Sign in to Antigravity to read your usage"
         case "glm":        return "Set up a GLM Coding Plan key for a coding tool to read your usage"
         case "copilot":    return "Sign in with GitHub CLI to read your Copilot usage"

--- a/Sources/Providers/CodexCredentials.swift
+++ b/Sources/Providers/CodexCredentials.swift
@@ -8,7 +8,7 @@ enum CodexCredentials {
     }
 
     static var authURL: URL {
-        URL(fileURLWithPath: NSHomeDirectory()).appendingPathComponent(".codex/auth.json")
+        CodexProfile.default().authURL
     }
 
     static func load(from url: URL = authURL, now: Date = Date()) throws -> Credential {
@@ -32,7 +32,7 @@ enum CodexCredentials {
         return Credential(accessToken: auth.tokens.access_token, accountID: auth.tokens.account_id)
     }
 
-    static func account(from url: URL = authURL) -> ProviderAccount? {
+    static func account(from url: URL = authURL, source: String = "Codex") -> ProviderAccount? {
         guard let data = try? Data(contentsOf: url),
               let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
               let tokens = root["tokens"] as? [String: Any],
@@ -44,7 +44,7 @@ enum CodexCredentials {
         return ProviderAccount(
             label: claims["email"] as? String,
             plan: auth?["chatgpt_plan_type"] as? String,
-            source: "Codex",
+            source: source,
             manageURL: URL(string: "https://chatgpt.com/#settings/Account")
         )
     }

--- a/Sources/Providers/CodexLocalProvider.swift
+++ b/Sources/Providers/CodexLocalProvider.swift
@@ -3,28 +3,38 @@ import SQLite3
 
 /// Reads live account limits using the session owned and refreshed by Codex.
 actor CodexLocalProvider: UsageProvider {
-    nonisolated let id = "codex"
-    nonisolated let displayName = "Codex"
+    nonisolated let id: String
+    nonisolated let displayName: String
     nonisolated let glyph = ProviderGlyph.openai
+    nonisolated let profile: CodexProfile
 
     private let session: URLSession
     nonisolated private let authURL: URL
     private let archive: UsageArchive
     private var retryNoEarlierThan: Date?
 
-    init(session: URLSession = .shared,
-         authURL: URL = CodexCredentials.authURL,
+    init(profile: CodexProfile = .default(),
+         session: URLSession = .shared,
+         authURL: URL? = nil,
          archive: UsageArchive = UsageArchive()) {
+        self.profile = profile
+        self.id = profile.id
+        self.displayName = profile.displayName
         self.session = session
-        self.authURL = authURL
+        self.authURL = authURL ?? profile.authURL
         self.archive = archive
         // Recreating the provider or relaunching must not bypass the server's retry deadline.
-        self.retryNoEarlierThan = archive.loadBackoffUntil(providerID: "codex")
+        self.retryNoEarlierThan = archive.loadBackoffUntil(providerID: profile.id)
     }
 
-    nonisolated var signInRoute: SignInRoute { .openApp(bundleID: "com.openai.codex", name: "Codex") }
+    nonisolated var signInRoute: SignInRoute {
+        guard profile.slug != nil else { return .openApp(bundleID: "com.openai.codex", name: "Codex") }
+        return .guidance("Run \(profile.signInCommand) in Terminal to sign in to \(displayName).")
+    }
 
-    nonisolated func account() -> ProviderAccount? { CodexCredentials.account(from: authURL) }
+    nonisolated func account() -> ProviderAccount? {
+        CodexCredentials.account(from: authURL, source: profile.sourceName)
+    }
 
     func fetchSnapshot() async throws -> ProviderSnapshot {
         let now = Date()
@@ -88,7 +98,7 @@ actor CodexLocalProvider: UsageProvider {
 /// Shared access to Codex's local state.
 enum CodexStore {
     static var stateURL: URL {
-        URL(fileURLWithPath: NSHomeDirectory()).appendingPathComponent(".codex/state_5.sqlite")
+        CodexProfile.default().stateURL
     }
 
     /// The desktop app's own thread catalogue.
@@ -99,8 +109,7 @@ enum CodexStore {
     /// `source_kind = 'chatgpt'`. Watching only the rollouts meant the notch
     /// could never see the desktop app working at all.
     static var desktopStoreURL: URL {
-        URL(fileURLWithPath: NSHomeDirectory())
-            .appendingPathComponent(".codex/sqlite/codex-dev.db")
+        CodexProfile.default().desktopStoreURL
     }
 
     /// The most recently touched desktop thread: when, and what it is called.

--- a/Sources/Providers/CodexProfile.swift
+++ b/Sources/Providers/CodexProfile.swift
@@ -1,0 +1,79 @@
+import Foundation
+
+/// Finder does not inherit a shell's CODEX_HOME. Discover the same directory
+/// convention as Claude instead, keeping each account's credentials and activity together.
+struct CodexProfile: Equatable, Hashable {
+    static let defaultID = "codex"
+    static let directoryPrefix = ".codex"
+
+    let slug: String?
+    let configDirectory: URL
+
+    static var homeDirectory: URL { URL(fileURLWithPath: NSHomeDirectory()) }
+
+    static func `default`(home: URL = homeDirectory) -> CodexProfile {
+        CodexProfile(slug: nil, configDirectory: home.appendingPathComponent(directoryPrefix))
+    }
+
+    static func discover(home: URL = homeDirectory,
+                         fileManager: FileManager = .default) -> [CodexProfile] {
+        let names = (try? fileManager.contentsOfDirectory(atPath: home.path)) ?? []
+        let extras = names.compactMap { name -> CodexProfile? in
+            guard let slug = slug(fromDirectoryName: name) else { return nil }
+            let directory = home.appendingPathComponent(name)
+            guard isProfileDirectory(directory, fileManager: fileManager) else { return nil }
+            return CodexProfile(slug: slug, configDirectory: directory)
+        }
+        return [.default(home: home)] + extras.sorted { $0.slug! < $1.slug! }
+    }
+
+    static func slug(fromDirectoryName name: String) -> String? {
+        let prefix = directoryPrefix + "-"
+        guard name.hasPrefix(prefix) else { return nil }
+        let slug = String(name.dropFirst(prefix.count))
+        return slug.isEmpty ? nil : slug
+    }
+
+    static func isProfileDirectory(_ url: URL, fileManager: FileManager = .default) -> Bool {
+        var isDirectory: ObjCBool = false
+        guard fileManager.fileExists(atPath: url.path, isDirectory: &isDirectory),
+              isDirectory.boolValue else { return false }
+        // A signed-out profile can still have settings or sessions. Keep its
+        // row so it can explain how to sign that account back in.
+        return ["auth.json", "config.toml", "sessions", "history.jsonl", "state_5.sqlite",
+                "sqlite/codex-dev.db"].contains {
+            fileManager.fileExists(atPath: url.appendingPathComponent($0).path)
+        }
+    }
+
+    // Preserve the default id so existing readings and preferences survive.
+    var id: String { slug.map { "\(Self.defaultID)-\($0)" } ?? Self.defaultID }
+    var displayName: String { slug.map { "Codex (\($0))" } ?? "Codex" }
+
+    static func slug(fromProviderID id: String) -> String? {
+        let prefix = defaultID + "-"
+        guard id.hasPrefix(prefix) else { return nil }
+        let slug = String(id.dropFirst(prefix.count))
+        return slug.isEmpty ? nil : slug
+    }
+
+    var authURL: URL { configDirectory.appendingPathComponent("auth.json") }
+    var stateURL: URL { configDirectory.appendingPathComponent("state_5.sqlite") }
+    var desktopStoreURL: URL { configDirectory.appendingPathComponent("sqlite/codex-dev.db") }
+
+    var displayPath: String {
+        let home = NSHomeDirectory()
+        let path = configDirectory.path
+        return path.hasPrefix(home + "/") ? "~" + path.dropFirst(home.count) : path
+    }
+
+    var sourceName: String { slug == nil ? "Codex" : "Codex in \(displayPath)" }
+
+    var signInCommand: String {
+        guard slug != nil else { return "codex login" }
+        // Quote the actual path, including spaces and apostrophes. A quoted ~
+        // would not expand, and an unquoted slug could become shell syntax.
+        let path = "'" + configDirectory.path.replacingOccurrences(of: "'", with: "'\"'\"'") + "'"
+        return "CODEX_HOME=\(path) codex -c 'cli_auth_credentials_store=\"file\"' login"
+    }
+}

--- a/Sources/Sessions/CodexActivityMonitor.swift
+++ b/Sources/Sessions/CodexActivityMonitor.swift
@@ -21,19 +21,22 @@ final class CodexActivityMonitor: ObservableObject, AgentActivityMonitor {
 
     private let stateStore: URL
     private let desktopStore: URL
+    private let profile: CodexProfile
     private let interval: TimeInterval
     /// How long after the last write a turn is still considered in flight.
     private let staleAfter: TimeInterval
     private var timer: Timer?
 
     init(
-        stateStore: URL = CodexStore.stateURL,
-        desktopStore: URL = CodexStore.desktopStoreURL,
+        profile: CodexProfile = .default(),
+        stateStore: URL? = nil,
+        desktopStore: URL? = nil,
         interval: TimeInterval = 2,
         staleAfter: TimeInterval = 8
     ) {
-        self.stateStore = stateStore
-        self.desktopStore = desktopStore
+        self.profile = profile
+        self.stateStore = stateStore ?? profile.stateURL
+        self.desktopStore = desktopStore ?? profile.desktopStoreURL
         self.interval = interval
         self.staleAfter = staleAfter
     }
@@ -54,13 +57,14 @@ final class CodexActivityMonitor: ObservableObject, AgentActivityMonitor {
 
     private func rescan() {
         let found = Self.read(stateStore: stateStore, desktopStore: desktopStore,
-                              staleAfter: staleAfter)
+                              staleAfter: staleAfter, profile: profile)
         guard found != sessions else { return }
         sessions = found
     }
 
     static func read(stateStore: URL, desktopStore: URL,
-                     staleAfter: TimeInterval, now: Date = Date()) -> [AgentSession] {
+                     staleAfter: TimeInterval, now: Date = Date(),
+                     profile: CodexProfile = .default()) -> [AgentSession] {
         // Both surfaces, because "Codex" is two programs that record their work
         // in different places: the CLI and the VS Code extension append to a
         // rollout, and the desktop app writes to its own catalogue. Whichever
@@ -70,11 +74,11 @@ final class CodexActivityMonitor: ObservableObject, AgentActivityMonitor {
         if let rollout = CodexStore.newestRollout(in: stateStore),
            let modified = (try? FileManager.default
                .attributesOfItem(atPath: rollout.path))?[.modificationDate] as? Date {
-            candidates.append((id: "codex.\(rollout.lastPathComponent)",
-                               name: "Codex", at: modified))
+            candidates.append((id: "\(profile.id).\(rollout.lastPathComponent)",
+                               name: profile.displayName, at: modified))
         }
         if let desktop = CodexStore.newestDesktopThread(in: desktopStore) {
-            candidates.append((id: "codex.desktop", name: desktop.title,
+            candidates.append((id: "\(profile.id).desktop", name: desktop.title,
                                at: desktop.updatedAt))
         }
 

--- a/Tests/CodexProfileTests.swift
+++ b/Tests/CodexProfileTests.swift
@@ -1,0 +1,272 @@
+import SQLite3
+import XCTest
+@testable import Codenotch
+
+final class CodexProfileTests: XCTestCase {
+    private func home(_ layout: [String: [String]] = [:]) throws -> URL {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("CodexProfileTests.\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        for (directory, files) in layout {
+            let url = root.appendingPathComponent(directory)
+            try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+            for file in files {
+                let path = url.appendingPathComponent(file)
+                try FileManager.default.createDirectory(at: path.deletingLastPathComponent(),
+                                                        withIntermediateDirectories: true)
+                try Data().write(to: path)
+            }
+        }
+        addTeardownBlock { try? FileManager.default.removeItem(at: root) }
+        return root
+    }
+
+    private func archive() -> UsageArchive {
+        let name = "CodexProfileTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: name)!
+        addTeardownBlock { defaults.removePersistentDomain(forName: name) }
+        return UsageArchive(defaults: defaults)
+    }
+
+    private func writeAuth(_ profile: CodexProfile, account: String, token: String = "fake") throws {
+        let claims: [String: Any] = ["email": "\(account)@example.test",
+                                   "https://api.openai.com/auth": ["chatgpt_plan_type": "plus"]]
+        let payload = try JSONSerialization.data(withJSONObject: claims).base64EncodedString()
+        let auth = ["tokens": ["access_token": token, "account_id": account,
+                               "id_token": "header.\(payload).signature"]]
+        try JSONSerialization.data(withJSONObject: auth).write(to: profile.authURL)
+    }
+
+    func testDefaultIdentityAndPathsStayCompatible() {
+        let profile = CodexProfile.default(home: URL(fileURLWithPath: "/Users/test"))
+        XCTAssertEqual(profile.id, "codex")
+        XCTAssertEqual(profile.displayName, "Codex")
+        XCTAssertEqual(profile.authURL.path, "/Users/test/.codex/auth.json")
+        XCTAssertEqual(profile.stateURL.path, "/Users/test/.codex/state_5.sqlite")
+        XCTAssertEqual(profile.desktopStoreURL.path, "/Users/test/.codex/sqlite/codex-dev.db")
+        XCTAssertEqual(CodexLocalProvider(profile: profile).signInRoute,
+                       .openApp(bundleID: "com.openai.codex", name: "Codex"))
+    }
+
+    func testDiscoveryIsStableAndIgnoresUnrelatedFiles() throws {
+        let root = try home([".codex-work": ["auth.json"], ".codex-alpha": ["config.toml"],
+                             ".codex-empty": [], ".codex-notes": ["README.md"],
+                             ".codex-": ["auth.json"], "codex-other": ["auth.json"]])
+        try Data().write(to: root.appendingPathComponent(".codex-file"))
+        let found = CodexProfile.discover(home: root)
+        XCTAssertEqual(found.map(\.id), ["codex", "codex-alpha", "codex-work"])
+        XCTAssertEqual(found.map(\.displayName), ["Codex", "Codex (alpha)", "Codex (work)"])
+        XCTAssertEqual(found[2].authURL, root.appendingPathComponent(".codex-work/auth.json"))
+    }
+
+    func testSignedOutProfilesAndMissingHomeAreSupported() throws {
+        let root = try home([".codex-a": ["sessions"], ".codex-b": ["history.jsonl"],
+                             ".codex-c": ["state_5.sqlite"], ".codex-d": ["sqlite/codex-dev.db"]])
+        XCTAssertEqual(CodexProfile.discover(home: root).map(\.id),
+                       ["codex", "codex-a", "codex-b", "codex-c", "codex-d"])
+        XCTAssertEqual(CodexProfile.discover(home: root.appendingPathComponent("missing")).map(\.id),
+                       ["codex"])
+    }
+
+    func testSignInNamesAndQuotesTheCorrectProfile() {
+        let profile = CodexProfile(slug: "work", configDirectory: URL(fileURLWithPath: "/Users/O'Brien/.codex-work"))
+        XCTAssertEqual(profile.signInCommand,
+                       "CODEX_HOME='/Users/O'\"'\"'Brien/.codex-work' codex -c 'cli_auth_credentials_store=\"file\"' login")
+        let provider = CodexLocalProvider(profile: profile)
+        XCTAssertEqual(provider.signInRoute,
+                       .guidance("Run \(profile.signInCommand) in Terminal to sign in to Codex (work)."))
+        let snapshot = ProviderSnapshot(id: profile.id, displayName: profile.displayName,
+                                        glyph: .openai, fidelity: .official, status: .needsAuth, windows: [])
+        XCTAssertEqual(snapshot.statusMessage, "Sign in to Codex in ~/.codex-work to read your usage")
+        XCTAssertNil(CodexProfile.slug(fromProviderID: "codex-"))
+        XCTAssertNil(CodexProfile.slug(fromProviderID: "codextra"))
+    }
+
+    func testAccountLabelsComeFromEachProfilesCredentials() throws {
+        let root = try home([".codex": [], ".codex-work": []])
+        let personal = CodexProfile.default(home: root)
+        let work = CodexProfile(slug: "work", configDirectory: root.appendingPathComponent(".codex-work"))
+        try writeAuth(personal, account: "personal")
+        try writeAuth(work, account: "work")
+        XCTAssertEqual(CodexLocalProvider(profile: personal).account()?.label, "personal@example.test")
+        XCTAssertEqual(CodexLocalProvider(profile: work).account()?.label, "work@example.test")
+        XCTAssertEqual(CodexLocalProvider(profile: work).account()?.source, "Codex in \(work.displayPath)")
+        try FileManager.default.removeItem(at: work.authURL)
+        XCTAssertNil(CodexLocalProvider(profile: work).account(), "must never fall back to the default account")
+    }
+
+    func testRequestsAndSnapshotsAreIsolatedAndTokensAreReread() async throws {
+        let root = try home([".codex": [], ".codex-work": []])
+        let personal = CodexProfile.default(home: root)
+        let work = CodexProfile(slug: "work", configDirectory: root.appendingPathComponent(".codex-work"))
+        try writeAuth(personal, account: "personal", token: "personal-token")
+        try writeAuth(work, account: "work", token: "work-token")
+        let session = CodexProfileEndpoint.session()
+        defer { session.invalidateAndCancel() }
+        let archive = archive()
+        let p = CodexLocalProvider(profile: personal, session: session, archive: archive)
+        let w = CodexLocalProvider(profile: work, session: session, archive: archive)
+        let personalReading = try await p.fetchSnapshot()
+        let workReading = try await w.fetchSnapshot()
+        XCTAssertEqual(personalReading.id, "codex")
+        XCTAssertEqual(personalReading.usedFraction, 0.10)
+        XCTAssertEqual(workReading.id, "codex-work")
+        XCTAssertEqual(workReading.usedFraction, 0.75)
+
+        try writeAuth(work, account: "work", token: "rotated-token")
+        let rotated = try await w.fetchSnapshot()
+        XCTAssertEqual(rotated.usedFraction, 0.80)
+        let unchanged = try CodexCredentials.load(from: personal.authURL)
+        XCTAssertEqual(unchanged.accessToken, "personal-token")
+    }
+
+    func testMissingProfileCredentialsNeverUseAnotherAccount() async throws {
+        let root = try home([".codex": [], ".codex-work": []])
+        try writeAuth(.default(home: root), account: "personal", token: "personal-token")
+        let work = CodexProfile(slug: "work", configDirectory: root.appendingPathComponent(".codex-work"))
+        let session = CodexProfileEndpoint.session()
+        defer { session.invalidateAndCancel() }
+        let provider = CodexLocalProvider(profile: work, session: session, archive: archive())
+        do {
+            _ = try await provider.fetchSnapshot()
+            XCTFail("A missing work login must not return the personal reading")
+        } catch UsageProviderError.needsAuth {} catch { XCTFail("Unexpected error: \(error)") }
+    }
+
+    func testRateLimitSurvivesRecreationWithoutBlockingTheDefault() async throws {
+        let root = try home([".codex": [], ".codex-work": []])
+        let personal = CodexProfile.default(home: root)
+        let work = CodexProfile(slug: "work", configDirectory: root.appendingPathComponent(".codex-work"))
+        try writeAuth(personal, account: "personal", token: "personal-token")
+        try writeAuth(work, account: "work", token: "limited-token")
+        let archive = archive()
+        let session = CodexProfileEndpoint.session()
+        defer { session.invalidateAndCancel() }
+        do {
+            _ = try await CodexLocalProvider(profile: work, session: session, archive: archive).fetchSnapshot()
+            XCTFail("Expected the work account's rate limit")
+        } catch UsageProviderError.rateLimited {} catch { XCTFail("Unexpected error: \(error)") }
+        XCTAssertNotNil(archive.loadBackoffUntil(providerID: work.id))
+        XCTAssertNil(archive.loadBackoffUntil(providerID: personal.id))
+        // A fresh token would succeed on the stub; the persisted deadline must prevent that request.
+        try writeAuth(work, account: "work", token: "work-token")
+        do {
+            _ = try await CodexLocalProvider(profile: work, session: session, archive: archive).fetchSnapshot()
+            XCTFail("Recreating the provider bypassed the persisted deadline")
+        } catch UsageProviderError.rateLimited {} catch { XCTFail("Unexpected error: \(error)") }
+        let reading = try await CodexLocalProvider(profile: personal, session: session, archive: archive).fetchSnapshot()
+        XCTAssertEqual(reading.usedFraction, 0.10)
+        XCTAssertNotNil(archive.loadBackoffUntil(providerID: work.id), "success for personal must not clear work backoff")
+    }
+
+    @MainActor
+    func testTwoProfilesKeepTheirOrderAndDisconnectIndependently() async throws {
+        let root = try home([".codex": [], ".codex-work": []])
+        let personal = CodexProfile.default(home: root)
+        let work = CodexProfile(slug: "work", configDirectory: root.appendingPathComponent(".codex-work"))
+        try writeAuth(personal, account: "personal", token: "personal-token")
+        try writeAuth(work, account: "work", token: "work-token")
+        let originalAuth = try Data(contentsOf: work.authURL)
+        let archive = archive()
+        let session = CodexProfileEndpoint.session()
+        defer { session.invalidateAndCancel() }
+        let providers: [UsageProvider] = [personal, work].map {
+            CodexLocalProvider(profile: $0, session: session, archive: archive)
+        }
+        let store = UsageStore(providers: providers, archive: archive, order: [work.id, personal.id])
+        await store.refresh()
+        XCTAssertEqual(store.snapshots.map(\.id), [work.id, personal.id])
+        XCTAssertEqual(store.providerSummaries.map(\.account?.label), ["work@example.test", "personal@example.test"])
+        XCTAssertEqual(Set(archive.load().keys), Set([work.id, personal.id]))
+        // Rebuilding with a disconnected profile exercises the same startup path as the app.
+        let restarted = UsageStore(providers: providers, archive: archive, disconnected: [work.id])
+        await restarted.refresh()
+        XCTAssertEqual(restarted.snapshots.map(\.id), [personal.id])
+        XCTAssertNil(archive.load()[work.id])
+        XCTAssertNotNil(archive.load()[personal.id])
+        XCTAssertEqual(try Data(contentsOf: work.authURL), originalAuth)
+    }
+
+    @MainActor
+    func testActivityUsesEachProfilesStoreAndDistinctSessionIDs() throws {
+        let root = try home([".codex": [], ".codex-work": []])
+        let personal = CodexProfile.default(home: root)
+        let work = CodexProfile(slug: "work", configDirectory: root.appendingPathComponent(".codex-work"))
+        try catalogue(profile: personal, title: "Personal task")
+        try catalogue(profile: work, title: "Work task")
+        let p = CodexActivityMonitor(profile: personal)
+        let w = CodexActivityMonitor(profile: work)
+        p.start(); w.start()
+        defer { p.stop(); w.stop() }
+        XCTAssertEqual(p.sessions.map(\.id), ["codex.desktop"])
+        XCTAssertEqual(w.sessions.map(\.id), ["codex-work.desktop"])
+        XCTAssertEqual(p.sessions.map(\.name), ["Personal task"])
+        XCTAssertEqual(w.sessions.map(\.name), ["Work task"])
+    }
+
+    private func catalogue(profile: CodexProfile, title: String) throws {
+        try FileManager.default.createDirectory(at: profile.desktopStoreURL.deletingLastPathComponent(),
+                                                withIntermediateDirectories: true)
+        var db: OpaquePointer?
+        XCTAssertEqual(sqlite3_open(profile.desktopStoreURL.path, &db), SQLITE_OK)
+        defer { sqlite3_close(db) }
+        XCTAssertEqual(sqlite3_exec(db, "CREATE TABLE local_thread_catalog (source_updated_at REAL, display_title TEXT, thread_id TEXT)", nil, nil, nil), SQLITE_OK)
+        XCTAssertEqual(sqlite3_exec(db, "INSERT INTO local_thread_catalog VALUES (\(Date().timeIntervalSince1970), '\(title)', 'test')", nil, nil, nil), SQLITE_OK)
+    }
+
+    @MainActor
+    func testCLIActivityWithTheSameRolloutFilenameDoesNotCollide() throws {
+        let root = try home([".codex": [], ".codex-work": []])
+        let personal = CodexProfile.default(home: root)
+        let work = CodexProfile(slug: "work", configDirectory: root.appendingPathComponent(".codex-work"))
+        for profile in [personal, work] {
+            let rollout = profile.configDirectory.appendingPathComponent("rollout.jsonl")
+            try Data().write(to: rollout)
+            var db: OpaquePointer?
+            XCTAssertEqual(sqlite3_open(profile.stateURL.path, &db), SQLITE_OK)
+            defer { sqlite3_close(db) }
+            XCTAssertEqual(sqlite3_exec(db, "CREATE TABLE threads (rollout_path TEXT, archived INTEGER, updated_at_ms INTEGER)", nil, nil, nil), SQLITE_OK)
+            XCTAssertEqual(sqlite3_exec(db, "INSERT INTO threads VALUES ('\(rollout.path)', 0, 1)", nil, nil, nil), SQLITE_OK)
+        }
+        let p = CodexActivityMonitor(profile: personal)
+        let w = CodexActivityMonitor(profile: work)
+        p.start(); w.start()
+        defer { p.stop(); w.stop() }
+        XCTAssertEqual(p.sessions.map(\.id), ["codex.rollout.jsonl"])
+        XCTAssertEqual(w.sessions.map(\.id), ["codex-work.rollout.jsonl"])
+        XCTAssertEqual(w.sessions.map(\.name), ["Codex (work)"])
+    }
+}
+
+/// Stateless: tests can run concurrently without a shared request queue.
+private final class CodexProfileEndpoint: URLProtocol {
+    static func session() -> URLSession {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [CodexProfileEndpoint.self]
+        return URLSession(configuration: configuration)
+    }
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+    override func stopLoading() {}
+
+    override func startLoading() {
+        let account = request.value(forHTTPHeaderField: "ChatGPT-Account-Id")
+        let token = request.value(forHTTPHeaderField: "Authorization")
+        let percent: Int
+        let status: Int
+        switch (account, token) {
+        case ("personal", "Bearer personal-token"): percent = 10; status = 200
+        case ("work", "Bearer work-token"): percent = 75; status = 200
+        case ("work", "Bearer rotated-token"): percent = 80; status = 200
+        case ("work", "Bearer limited-token"): percent = 0; status = 429
+        default: percent = 0; status = 401
+        }
+        let response = HTTPURLResponse(url: request.url!, statusCode: status,
+                                       httpVersion: nil, headerFields: ["Retry-After": "300"])!
+        let body = Data("{\"rate_limit\":{\"primary_window\":{\"used_percent\":\(percent),\"limit_window_seconds\":18000}}}".utf8)
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: body)
+        client?.urlProtocolDidFinishLoading(self)
+    }
+}


### PR DESCRIPTION
Codex currently reads only `~/.codex`, so a second account used through `CODEX_HOME=~/.codex-work` has no separate usage ring or activity indicator. This adds the same profile discovery convention already used for Claude: the default account stays `Codex`, while used `~/.codex-<slug>` directories appear as `Codex (slug)` after restarting Codenotch.

Each profile reads its own credentials and activity databases, has an independent retry deadline, and can be reordered or disconnected in Settings without affecting another profile. Existing default-account IDs and preferences are preserved. The README documents signing into additional accounts through Codex CLI; named profiles also show the corresponding sign-in command. Codenotch only reads credentials and leaves sign-in and token refresh to Codex.

Validation:
- `make test` on macOS 26.6.2 / Xcode 26.6: 764 tests passed.
- Added coverage for discovery and ordering, shell quoting, per-profile credentials and requests, token rotation, retry isolation, disconnect behavior, and separate CLI/desktop activity databases.
- Local installed fork successfully reads live Codex usage; the user also confirmed the additional-account setup works. Automated tests use synthetic credentials and intercepted requests.
