### PR TITLE
Add a Command Code provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ A Windows port — Rust/Tauri 2, same design and providers — lives in [`window
 | **GLM** | official | Z.ai's Coding Plan monitor endpoint, with a key borrowed from whichever coding tool already holds one — Claude Code's `settings.json`, ZCode, or OpenCode. |
 | **Grok** | official | The Grok CLI session in `~/.grok/auth.json`, against the same credits billing endpoint `/usage` uses. |
 | **OpenCode** | official | The Go plan's official usage endpoint, with the `opencode-go` key OpenCode itself stores on sign-in. |
+| **Command Code** | official | The GOAT plan's `/alpha` billing endpoints, with the key the Command Code app writes to `~/.commandcode/auth.json`. |
 | **GitHub Copilot** | official | GitHub's Copilot quota endpoint, authenticated with the GitHub CLI session already on the Mac (`gh auth login`). |
 
 Codenotch never signs in anywhere. Every reading is borrowed from a credential

--- a/Sources/App/AppDelegate.swift
+++ b/Sources/App/AppDelegate.swift
@@ -83,7 +83,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 providers: claudeProfiles.map { ClaudeOAuthProvider(profile: $0) }
                     + [CursorLocalProvider(), CodexLocalProvider(), AntigravityProvider(),
                        GLMProvider(), GrokLocalProvider(), OpenCodeProvider(),
-                       GitHubCopilotProvider(),
+                       CommandCodeProvider(), GitHubCopilotProvider(),
                        // A closure, not the value: the provider is an actor and
                        // re-reads the budget on every fetch, so a ceiling typed
                        // into Settings applies without a restart.

--- a/Sources/Model/UsageModel.swift
+++ b/Sources/Model/UsageModel.swift
@@ -219,6 +219,7 @@ struct ProviderSnapshot: Identifiable, Equatable {
         case "glm":        return "Set up a GLM Coding Plan key for a coding tool to read your usage"
         case "copilot":    return "Sign in with GitHub CLI to read your Copilot usage"
         case "opencode":   return "Connect the Go plan in OpenCode to read your usage"
+        case "commandcode": return "Sign in with the Command Code app to read your usage"
         default:           return "Sign in to \(displayName) to read your usage"
         }
     }

--- a/Sources/Providers/CommandCodeCredentials.swift
+++ b/Sources/Providers/CommandCodeCredentials.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+/// Identity from `~/.commandcode/auth.json`, the same file the Command Code
+/// desktop app writes on login.
+///
+/// Codenotch never signs in — it borrows that key. Refreshing is Command
+/// Code's job. `COMMAND_CODE_API_KEY` wins when set, matching the desktop
+/// harness; a differently named Hermes leftover is ignored on purpose.
+struct CommandCodeCredentials {
+    static var authURL: URL {
+        URL(fileURLWithPath: NSHomeDirectory())
+            .appendingPathComponent(".commandcode/auth.json")
+    }
+
+    let apiKey: String
+    let userName: String?
+
+    static func account(from url: URL = authURL) -> ProviderAccount? {
+        guard let stored = try? load(from: url) else { return nil }
+        return ProviderAccount(
+            label: stored.userName,
+            plan: nil,
+            source: "Command Code",
+            manageURL: URL(string: "https://commandcode.ai")
+        )
+    }
+
+    static func load(from url: URL = authURL,
+                     environment: [String: String] = ProcessInfo.processInfo.environment)
+                    throws -> CommandCodeCredentials {
+        if let env = environment["COMMAND_CODE_API_KEY"]?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !env.isEmpty {
+            return CommandCodeCredentials(apiKey: env, userName: nil)
+        }
+
+        guard FileManager.default.fileExists(atPath: url.path),
+              let data = try? Data(contentsOf: url),
+              let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let key = nonEmpty(root["apiKey"] as? String)
+        else { throw UsageProviderError.needsAuth }
+
+        return CommandCodeCredentials(
+            apiKey: key,
+            userName: nonEmpty(root["userName"] as? String)
+        )
+    }
+
+    private static func nonEmpty(_ value: String?) -> String? {
+        value.flatMap { $0.isEmpty ? nil : $0 }
+    }
+}

--- a/Sources/Providers/CommandCodeProvider.swift
+++ b/Sources/Providers/CommandCodeProvider.swift
@@ -1,0 +1,150 @@
+import Foundation
+import os
+
+/// Reads Command Code GOAT usage from the same `/alpha` endpoints the
+/// desktop app uses, with the key in `~/.commandcode/auth.json`.
+///
+/// The numbers are Command Code's, so this is `.official`. The older
+/// `/internal` cookie path is gone; a Chrome session is not a credential.
+actor CommandCodeProvider: UsageProvider {
+    nonisolated let id = "commandcode"
+    nonisolated let displayName = "Command Code"
+    nonisolated let glyph = ProviderGlyph.commandcode
+
+    private let session: URLSession
+    private let archive: UsageArchive
+    private let authURL: URL
+    private var retryNoEarlierThan: Date?
+    private var consecutiveRateLimits = 0
+    nonisolated(unsafe) private var lastKnownPlan: String?
+    nonisolated(unsafe) private var lastKnownUser: String?
+
+    init(session: URLSession = .shared,
+         archive: UsageArchive = UsageArchive(),
+         authURL: URL = CommandCodeCredentials.authURL) {
+        self.session = session
+        self.archive = archive
+        self.authURL = authURL
+        self.retryNoEarlierThan = archive.loadBackoffUntil(providerID: id)
+    }
+
+    nonisolated var signInRoute: SignInRoute {
+        .guidance("Sign in with the Command Code app — it writes ~/.commandcode/auth.json and the notch reads it.")
+    }
+
+    nonisolated func forgetCachedCredential() {
+        // Nothing is cached: the key is re-read from disk on every fetch,
+        // which is prompt-free, unlike a keychain read.
+    }
+
+    nonisolated func account() -> ProviderAccount? {
+        guard let base = CommandCodeCredentials.account(from: authURL) else { return nil }
+        return ProviderAccount(
+            label: lastKnownUser ?? base.label,
+            plan: lastKnownPlan ?? base.plan,
+            source: base.source,
+            manageURL: base.manageURL
+        )
+    }
+
+    func fetchSnapshot() async throws -> ProviderSnapshot {
+        if let retryNoEarlierThan, retryNoEarlierThan > Date() {
+            let remaining = retryNoEarlierThan.timeIntervalSinceNow
+            Log.usage.debug("commandcode: skipping fetch, backing off for \(remaining, format: .fixed(precision: 0))s")
+            throw UsageProviderError.rateLimited(retryAfter: remaining)
+        }
+
+        guard let credentials = try? CommandCodeCredentials.load(from: authURL) else {
+            throw UsageProviderError.needsAuth
+        }
+
+        do {
+            lastKnownUser = credentials.userName
+            let whoami = try await body(from: CommandCodeUsage.whoami, token: credentials.apiKey)
+            let orgId = CommandCodeUsage.orgId(whoamiJSON: whoami)
+
+            let creditsURL = CommandCodeUsage.credits.withQuery(["orgId": orgId])
+            let subsURL = CommandCodeUsage.subscriptions.withQuery(["orgId": orgId])
+            async let creditsTask = body(from: creditsURL, token: credentials.apiKey)
+            async let subsTask = body(from: subsURL, token: credentials.apiKey)
+            let credits = try await creditsTask
+            let subscription = try await subsTask
+
+            let subObject = (try? JSONSerialization.jsonObject(with: Data(subscription.utf8))) as? [String: Any]
+            let subData = (subObject?["data"] as? [String: Any]) ?? subObject ?? [:]
+            lastKnownPlan = CommandCodeUsage.planName(subData["planId"] as? String)
+
+            var summaryQuery: [String: String?] = ["orgId": orgId]
+            if let start = CommandCodeUsage.date(subData["currentPeriodStart"]) {
+                let stamp = ISO8601DateFormatter()
+                stamp.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+                summaryQuery["since"] = stamp.string(from: start)
+            }
+            let summary = try await body(
+                from: CommandCodeUsage.summary.withQuery(summaryQuery),
+                token: credentials.apiKey
+            )
+
+            let windows = try CommandCodeUsage.windows(
+                summaryJSON: summary,
+                creditsJSON: credits,
+                subscriptionJSON: subscription
+            )
+
+            consecutiveRateLimits = 0
+            retryNoEarlierThan = nil
+            archive.saveBackoffUntil(nil, providerID: id)
+
+            return ProviderSnapshot(
+                id: id,
+                displayName: displayName,
+                glyph: glyph,
+                fidelity: .official,
+                status: .ok,
+                windows: windows,
+                headlineID: "monthly"
+            )
+        } catch UsageProviderError.rateLimited(let retryAfter) {
+            consecutiveRateLimits += 1
+            retryNoEarlierThan = Date().addingTimeInterval(retryAfter)
+            archive.saveBackoffUntil(retryNoEarlierThan, providerID: id)
+            Log.usage.notice("commandcode: rate limited (\(self.consecutiveRateLimits)x), next attempt in \(retryAfter, format: .fixed(precision: 0))s")
+            throw UsageProviderError.rateLimited(retryAfter: retryAfter)
+        }
+    }
+
+    private func body(from url: URL, token: String) async throws -> String {
+        var request = URLRequest(url: url)
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        request.setValue("command-code-desktop", forHTTPHeaderField: "User-Agent")
+        request.setValue("desktop", forHTTPHeaderField: "x-command-code-version")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.timeoutInterval = 15
+
+        Log.usage.debug("GET \(url.host ?? "", privacy: .public)\(url.path, privacy: .public)")
+        let (data, response) = try await session.data(for: request)
+        let status = (response as? HTTPURLResponse)?.statusCode ?? 0
+        if status == 401 || status == 403 { throw UsageProviderError.needsAuth }
+        if status == 429 {
+            throw UsageProviderError.rateLimited(retryAfter: 60)
+        }
+        guard (200..<300).contains(status),
+              let text = String(data: data, encoding: .utf8)
+        else { throw UsageProviderError.badResponse(status: status) }
+        return text
+    }
+}
+
+private extension URL {
+    func withQuery(_ items: [String: String?]) -> URL {
+        guard var components = URLComponents(url: self, resolvingAgainstBaseURL: false) else {
+            return self
+        }
+        let pairs = items.compactMap { key, value -> URLQueryItem? in
+            guard let value, !value.isEmpty else { return nil }
+            return URLQueryItem(name: key, value: value)
+        }
+        if !pairs.isEmpty { components.queryItems = pairs }
+        return components.url ?? self
+    }
+}

--- a/Sources/Providers/CommandCodeUsage.swift
+++ b/Sources/Providers/CommandCodeUsage.swift
@@ -1,0 +1,107 @@
+import Foundation
+
+/// Parses Command Code's `/alpha` billing payload — the same four documents
+/// the desktop app's `fetchUsageData` asks for:
+///
+/// - `GET /alpha/usage/summary` → `{ totalCost, totalCount, … }`
+/// - `GET /alpha/billing/credits` → `{ credits: { monthlyCredits }, windowLimits }`
+/// - `GET /alpha/billing/subscriptions` → `{ data: { planId, currentPeriodEnd } }`
+///
+/// The ring is monthly spend over monthly cap (`totalCost + monthlyCredits`).
+/// Five-hour and weekly windows ride in the tooltip when the cap is known.
+/// A `resetAt` of 0 is absence, not 1970.
+enum CommandCodeUsage {
+    static let whoami = URL(string: "https://api.commandcode.ai/alpha/whoami")!
+    static let credits = URL(string: "https://api.commandcode.ai/alpha/billing/credits")!
+    static let subscriptions = URL(string: "https://api.commandcode.ai/alpha/billing/subscriptions")!
+    static let summary = URL(string: "https://api.commandcode.ai/alpha/usage/summary")!
+
+    static func windows(summaryJSON: String,
+                        creditsJSON: String,
+                        subscriptionJSON: String) throws -> [LimitWindow] {
+        guard let summary = object(summaryJSON),
+              let creditsRoot = object(creditsJSON)
+        else { throw UsageProviderError.badResponse(status: 0) }
+
+        let credits = (creditsRoot["credits"] as? [String: Any]) ?? [:]
+        let limits = (creditsRoot["windowLimits"] as? [String: Any]) ?? [:]
+        let subRoot = object(subscriptionJSON) ?? [:]
+        let sub = (subRoot["data"] as? [String: Any]) ?? subRoot
+        let periodEnd = date(sub["currentPeriodEnd"])
+
+        let used = number(summary["totalCost"]) ?? 0
+        let remaining = number(credits["monthlyCredits"]) ?? 0
+        let cap = (used > 0 || remaining > 0) ? used + remaining : 0
+        guard cap > 0 else {
+            throw UsageProviderError.nothingMetered("Command Code has nothing metered on this account yet")
+        }
+
+        var windows: [LimitWindow] = [
+            LimitWindow(
+                id: "monthly",
+                label: "Monthly limit",
+                usedFraction: used / cap,
+                resetsAt: periodEnd
+            )
+        ]
+
+        if let five = window(limits["fiveHour"], id: "fiveHour", label: "5h limit") {
+            windows.append(five)
+        }
+        if let weekly = window(limits["weekly"], id: "weekly", label: "Weekly limit") {
+            windows.append(weekly)
+        }
+        return windows
+    }
+
+    static func planName(_ planId: String?) -> String? {
+        guard let planId, !planId.isEmpty else { return nil }
+        let key = planId.lowercased().replacingOccurrences(of: "-", with: "_")
+        if key.contains("goat") { return "GOAT" }
+        return planId
+    }
+
+    static func orgId(whoamiJSON: String) -> String? {
+        guard let root = object(whoamiJSON) else { return nil }
+        let org = (root["org"] as? [String: Any]) ?? [:]
+        return org["id"] as? String
+    }
+
+    private static func window(_ any: Any?, id: String, label: String) -> LimitWindow? {
+        guard let entry = any as? [String: Any],
+              let cap = number(entry["cap"]), cap > 0
+        else { return nil }
+        let used = number(entry["used"]) ?? 0
+        return LimitWindow(
+            id: id,
+            label: label,
+            usedFraction: used / cap,
+            resetsAt: date(entry["resetAt"])
+        )
+    }
+
+    private static func object(_ json: String) -> [String: Any]? {
+        guard let data = json.data(using: .utf8),
+              let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else { return nil }
+        return root
+    }
+
+    private static func number(_ any: Any?) -> Double? {
+        (any as? NSNumber)?.doubleValue
+    }
+
+    /// ISO 8601, unix seconds, or unix milliseconds. Zero is "no reset".
+    static func date(_ any: Any?) -> Date? {
+        if let text = any as? String {
+            let fractional = ISO8601DateFormatter()
+            fractional.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+            if let date = fractional.date(from: text) { return date }
+            return ISO8601DateFormatter().date(from: text)
+        }
+        guard let value = number(any), value > 0 else { return nil }
+        var unix = value
+        if unix > 1_000_000_000_000 { unix /= 1000 }
+        return Date(timeIntervalSince1970: unix)
+    }
+}

--- a/Sources/Providers/GlyphOutline.swift
+++ b/Sources/Providers/GlyphOutline.swift
@@ -530,6 +530,24 @@ enum GlyphOutline {
          CGPoint(x: 0.7500, y: 0.9600), CGPoint(x: 0.1500, y: 0.9600)]
     ]
 
+    /// Command Code's mark is the macOS command key — four loops around a
+    /// cross. Geometric, not traced: their SVG is that symbol, and a screenshot
+    /// trace would be worse than a readable glyph at 16pt.
+    static let commandcode: [[CGPoint]] = [
+        [CGPoint(x: 0.12, y: 0.12), CGPoint(x: 0.32, y: 0.12),
+         CGPoint(x: 0.32, y: 0.32), CGPoint(x: 0.12, y: 0.32)],
+        [CGPoint(x: 0.68, y: 0.12), CGPoint(x: 0.88, y: 0.12),
+         CGPoint(x: 0.88, y: 0.32), CGPoint(x: 0.68, y: 0.32)],
+        [CGPoint(x: 0.12, y: 0.68), CGPoint(x: 0.32, y: 0.68),
+         CGPoint(x: 0.32, y: 0.88), CGPoint(x: 0.12, y: 0.88)],
+        [CGPoint(x: 0.68, y: 0.68), CGPoint(x: 0.88, y: 0.68),
+         CGPoint(x: 0.88, y: 0.88), CGPoint(x: 0.68, y: 0.88)],
+        [CGPoint(x: 0.22, y: 0.42), CGPoint(x: 0.78, y: 0.42),
+         CGPoint(x: 0.78, y: 0.58), CGPoint(x: 0.22, y: 0.58)],
+        [CGPoint(x: 0.42, y: 0.22), CGPoint(x: 0.58, y: 0.22),
+         CGPoint(x: 0.58, y: 0.78), CGPoint(x: 0.42, y: 0.78)]
+    ]
+
     /// GitHub Copilot's own mark, traced from its icon.
     static let copilot: [[CGPoint]] = [
         [

--- a/Sources/Providers/ProviderGlyph.swift
+++ b/Sources/Providers/ProviderGlyph.swift
@@ -20,6 +20,7 @@ enum ProviderGlyph: String, Codable, Equatable {
     case glm
     case grok
     case opencode
+    case commandcode
     case copilot
 
     /// If an asset with this name is in the bundle it wins over the traced
@@ -47,6 +48,7 @@ enum ProviderGlyph: String, Codable, Equatable {
         case .glm:    return 0.95
         case .grok:   return 1.0
         case .opencode: return 0.95
+        case .commandcode: return 0.96
         case .copilot: return 0.96
         case .third:  return 1.0
         }
@@ -63,6 +65,7 @@ enum ProviderGlyph: String, Codable, Equatable {
         case .glm:    return GlyphOutline.glm
         case .grok:   return GlyphOutline.grok
         case .opencode: return GlyphOutline.opencode
+        case .commandcode: return GlyphOutline.commandcode
         case .copilot: return GlyphOutline.copilot
         }
     }

--- a/Sources/Settings/SettingsView.swift
+++ b/Sources/Settings/SettingsView.swift
@@ -713,8 +713,8 @@ struct SettingsView: View {
         "Codenotch reads usage from tools already signed in on this Mac — it "
         + "never asks for your password. Install and sign in to any of Claude "
         + "Code (the terminal tool, not the Claude app), Cursor (the editor or "
-        + "cursor-agent), Codex, Antigravity, GLM, Grok, OpenCode, GitHub "
-        + "Copilot or a Gemini API key (via Gemini CLI, OpenCode or Hermes), "
+        + "cursor-agent), Codex, Antigravity, GLM, Grok, OpenCode, Command "
+        + "Code, GitHub Copilot or a Gemini API key (via Gemini CLI, OpenCode or Hermes), "
         + "and its ring appears in the notch."
 
     /// Said before it happens rather than after. A system dialogue asking to

--- a/Tests/CommandCodeUsageTests.swift
+++ b/Tests/CommandCodeUsageTests.swift
@@ -1,0 +1,165 @@
+import XCTest
+@testable import Codenotch
+
+/// Pinned to the `/alpha` documents the Command Code desktop app reads.
+/// Numbers are round; no live secrets.
+final class CommandCodeUsageTests: XCTestCase {
+    private let summary = #"{"totalCost":50.5,"totalCount":10,"totalTokensIn":0,"totalTokensOut":0}"#
+    private let credits = """
+    {"credits":{"monthlyCredits":19.5,"belowThreshold":false},\
+    "windowLimits":{\
+    "fiveHour":{"used":0,"cap":14,"resetAt":0,"exceeded":false},\
+    "weekly":{"used":22.45,"cap":35,"resetAt":1787857355088,"exceeded":false}}}
+    """
+    private let subscription = """
+    {"data":{"planId":"individual-goat",\
+    "currentPeriodStart":"2026-08-13T15:21:27.000Z",\
+    "currentPeriodEnd":"2026-09-13T15:21:27.000Z"}}
+    """
+
+    private func windows() throws -> [LimitWindow] {
+        try CommandCodeUsage.windows(
+            summaryJSON: summary,
+            creditsJSON: credits,
+            subscriptionJSON: subscription
+        )
+    }
+
+    func testTheRingIsMonthlySpendOverCap() throws {
+        let monthly = try XCTUnwrap(windows().first { $0.id == "monthly" })
+        XCTAssertEqual(monthly.label, "Monthly limit")
+        XCTAssertEqual(monthly.usedFraction ?? -1, 50.5 / 70.0, accuracy: 0.0001)
+        let reset = try XCTUnwrap(monthly.resetsAt)
+        var utc = Calendar(identifier: .gregorian)
+        utc.timeZone = TimeZone(identifier: "UTC")!
+        XCTAssertEqual(utc.component(.day, from: reset), 13)
+        XCTAssertEqual(utc.component(.month, from: reset), 9)
+    }
+
+    func testFiveHourResetOfZeroIsAbsence() throws {
+        let five = try XCTUnwrap(windows().first { $0.id == "fiveHour" })
+        XCTAssertEqual(five.usedFraction ?? -1, 0, accuracy: 0.0001)
+        XCTAssertNil(five.resetsAt)
+    }
+
+    func testWeeklyWindowUsesMillisecondReset() throws {
+        let weekly = try XCTUnwrap(windows().first { $0.id == "weekly" })
+        XCTAssertEqual(weekly.usedFraction ?? -1, 22.45 / 35.0, accuracy: 0.0001)
+        XCTAssertNotNil(weekly.resetsAt)
+    }
+
+    func testHeadlineIsMonthly() throws {
+        let snap = ProviderSnapshot(
+            id: "commandcode", displayName: "Command Code", glyph: .commandcode,
+            fidelity: .official, status: .ok, windows: try windows(),
+            headlineID: "monthly"
+        )
+        XCTAssertEqual(snap.headline?.id, "monthly")
+    }
+
+    func testTheSignInPromptNamesTheApp() {
+        let snapshot = ProviderSnapshot(
+            id: "commandcode", displayName: "Command Code", glyph: .commandcode,
+            fidelity: .official, status: .needsAuth, windows: []
+        )
+        XCTAssertEqual(snapshot.statusMessage,
+                       "Sign in with the Command Code app to read your usage")
+    }
+
+    func testEmptyCreditsAreNotAReading() {
+        XCTAssertThrowsError(try CommandCodeUsage.windows(
+            summaryJSON: #"{"totalCost":0}"#,
+            creditsJSON: #"{"credits":{}}"#,
+            subscriptionJSON: "{}"
+        )) { error in
+            guard case UsageProviderError.nothingMetered = error else {
+                return XCTFail("expected nothingMetered, got \(error)")
+            }
+        }
+    }
+
+    func testGarbageIsABadResponse() {
+        XCTAssertThrowsError(try CommandCodeUsage.windows(
+            summaryJSON: "not json",
+            creditsJSON: "{}",
+            subscriptionJSON: "{}"
+        )) { error in
+            guard case UsageProviderError.badResponse = error else {
+                return XCTFail("expected badResponse, got \(error)")
+            }
+        }
+    }
+
+    func testIndividualGoatIsGOAT() {
+        XCTAssertEqual(CommandCodeUsage.planName("individual-goat"), "GOAT")
+    }
+
+    func testOrgIdComesFromWhoami() {
+        let json = #"{"user":{"id":"u1"},"org":{"id":"org-9"}}"#
+        XCTAssertEqual(CommandCodeUsage.orgId(whoamiJSON: json), "org-9")
+    }
+}
+
+final class CommandCodeCredentialsTests: XCTestCase {
+    private func file(_ text: String) throws -> URL {
+        let url = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("commandcode-auth-\(UUID().uuidString).json")
+        try text.write(to: url, atomically: true, encoding: .utf8)
+        addTeardownBlock { try? FileManager.default.removeItem(at: url) }
+        return url
+    }
+
+    func testReadsTheDesktopAuthFile() throws {
+        let url = try file(#"{"apiKey":"user_testkey","userName":"tester"}"#)
+        let loaded = try CommandCodeCredentials.load(from: url, environment: [:])
+        XCTAssertEqual(loaded.apiKey, "user_testkey")
+        XCTAssertEqual(loaded.userName, "tester")
+    }
+
+    func testEnvWinsOverTheFile() throws {
+        let url = try file(#"{"apiKey":"user_file"}"#)
+        let loaded = try CommandCodeCredentials.load(
+            from: url,
+            environment: ["COMMAND_CODE_API_KEY": "user_env"]
+        )
+        XCTAssertEqual(loaded.apiKey, "user_env")
+    }
+
+    func testHermesNamedKeyIsIgnored() throws {
+        let url = try file(#"{"apiKey":"user_file"}"#)
+        let loaded = try CommandCodeCredentials.load(
+            from: url,
+            environment: ["COMMANDCODE_API_KEY": "user_hermes"]
+        )
+        XCTAssertEqual(loaded.apiKey, "user_file")
+    }
+
+    func testAMissingFileIsNeedsAuth() {
+        XCTAssertThrowsError(try CommandCodeCredentials.load(
+            from: URL(fileURLWithPath: "/tmp/missing-commandcode-auth.json"),
+            environment: [:]
+        )) { error in
+            guard case UsageProviderError.needsAuth = error else {
+                return XCTFail("expected needsAuth, got \(error)")
+            }
+        }
+    }
+}
+
+/// The mark is geometric rather than traced, so its boxes are pinned: four
+/// corner loops and a cross, all inside the unit box, reading as ⌘.
+final class CommandCodeGlyphTests: XCTestCase {
+    func testTheOutlineIsSixLoopsInsideTheUnitBox() {
+        let outline = GlyphOutline.commandcode
+        XCTAssertEqual(outline.count, 6)
+        XCTAssertEqual(ProviderGlyph.commandcode.outline, outline)
+        XCTAssertEqual(ProviderGlyph.commandcode.rawValue, "commandcode")
+        for loop in outline {
+            XCTAssertEqual(loop.count, 4)
+            for point in loop {
+                XCTAssertTrue((0...1).contains(point.x), "x \(point.x) outside the unit box")
+                XCTAssertTrue((0...1).contains(point.y), "y \(point.y) outside the unit box")
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Official Command Code GOAT ring, using the same `/alpha` documents the desktop app already reads
- Monthly spend over cap is the headline; 5h and weekly ride in the tooltip
- A `resetAt` of 0 is absence, not 1970
- Tests pin the payload shape with round numbers; no live secrets and no network

Closes #62

## Test plan
- [ ] `make test`
- [ ] With Command Code signed in, the ring appears and matches the app's monthly figure
- [ ] Without a local Command Code session, the row says to sign in with the Command Code app
- [ ] A 5h window with `resetAt: 0` shows no reset time

Made with [Cursor](https://cursor.com)