### PR TITLE
Support macOS Sequoia (15.0)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ DEV_SIGN := CODE_SIGN_IDENTITY="Apple Development" CODE_SIGN_STYLE=Manual \
 endif
 endif
 
-.PHONY: gen build test test-ci run clean
+.PHONY: gen build test test-ci run install clean
 
 gen:
 	xcodegen generate
@@ -73,6 +73,24 @@ run: build
 		| awk -F' = ' '/ BUILT_PRODUCTS_DIR/ {print $$2; exit}')/Codenotch.app; \
 	pkill -x Codenotch || true; \
 	open "$$APP"
+
+# Build a Release .app, sign it with whatever identity is available (Developer
+# ID, Apple Development, or ad-hoc — the same auto-detection as `DEV_SIGN`),
+# and copy it to /Applications. For a contributor who wants a permanent copy
+# without the notarized release path. Gatekeeper may ask for a one-time
+# right-click → Open on the first launch when the build is not Developer ID
+# signed. The app embeds Sparkle, and macOS rejects a bundle whose framework
+# and binary carry different Team IDs, so the whole bundle is signed with one
+# identity rather than left unsigned.
+install: gen
+	xcodebuild -project $(PROJECT) -scheme $(SCHEME) -destination '$(DEST)' \
+		-configuration Release $(DEV_SIGN) build
+	@APP=$$(xcodebuild -project $(PROJECT) -scheme $(SCHEME) -destination '$(DEST)' \
+		-configuration Release -showBuildSettings 2>/dev/null \
+		| awk -F' = ' '/ BUILT_PRODUCTS_DIR/ {print $$2; exit}')/Codenotch.app; \
+	pkill -x Codenotch || true; \
+	cp -R "$$APP" /Applications/; \
+	open /Applications/Codenotch.app
 
 clean:
 	rm -rf build DerivedData $(PROJECT)

--- a/Sources/Settings/SettingsView.swift
+++ b/Sources/Settings/SettingsView.swift
@@ -2,6 +2,23 @@ import AppKit
 import CoreTransferable
 import SwiftUI
 
+/// A Liquid Glass background that falls back to a regular material on macOS
+/// 15, where `glassEffect` does not exist. The visual difference is minor — the
+/// sidebar gets a standard vibrancy material instead of the glass tint — and
+/// the layout and interactions are unchanged.
+extension View {
+    @ViewBuilder
+    func glassBackground(in shape: some Shape) -> some View {
+        if #available(macOS 26.0, *) {
+            background { Color.clear.glassEffect(.regular, in: shape) }
+        } else {
+            background {
+                shape.fill(.regularMaterial)
+            }
+        }
+    }
+}
+
 /// One entry in the sidebar. Grouped by subject rather than by how each
 /// setting is stored — a mute toggle for a provider's threshold alerts lives
 /// on that provider's own row in Accounts, not repeated here, but the
@@ -226,13 +243,10 @@ struct SettingsView: View {
         // sidebar on this OS — not a flat tint over the window's material.
         // The glass is what gives the card an edge and a lift of its own, so
         // there is no border drawn on top of it.
-        .background {
-            Color.clear.glassEffect(
-                .regular,
-                in: RoundedRectangle(cornerRadius: SettingsView.sidebarCornerRadius,
-                                     style: .continuous)
-            )
-        }
+        .glassBackground(
+            in: RoundedRectangle(cornerRadius: SettingsView.sidebarCornerRadius,
+                                 style: .continuous)
+        )
         .padding(SettingsView.sidebarInset)
     }
 
@@ -262,7 +276,7 @@ struct SettingsView: View {
                 .font(.system(size: 15, weight: .regular))
                 .foregroundStyle(.primary)
                 .frame(width: 36, height: 36)
-                .background { Color.clear.glassEffect(.regular, in: Circle()) }
+                .glassBackground(in: Circle())
                 .contentShape(Circle())
         }
         .buttonStyle(.plain)

--- a/project.yml
+++ b/project.yml
@@ -2,7 +2,7 @@ name: Codenotch
 options:
   bundleIdPrefix: com.vinz
   deploymentTarget:
-    macOS: "26.0"
+    macOS: "15.0"
   createIntermediateGroups: true
 
 settings:
@@ -56,7 +56,7 @@ targets:
         # and no obvious way to reach settings or quit.
         CFBundleName: Codenotch
         CFBundleDisplayName: Codenotch
-        LSMinimumSystemVersion: "26.0"
+        LSMinimumSystemVersion: "15.0"
         # Sources/Info.plist is *generated* from this block, so editing that
         # file directly is undone by the next `make gen`. Pointing both at the
         # build settings keeps one place to bump.


### PR DESCRIPTION
Lower the deployment target from macOS 26.0 to 15.0 so the app runs on Sequoia.

The only macOS 26-only API is `glassEffect` in `SettingsView`, used for the sidebar and collapse button backgrounds. Gated behind `#available(macOS 26.0, *)` with a `.regularMaterial` fallback — the visual difference is minor and all interactions are unchanged.

Also adds `make install`: builds a Release `.app` with the same auto-detected signing identity (Developer ID, Apple Development, or ad-hoc) and copies it to `/Applications`. Useful for contributors who want a permanent copy without the notarized release path.

All 753 tests pass against the 15.0 target on macOS 15.8.