### PR TITLE
Support macOS 15+ and Intel (x86_64) architecture

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,8 @@ endif
 
 PROJECT := Codenotch.xcodeproj
 SCHEME  := Codenotch
-DEST    := platform=macOS,arch=arm64
+ARCH    ?= $(shell uname -m)
+DEST    ?= platform=macOS,arch=$(ARCH)
 
 # Debug signs itself when the maintainer's Developer ID certificate isn't in
 # the keychain, which is every machine but the maintainer's — so a contributor

--- a/Sources/Info.plist
+++ b/Sources/Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>26.0</string>
+	<string>15.0</string>
 	<key>SUAutomaticallyUpdate</key>
 	<true/>
 	<key>SUEnableAutomaticChecks</key>

--- a/Sources/Settings/SettingsView.swift
+++ b/Sources/Settings/SettingsView.swift
@@ -227,11 +227,17 @@ struct SettingsView: View {
         // The glass is what gives the card an edge and a lift of its own, so
         // there is no border drawn on top of it.
         .background {
-            Color.clear.glassEffect(
-                .regular,
-                in: RoundedRectangle(cornerRadius: SettingsView.sidebarCornerRadius,
-                                     style: .continuous)
-            )
+            if #available(macOS 26.0, *) {
+                Color.clear.glassEffect(
+                    .regular,
+                    in: RoundedRectangle(cornerRadius: SettingsView.sidebarCornerRadius,
+                                         style: .continuous)
+                )
+            } else {
+                RoundedRectangle(cornerRadius: SettingsView.sidebarCornerRadius,
+                                 style: .continuous)
+                    .fill(.regularMaterial)
+            }
         }
         .padding(SettingsView.sidebarInset)
     }
@@ -262,7 +268,13 @@ struct SettingsView: View {
                 .font(.system(size: 15, weight: .regular))
                 .foregroundStyle(.primary)
                 .frame(width: 36, height: 36)
-                .background { Color.clear.glassEffect(.regular, in: Circle()) }
+                .background {
+                    if #available(macOS 26.0, *) {
+                        Color.clear.glassEffect(.regular, in: Circle())
+                    } else {
+                        Circle().fill(.regularMaterial)
+                    }
+                }
                 .contentShape(Circle())
         }
         .buttonStyle(.plain)

--- a/project.yml
+++ b/project.yml
@@ -2,7 +2,7 @@ name: Codenotch
 options:
   bundleIdPrefix: com.vinz
   deploymentTarget:
-    macOS: "26.0"
+    macOS: "15.0"
   createIntermediateGroups: true
 
 settings:
@@ -56,7 +56,7 @@ targets:
         # and no obvious way to reach settings or quit.
         CFBundleName: Codenotch
         CFBundleDisplayName: Codenotch
-        LSMinimumSystemVersion: "26.0"
+        LSMinimumSystemVersion: "15.0"
         # Sources/Info.plist is *generated* from this block, so editing that
         # file directly is undone by the next `make gen`. Pointing both at the
         # build settings keeps one place to bump.


### PR DESCRIPTION
This PR enables building and running Codenotch on macOS 15 (Sequoia) and Intel (`x86_64`) Macs:

- **Dynamic architecture detection:** Updated `Makefile` to use `$(shell uname -m)`, defaulting to `arm64` on Apple Silicon and `x86_64` on Intel Macs.
- **Deployment target lowered to macOS 15.0:** Updated `project.yml` so LaunchServices permits launching on macOS 15+.
- **Graceful API fallback:** Wrapped `.glassEffect(...)` in `SettingsView.swift` with `if #available(macOS 26.0, *)`, falling back to `.regularMaterial` on macOS 15.
- **Tests:** All 753 unit tests pass (`make test`).