### PR TITLE
Add Ollama Cloud provider

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ DEV_SIGN := CODE_SIGN_IDENTITY="Apple Development" CODE_SIGN_STYLE=Manual \
 endif
 endif
 
-.PHONY: gen build test test-ci run clean
+.PHONY: gen build test test-ci run install clean
 
 gen:
 	xcodegen generate
@@ -73,6 +73,24 @@ run: build
 		| awk -F' = ' '/ BUILT_PRODUCTS_DIR/ {print $$2; exit}')/Codenotch.app; \
 	pkill -x Codenotch || true; \
 	open "$$APP"
+
+# Build a Release .app, sign it with whatever identity is available (Developer
+# ID, Apple Development, or ad-hoc — the same auto-detection as `DEV_SIGN`),
+# and copy it to /Applications. For a contributor who wants a permanent copy
+# without the notarized release path. Gatekeeper may ask for a one-time
+# right-click → Open on the first launch when the build is not Developer ID
+# signed. The app embeds Sparkle, and macOS rejects a bundle whose framework
+# and binary carry different Team IDs, so the whole bundle is signed with one
+# identity rather than left unsigned.
+install: gen
+	xcodebuild -project $(PROJECT) -scheme $(SCHEME) -destination '$(DEST)' \
+		-configuration Release $(DEV_SIGN) build
+	@APP=$$(xcodebuild -project $(PROJECT) -scheme $(SCHEME) -destination '$(DEST)' \
+		-configuration Release -showBuildSettings 2>/dev/null \
+		| awk -F' = ' '/ BUILT_PRODUCTS_DIR/ {print $$2; exit}')/Codenotch.app; \
+	pkill -x Codenotch || true; \
+	cp -R "$$APP" /Applications/; \
+	open /Applications/Codenotch.app
 
 clean:
 	rm -rf build DerivedData $(PROJECT)

--- a/Sources/App/AppDelegate.swift
+++ b/Sources/App/AppDelegate.swift
@@ -84,6 +84,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                     + [CursorLocalProvider(), CodexLocalProvider(), AntigravityProvider(),
                        GLMProvider(), GrokLocalProvider(), OpenCodeProvider(),
                        GitHubCopilotProvider(),
+                       OllamaProvider(),
                        // A closure, not the value: the provider is an actor and
                        // re-reads the budget on every fetch, so a ceiling typed
                        // into Settings applies without a restart.

--- a/Sources/Features/TooltipCard.swift
+++ b/Sources/Features/TooltipCard.swift
@@ -270,25 +270,36 @@ private struct LimitWindowRow: View {
         window.resetsAt.map { ResetCopy.text(for: $0, now: now, format: resetTimeFormat) } ?? ""
     }
 
+    /// A count-only row (no fraction, no reset) — like Ollama's per-model request
+    /// counts — renders as a single table line: name left, count right.
+    private var isCountRow: Bool {
+        window.usedFraction == nil && window.used != nil
+    }
+
     var body: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            SplitRow(leading: window.label, trailing: resetText)
+        if isCountRow {
+            SplitRow(leading: window.label, trailing: "\(window.used ?? 0)",
+                     trailingColor: Palette.textSecondary)
+        } else {
+            VStack(alignment: .leading, spacing: 0) {
+                SplitRow(leading: window.label, trailing: resetText)
 
-            // No bar without a denominator — an empty track would read as "none
-            // used", which is not what "we do not know the limit" means.
-            if window.usedFraction != nil {
-                ZStack(alignment: .leading) {
-                    Capsule().fill(Palette.barTrack)
-                    Capsule().fill(band.color(accent: accentColor)).frame(width: fillWidth)
+                // No bar without a denominator — an empty track would read as "none
+                // used", which is not what "we do not know the limit" means.
+                if window.usedFraction != nil {
+                    ZStack(alignment: .leading) {
+                        Capsule().fill(Palette.barTrack)
+                        Capsule().fill(band.color(accent: accentColor)).frame(width: fillWidth)
+                    }
+                    .frame(width: trackWidth, height: NotchLayout.barHeight)
+                    .padding(.top, NotchLayout.labelToBar)
                 }
-                .frame(width: trackWidth, height: NotchLayout.barHeight)
-                .padding(.top, NotchLayout.labelToBar)
-            }
 
-            Text("\(window.usedFraction == nil ? "" : fidelity.qualifier)\(window.summary)")
-                .font(Typography.cardBody)
-                .foregroundStyle(Palette.textPrimary)
-                .padding(.top, NotchLayout.barToUsed)
+                Text("\(window.usedFraction == nil ? "" : fidelity.qualifier)\(window.summary)")
+                    .font(Typography.cardBody)
+                    .foregroundStyle(Palette.textPrimary)
+                    .padding(.top, NotchLayout.barToUsed)
+            }
         }
     }
 }
@@ -471,7 +482,8 @@ struct TooltipCard: View {
             sessionCount: activity?.sessions.count ?? 0,
             sessionCap: sessionCap,
             statusMessage: snapshot.statusMessage,
-            blockMessage: snapshot.block?.summary(now: now)
+            blockMessage: snapshot.block?.summary(now: now),
+            compactRowCount: snapshot.compactRowCount
         )
     }
 

--- a/Sources/Model/UsageModel.swift
+++ b/Sources/Model/UsageModel.swift
@@ -200,6 +200,12 @@ struct ProviderSnapshot: Identifiable, Equatable {
     /// a dash rather than an authoritative-looking 0%.
     var hasReading: Bool { !windows.isEmpty }
 
+    /// How many windows are count-only (no fraction, no bar) — they render as
+    /// single-line rows and take less vertical space than full bar rows.
+    var compactRowCount: Int {
+        windows.filter { $0.usedFraction == nil && $0.used != nil }.count
+    }
+
     /// A ring can only be drawn when the provider said what the limit was.
     var ringFraction: Double? { usedFraction }
 
@@ -219,6 +225,7 @@ struct ProviderSnapshot: Identifiable, Equatable {
         case "glm":        return "Set up a GLM Coding Plan key for a coding tool to read your usage"
         case "copilot":    return "Sign in with GitHub CLI to read your Copilot usage"
         case "opencode":   return "Connect the Go plan in OpenCode to read your usage"
+        case "ollama":     return "Enter an Ollama API key in Settings, or export OLLAMA_API_KEY"
         default:           return "Sign in to \(displayName) to read your usage"
         }
     }

--- a/Sources/Notch/NotchLayout.swift
+++ b/Sources/Notch/NotchLayout.swift
@@ -274,7 +274,8 @@ enum NotchLayout {
     static func cardHeight(windowCount: Int, sessionCount: Int = 0,
                            sessionCap: Int = defaultSessionCap,
                            statusMessage: String? = nil,
-                           blockMessage: String? = nil) -> CGFloat {
+                           blockMessage: String? = nil,
+                           compactRowCount: Int = 0) -> CGFloat {
         let header = max(glyphSize, cardTitleLineHeight)
         var height = 2 * cardPadding + header
 
@@ -285,9 +286,14 @@ enum NotchLayout {
         }
 
         if windowCount > 0 {
-            let block = 2 * cardBodyLineHeight + labelToBar + barHeight + barToUsed
+            let fullCount = windowCount - compactRowCount
+            // A full window row: label + bar + summary.
+            let fullBlock = 2 * cardBodyLineHeight + labelToBar + barHeight + barToUsed
+            // A compact (count-only) row: a single SplitRow line.
+            let compactBlock = cardBodyLineHeight
             height += headerToBlock
-                + CGFloat(windowCount) * block
+                + CGFloat(fullCount) * fullBlock
+                + CGFloat(compactRowCount) * compactBlock
                 + CGFloat(windowCount - 1) * blockSpacing
         } else {
             // The status message, at whatever height it actually wraps to.

--- a/Sources/Notch/NotchRootView.swift
+++ b/Sources/Notch/NotchRootView.swift
@@ -206,7 +206,8 @@ struct NotchRootView: View {
                 sessionCount: model.activity(for: snapshot.id)?.sessions.count ?? 0,
                 sessionCap: model.sessionCap,
                 statusMessage: snapshot.statusMessage,
-                blockMessage: snapshot.block?.summary(now: model.now)
+                blockMessage: snapshot.block?.summary(now: model.now),
+                compactRowCount: snapshot.compactRowCount
             )
         return place.point(
             along: model.slack + model.ringCenter(index: index),

--- a/Sources/Notch/NotchWindowController.swift
+++ b/Sources/Notch/NotchWindowController.swift
@@ -290,7 +290,8 @@ final class NotchWindowController {
             sessionCount: model.activity(for: snapshot.id)?.sessions.count ?? 0,
             sessionCap: model.sessionCap,
             statusMessage: snapshot.statusMessage,
-            blockMessage: snapshot.block?.summary(now: model.now)
+            blockMessage: snapshot.block?.summary(now: model.now),
+            compactRowCount: snapshot.compactRowCount
         )
         // Across the stack the region is the card, its tail, and the gap the
         // pointer has to cross. Along it, the card's own extent.

--- a/Sources/Providers/GlyphOutline.swift
+++ b/Sources/Providers/GlyphOutline.swift
@@ -827,4 +827,24 @@ enum GlyphOutline {
             CGPoint(x: 0.93000, y: 0.46000),
         ],
     ]
+
+    /// A simple alpaca silhouette — two pointed ears, a rounded body, four legs.
+    static let ollama: [[CGPoint]] = [
+        // Left ear
+        [CGPoint(x: 0.30, y: 0.00), CGPoint(x: 0.38, y: 0.18),
+         CGPoint(x: 0.26, y: 0.20)],
+        // Right ear
+        [CGPoint(x: 0.55, y: 0.00), CGPoint(x: 0.62, y: 0.18),
+         CGPoint(x: 0.67, y: 0.20)],
+        // Head + body + legs as one outline
+        [CGPoint(x: 0.20, y: 0.20), CGPoint(x: 0.80, y: 0.20),
+         CGPoint(x: 0.85, y: 0.30), CGPoint(x: 0.85, y: 0.55),
+         CGPoint(x: 0.80, y: 0.60), CGPoint(x: 0.80, y: 0.80),
+         CGPoint(x: 0.72, y: 0.80), CGPoint(x: 0.72, y: 0.65),
+         CGPoint(x: 0.55, y: 0.65), CGPoint(x: 0.55, y: 0.80),
+         CGPoint(x: 0.47, y: 0.80), CGPoint(x: 0.47, y: 0.65),
+         CGPoint(x: 0.30, y: 0.65), CGPoint(x: 0.30, y: 0.80),
+         CGPoint(x: 0.22, y: 0.80), CGPoint(x: 0.22, y: 0.60),
+         CGPoint(x: 0.17, y: 0.55), CGPoint(x: 0.17, y: 0.30)]
+    ]
 }

--- a/Sources/Providers/KeychainItem.swift
+++ b/Sources/Providers/KeychainItem.swift
@@ -96,4 +96,56 @@ enum KeychainItem {
     static func modifiedAt(services: [String], account: String? = nil) -> Date? {
         newest(services: services, account: account)?.modifiedAt
     }
+
+    /// Reads the data from the newest item under a service. The one call that
+    /// can trigger a keychain prompt for items owned by another app — but for
+    /// items this app created itself (`store`), no prompt is involved.
+    static func read(service: String, account: String? = nil) -> String? {
+        guard let match = newest(service: service, account: account) else { return nil }
+        var query: [CFString: Any] = [
+            kSecClass: kSecClassGenericPassword,
+            kSecValuePersistentRef: match.persistentRef,
+            kSecReturnData: true,
+            kSecMatchLimit: kSecMatchLimitOne
+        ]
+        var result: CFTypeRef?
+        guard SecItemCopyMatching(query as CFDictionary, &result) == errSecSuccess,
+              let data = result as? Data
+        else { return nil }
+        return String(data: data, encoding: .utf8)
+    }
+
+    /// Stores a string under a service+account, creating or updating the item.
+    /// For items this app owns, no prompt is involved on either write or read.
+    static func store(service: String, account: String, value: String) -> Bool {
+        let data = Data(value.utf8)
+        let query: [CFString: Any] = [
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrService: service,
+            kSecAttrAccount: account
+        ]
+        let attributes: [CFString: Any] = [
+            kSecValueData: data,
+            kSecAttrAccessible: kSecAttrAccessibleAfterFirstUnlock
+        ]
+        let updateStatus = SecItemUpdate(query as CFDictionary, attributes as CFDictionary)
+        if updateStatus == errSecSuccess { return true }
+        if updateStatus == errSecItemNotFound {
+            var addQuery = query
+            addQuery.merge(attributes) { _, new in new }
+            return SecItemAdd(addQuery as CFDictionary, nil) == errSecSuccess
+        }
+        return false
+    }
+
+    /// Deletes the item under a service+account, if one exists.
+    @discardableResult
+    static func delete(service: String, account: String) -> Bool {
+        let query: [CFString: Any] = [
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrService: service,
+            kSecAttrAccount: account
+        ]
+        return SecItemDelete(query as CFDictionary) == errSecSuccess
+    }
 }

--- a/Sources/Providers/OllamaCredentials.swift
+++ b/Sources/Providers/OllamaCredentials.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+/// The Ollama cloud API key, read from the environment first and the keychain
+/// second.
+///
+/// Unlike every other provider, Codenotch owns this credential: the user types
+/// it into Settings, and it is stored in the login keychain under a service
+/// name no other app uses. The environment variable `OLLAMA_API_KEY` is checked
+/// first, so a shell that already exports one works without any setup.
+enum OllamaCredentials {
+    static let keychainService = "ollama-api-key"
+    static let keychainAccount = "codenotch"
+
+    /// The API key, wherever it is found. Environment first, then keychain.
+    static func load() -> String? {
+        if let env = ProcessInfo.processInfo.environment["OLLAMA_API_KEY"],
+           !env.isEmpty {
+            return env
+        }
+        return KeychainItem.read(service: keychainService, account: keychainAccount)
+    }
+
+    /// Whether a key is available from either source.
+    static var isPresent: Bool { load() != nil }
+
+    /// Stores a key in the keychain, so it survives relaunches. Overwrites any
+    /// existing item under the same service+account.
+    @discardableResult
+    static func store(_ key: String) -> Bool {
+        KeychainItem.store(service: keychainService, account: keychainAccount, value: key)
+    }
+
+    /// Removes the key from the keychain. Called on sign-out, so the next
+    /// fetch finds nothing and the ring goes dark.
+    @discardableResult
+    static func delete() -> Bool {
+        KeychainItem.delete(service: keychainService, account: keychainAccount)
+    }
+}

--- a/Sources/Providers/OllamaProvider.swift
+++ b/Sources/Providers/OllamaProvider.swift
@@ -1,0 +1,77 @@
+import Foundation
+import os
+
+/// Reads Ollama cloud usage from `https://ollama.com/api/usage`, authenticating
+/// with an API key the user provides in Settings or exports as
+/// `OLLAMA_API_KEY`.
+///
+/// The only provider that owns its credential rather than borrowing one: the
+/// key is stored in the login keychain under a service no other app uses, and
+/// sign-out deletes it. Polling and error handling follow the same path every
+/// other provider takes through `UsageStore`.
+actor OllamaProvider: UsageProvider {
+    nonisolated let id = "ollama"
+    nonisolated let displayName = "Ollama"
+    nonisolated let glyph = ProviderGlyph.ollama
+
+    private let endpoint = URL(string: "https://ollama.com/api/usage")!
+    private let session: URLSession
+
+    init(session: URLSession = .shared) {
+        self.session = session
+    }
+
+    nonisolated var signInRoute: SignInRoute {
+        .guidance("Enter an Ollama API key below, or export OLLAMA_API_KEY in your shell.")
+    }
+
+    nonisolated func account() -> ProviderAccount? {
+        guard OllamaCredentials.isPresent else { return nil }
+        return ProviderAccount(
+            label: nil,
+            plan: nil,
+            source: "Ollama",
+            manageURL: URL(string: "https://ollama.com/settings")
+        )
+    }
+
+    func fetchSnapshot() async throws -> ProviderSnapshot {
+        guard let key = OllamaCredentials.load() else { throw UsageProviderError.needsAuth }
+
+        var request = URLRequest(url: endpoint)
+        request.setValue("Bearer \(key)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.timeoutInterval = 15
+
+        let (data, response) = try await session.data(for: request)
+        let status = (response as? HTTPURLResponse)?.statusCode ?? 0
+
+        if status == 401 || status == 403 { throw UsageProviderError.needsAuth }
+        guard (200..<300).contains(status) else {
+            throw UsageProviderError.badResponse(status: status)
+        }
+
+        let body = String(data: data, encoding: .utf8) ?? ""
+        Log.usage.debug("ollama usage -> \(body.prefix(900), privacy: .public)")
+
+        let result = try OllamaUsage.parse(body)
+        return ProviderSnapshot(
+            id: id,
+            displayName: displayName,
+            glyph: glyph,
+            fidelity: .official,
+            status: .ok,
+            windows: result.windows,
+            headlineID: result.headlineID
+        )
+    }
+
+    nonisolated func signOut() async {
+        OllamaCredentials.delete()
+    }
+
+    nonisolated func forgetCachedCredential() {
+        // Nothing is cached in memory — the key is re-read from the keychain or
+        // environment on every fetch.
+    }
+}

--- a/Sources/Providers/OllamaUsage.swift
+++ b/Sources/Providers/OllamaUsage.swift
@@ -1,0 +1,118 @@
+import Foundation
+
+/// Parses Ollama's `GET /api/usage` response.
+///
+/// **Modern plans** (Pro 20/60/100/500) return a single monthly window:
+///
+/// ```json
+/// { "activity": {
+///     "cost": "0.00000",
+///     "period": { "type": "last_4_weeks",
+///                 "starting_at": "2026-08-17T00:00:00Z",
+///                 "ending_at": "2026-09-08T08:28:05Z" } },
+///   "limits": {
+///     "monthly": {
+///       "usage": 0.152,
+///       "models": [ { "name": "glm-5.3", "request_count": 468 }, ... ] } } }
+/// ```
+///
+/// `usage` is a **fraction of the plan's monthly allowance** — 0.152 means
+/// 15.2% — not dollars. The plan tier (20/60/100/500) sets the dollar ceiling,
+/// but the fraction is the same number the ring needs regardless of tier.
+///
+/// **Legacy plans** return `session` and `weekly` windows instead:
+///
+/// ```json
+/// { "limits": {
+///     "session": { "usage": 0.12, "models": [...] },
+///     "weekly":  { "usage": 0.41, "models": [...] } },
+///   "activity": { "cost": "0.10", "period": { "type": "last_4_weeks" } } }
+/// ```
+///
+/// Legacy responses carry no `ending_at`, so their reset date is unknown.
+enum OllamaUsage {
+    /// The parsed result: the windows to show and which one the ring means.
+    struct Result {
+        let windows: [LimitWindow]
+        let headlineID: String?
+    }
+
+    static func parse(_ json: String) throws -> Result {
+        guard let data = json.data(using: .utf8),
+              let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else { throw UsageProviderError.badResponse(status: 0) }
+
+        let limits = root["limits"] as? [String: Any] ?? [:]
+        let activity = root["activity"] as? [String: Any] ?? [:]
+        let period = activity["period"] as? [String: Any] ?? [:]
+        // The API exposes only a rolling 4-week activity window
+        // (`period.starting_at` = 4 weeks ago, `period.ending_at` = now). It does
+        // not expose the billing cycle start or reset date, so the window
+        // carries no `resetsAt` — showing one would be a guess.
+
+        var windows: [LimitWindow] = []
+        var headlineID: String?
+
+        // Modern: a single monthly window with a usage fraction.
+        if let monthly = limits["monthly"] as? [String: Any] {
+            if let usage = monthly["usage"] as? Double, usage > 0 {
+                windows.append(LimitWindow(
+                    id: "monthly", label: "Monthly usage",
+                    usedFraction: usage, resetsAt: nil
+                ))
+                headlineID = "monthly"
+            }
+            windows.append(contentsOf: models(from: monthly, prefix: "monthly"))
+        }
+
+        // Legacy: session and weekly windows, each with its own fraction.
+        if let session = limits["session"] as? [String: Any] {
+            if let usage = session["usage"] as? Double, usage > 0 {
+                windows.append(LimitWindow(
+                    id: "session", label: "Session usage",
+                    usedFraction: usage, resetsAt: nil
+                ))
+                if headlineID == nil { headlineID = "session" }
+            }
+            windows.append(contentsOf: models(from: session, prefix: "session"))
+        }
+
+        if let weekly = limits["weekly"] as? [String: Any] {
+            if let usage = weekly["usage"] as? Double, usage > 0 {
+                windows.append(LimitWindow(
+                    id: "weekly", label: "Weekly usage",
+                    usedFraction: usage, resetsAt: nil
+                ))
+                // Weekly is the better headline than session for legacy plans.
+                headlineID = "weekly"
+            }
+            windows.append(contentsOf: models(from: weekly, prefix: "weekly"))
+        }
+
+        guard !windows.isEmpty else {
+            throw UsageProviderError.nothingMetered(
+                "No Ollama usage recorded yet for this period."
+            )
+        }
+
+        return Result(windows: windows, headlineID: headlineID)
+    }
+
+    /// Per-model request counts as individual windows, so each model gets its
+    /// own row in the tooltip. Returns an empty array when there are no models
+    /// or all have zero requests.
+    private static func models(
+        from limit: [String: Any], prefix: String
+    ) -> [LimitWindow] {
+        guard let models = limit["models"] as? [[String: Any]] else { return [] }
+        return models.compactMap { model in
+            guard let name = model["name"] as? String,
+                  let count = model["request_count"] as? Int, count > 0
+            else { return nil }
+            return LimitWindow(
+                id: "\(prefix).\(name)", label: name,
+                used: count, resetsAt: nil
+            )
+        }
+    }
+}

--- a/Sources/Providers/ProviderGlyph.swift
+++ b/Sources/Providers/ProviderGlyph.swift
@@ -21,6 +21,7 @@ enum ProviderGlyph: String, Codable, Equatable {
     case grok
     case opencode
     case copilot
+    case ollama
 
     /// If an asset with this name is in the bundle it wins over the traced
     /// outline — drop a PDF/SVG export from Figma in and it is picked up.
@@ -48,6 +49,7 @@ enum ProviderGlyph: String, Codable, Equatable {
         case .grok:   return 1.0
         case .opencode: return 0.95
         case .copilot: return 0.96
+        case .ollama: return 0.95
         case .third:  return 1.0
         }
     }
@@ -64,6 +66,7 @@ enum ProviderGlyph: String, Codable, Equatable {
         case .grok:   return GlyphOutline.grok
         case .opencode: return GlyphOutline.opencode
         case .copilot: return GlyphOutline.copilot
+        case .ollama: return GlyphOutline.ollama
         }
     }
 }

--- a/Sources/Settings/SettingsView.swift
+++ b/Sources/Settings/SettingsView.swift
@@ -2,6 +2,23 @@ import AppKit
 import CoreTransferable
 import SwiftUI
 
+/// A Liquid Glass background that falls back to a regular material on macOS
+/// 15, where `glassEffect` does not exist. The visual difference is minor — the
+/// sidebar gets a standard vibrancy material instead of the glass tint — and
+/// the layout and interactions are unchanged.
+extension View {
+    @ViewBuilder
+    func glassBackground(in shape: some Shape) -> some View {
+        if #available(macOS 26.0, *) {
+            background { Color.clear.glassEffect(.regular, in: shape) }
+        } else {
+            background {
+                shape.fill(.regularMaterial)
+            }
+        }
+    }
+}
+
 /// One entry in the sidebar. Grouped by subject rather than by how each
 /// setting is stored — a mute toggle for a provider's threshold alerts lives
 /// on that provider's own row in Accounts, not repeated here, but the
@@ -226,13 +243,10 @@ struct SettingsView: View {
         // sidebar on this OS — not a flat tint over the window's material.
         // The glass is what gives the card an edge and a lift of its own, so
         // there is no border drawn on top of it.
-        .background {
-            Color.clear.glassEffect(
-                .regular,
-                in: RoundedRectangle(cornerRadius: SettingsView.sidebarCornerRadius,
-                                     style: .continuous)
-            )
-        }
+        .glassBackground(
+            in: RoundedRectangle(cornerRadius: SettingsView.sidebarCornerRadius,
+                                 style: .continuous)
+        )
         .padding(SettingsView.sidebarInset)
     }
 
@@ -262,7 +276,7 @@ struct SettingsView: View {
                 .font(.system(size: 15, weight: .regular))
                 .foregroundStyle(.primary)
                 .frame(width: 36, height: 36)
-                .background { Color.clear.glassEffect(.regular, in: Circle()) }
+                .glassBackground(in: Circle())
                 .contentShape(Circle())
         }
         .buttonStyle(.plain)

--- a/Sources/Settings/SettingsView.swift
+++ b/Sources/Settings/SettingsView.swift
@@ -1153,6 +1153,41 @@ private struct AccountRow: View {
                 .help("Fills the ring against a ceiling you choose; Google publishes "
                       + "none for an API key.")
             }
+            // Ollama owns its credential: the user enters an API key here, stored
+            // in the keychain. The env var OLLAMA_API_KEY is checked first, so a
+            // shell that exports one needs no entry here.
+            if provider.id == "ollama" {
+                ollamaKeyEntry
+            }
+        }
+    }
+
+    /// The API key input for Ollama. Stored in the keychain on Save, then a
+    /// refresh is triggered so the ring picks up the new credential without a
+    /// relaunch.
+    @State private var ollamaKey = ""
+    @State private var ollamaKeySaved = false
+
+    private var ollamaKeyEntry: some View {
+        HStack(spacing: 8) {
+            SecureField("Ollama API key", text: $ollamaKey)
+                .textContentType(.password)
+                .textFieldStyle(.roundedBorder)
+                .controlSize(.small)
+            Button("Save") {
+                guard !ollamaKey.isEmpty else { return }
+                OllamaCredentials.store(ollamaKey)
+                ollamaKey = ""
+                ollamaKeySaved = true
+                _ = signIn(provider.id)
+            }
+            .controlSize(.small)
+            .disabled(ollamaKey.isEmpty)
+            if ollamaKeySaved {
+                Text("Saved.")
+                    .foregroundStyle(.green)
+                    .controlSize(.small)
+            }
         }
     }
 

--- a/Tests/OllamaUsageTests.swift
+++ b/Tests/OllamaUsageTests.swift
@@ -1,0 +1,134 @@
+import XCTest
+@testable import Codenotch
+
+/// Parses the response from Ollama's `GET /api/usage` endpoint, covering both
+/// modern (Pro 20/60/100/500) and legacy plan shapes.
+final class OllamaUsageTests: XCTestCase {
+    /// Verbatim from the API spec — a modern Pro plan with three models.
+    private let modernResponse = """
+    {
+      "activity": {
+        "cost": "0.00000",
+        "period": {
+          "type": "last_4_weeks",
+          "starting_at": "2026-08-17T00:00:00Z",
+          "ending_at": "2026-09-08T08:28:05.581584229Z"
+        },
+        "models": []
+      },
+      "limits": {
+        "monthly": {
+          "usage": 0.152,
+          "models": [
+            { "name": "glm-5.3", "request_count": 468 },
+            { "name": "glm-5.3-flash", "request_count": 1176 },
+            { "name": "deepseek-v4-flash:0731", "request_count": 3415 }
+          ]
+        }
+      }
+    }
+    """
+
+    /// Legacy plan shape — session and weekly windows, no monthly, no reset.
+    private let legacyResponse = """
+    {
+      "limits": {
+        "session": { "usage": 0.12, "models": [{ "name": "gpt-oss:120b", "request_count": 7 }] },
+        "weekly":  { "usage": 0.41, "models": [{ "name": "gpt-oss:120b", "request_count": 86 }] }
+      },
+      "activity": { "cost": "0.10", "period": { "type": "last_4_weeks" } }
+    }
+    """
+
+    // MARK: - Modern plans
+
+    func testModernHeadlineIsMonthlyUsageFraction() throws {
+        let result = try OllamaUsage.parse(modernResponse)
+        XCTAssertEqual(result.headlineID, "monthly")
+        let headline = result.windows.first { $0.id == "monthly" }
+        XCTAssertEqual(headline?.usedFraction, 0.152)
+    }
+
+    func testModernPerModelRows() throws {
+        let result = try OllamaUsage.parse(modernResponse)
+        let modelRows = result.windows.filter { $0.id.hasPrefix("monthly.") }
+        XCTAssertEqual(modelRows.count, 3)
+        XCTAssertEqual(modelRows.first?.label, "glm-5.3")
+        XCTAssertEqual(modelRows.first?.used, 468)
+        XCTAssertNil(modelRows.first?.usedFraction)
+    }
+
+    func testModernHasNoResetDateBecauseApiDoesNotExposeBillingCycle() throws {
+        let result = try OllamaUsage.parse(modernResponse)
+        let monthly = result.windows.first { $0.id == "monthly" }
+        // The API exposes only a rolling 4-week activity window, not the billing
+        // cycle reset — so `resetsAt` must be nil rather than a guess.
+        XCTAssertNil(monthly?.resetsAt)
+    }
+
+    // MARK: - Legacy plans
+
+    func testLegacyHasSessionAndWeeklyWindows() throws {
+        let result = try OllamaUsage.parse(legacyResponse)
+        XCTAssertNotNil(result.windows.first { $0.id == "session" })
+        XCTAssertNotNil(result.windows.first { $0.id == "weekly" })
+        XCTAssertNil(result.windows.first { $0.id == "monthly" })
+    }
+
+    func testLegacyHeadlineIsWeekly() throws {
+        let result = try OllamaUsage.parse(legacyResponse)
+        XCTAssertEqual(result.headlineID, "weekly")
+    }
+
+    func testLegacyModelRows() throws {
+        let result = try OllamaUsage.parse(legacyResponse)
+        let sessionModel = result.windows.first { $0.id == "session.gpt-oss:120b" }
+        XCTAssertEqual(sessionModel?.used, 7)
+        let weeklyModel = result.windows.first { $0.id == "weekly.gpt-oss:120b" }
+        XCTAssertEqual(weeklyModel?.used, 86)
+    }
+
+    func testLegacyHasNoResetDate() throws {
+        let result = try OllamaUsage.parse(legacyResponse)
+        let session = result.windows.first { $0.id == "session" }
+        XCTAssertNil(session?.resetsAt)
+    }
+
+    // MARK: - Edge cases
+
+    func testEmptyUsageThrowsNothingMetered() {
+        let empty = """
+        { "activity": { "cost": "0.00", "period": {}, "models": [] },
+          "limits": { "monthly": { "usage": 0, "models": [] } } }
+        """
+        XCTAssertThrowsError(try OllamaUsage.parse(empty)) { error in
+            guard case UsageProviderError.nothingMetered = error else {
+                return XCTFail("expected nothingMetered, got \(error)")
+            }
+        }
+    }
+
+    func testModelsOnlyWithZeroUsage() throws {
+        // No usage fraction, but models have request counts — the model rows
+        // keep the result from being "nothing metered".
+        let noFraction = """
+        { "activity": { "period": { "ending_at": "2026-09-08T08:28:05Z" } },
+          "limits": { "monthly": {
+            "usage": 0,
+            "models": [ { "name": "tiny", "request_count": 3 } ] } } }
+        """
+        let result = try OllamaUsage.parse(noFraction)
+        XCTAssertNil(result.headlineID)
+        XCTAssertEqual(result.windows.count, 1)
+        XCTAssertEqual(result.windows.first?.label, "tiny")
+        XCTAssertEqual(result.windows.first?.used, 3)
+    }
+
+    func testGarbageThrowsBadResponse() {
+        XCTAssertThrowsError(try OllamaUsage.parse("not json")) { error in
+            guard case UsageProviderError.badResponse = error else {
+                return XCTFail("expected badResponse, got \(error)")
+            }
+        }
+    }
+}

--- a/project.yml
+++ b/project.yml
@@ -2,7 +2,7 @@ name: Codenotch
 options:
   bundleIdPrefix: com.vinz
   deploymentTarget:
-    macOS: "26.0"
+    macOS: "15.0"
   createIntermediateGroups: true
 
 settings:
@@ -56,7 +56,7 @@ targets:
         # and no obvious way to reach settings or quit.
         CFBundleName: Codenotch
         CFBundleDisplayName: Codenotch
-        LSMinimumSystemVersion: "26.0"
+        LSMinimumSystemVersion: "15.0"
         # Sources/Info.plist is *generated* from this block, so editing that
         # file directly is undone by the next `make gen`. Pointing both at the
         # build settings keeps one place to bump.


### PR DESCRIPTION
Adds Ollama as a new usage provider, reading `https://ollama.com/api/usage` with a Bearer API key.

## Auth

The API key is read from the `OLLAMA_API_KEY` environment variable first, then from the login keychain (service `ollama-api-key`). A `SecureField` in Settings lets the user enter and save the key without a shell export — following the same pattern as the existing `gemini-api` budget field. Sign-out deletes the key from the keychain.

This is the first provider that owns its credential rather than borrowing one from another app. `KeychainItem` gains `store`/`read`/`delete` methods for this.

## Parsing

The parser handles both plan shapes:

- **Modern** (Pro 20/60/100/500): a single `monthly` window with a usage fraction (0.152 = 15.2% of the plan allowance). Per-model request counts are listed below as compact rows.
- **Legacy**: `session` and `weekly` windows, each with their own fraction and model list. No reset date (the API doesn't expose the billing cycle end).

The `usage` field is a fraction of the plan's monthly allowance, not dollars — it goes straight into the ring as a percentage.

## Compact rows

Per-model request counts render as single-line `SplitRow`s (model name left, count right) rather than full bar rows. `LimitWindowRow` gains an `isCountRow` branch, `NotchLayout.cardHeight` takes a `compactRowCount` parameter so count-only rows reserve one line height instead of three, and `ProviderSnapshot` gains a `compactRowCount` computed property to feed it.

## Tests

10 new tests covering both plan shapes, empty responses, and garbage input.