### PR TITLE
Detect Claude Desktop sessions, and auto-renew the OAuth token via the standalone CLI

### DIFF
--- a/Sources/App/AppDelegate.swift
+++ b/Sources/App/AppDelegate.swift
@@ -12,6 +12,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// Held for the life of the app: releasing it stops the scheduled checks.
     private var updater: Updater?
     private var statusItem: StatusItemController?
+    /// Keeps the Claude keychain token from ageing out on a Mac where the CLI
+    /// is never run by hand. See `ClaudeTokenRefresher`.
+    private var tokenRefresher: ClaudeTokenRefresher?
     private var cancellables = Set<AnyCancellable>()
 
     /// The unit bundle is hosted by this app, so `xcodebuild test` launches it
@@ -28,6 +31,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// provider and a session monitor of its own, keyed by the same id, so a
     /// work login's sessions spin the work ring and nobody else's.
     private let claudeProfiles = ClaudeProfile.discover()
+    private var claudeProviders: [ClaudeOAuthProvider] = []
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         // Set here, not in the Info.plist: this call is applied at launch and
@@ -67,8 +71,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             // it drew every provider from the archive and only dropped the
             // switched-off ones once the binding below delivered.
             Log.usage.info("claude profiles: \(self.claudeProfiles.map(\.displayPath).joined(separator: ", "), privacy: .public)")
+            // Held as concrete providers, not just handed to the store: the
+            // token refresher needs to ask one of them how long its token has
+            // left, and the protocol has no business carrying that.
+            let claudeProviders = claudeProfiles.map { ClaudeOAuthProvider(profile: $0) }
+            self.claudeProviders = claudeProviders
             let store = UsageStore(
-                providers: claudeProfiles.map { ClaudeOAuthProvider(profile: $0) }
+                providers: claudeProviders
                     + [CursorLocalProvider(), CodexLocalProvider(), AntigravityProvider(),
                        GLMProvider()]
                     + webProviders,
@@ -190,8 +199,50 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             "codex": CodexActivityMonitor(),
             "gemini": AntigravityActivityMonitor()
         ]
+        var claudeMonitors: [ClaudeSessionMonitor] = []
         for profile in claudeProfiles {
-            monitors[profile.id] = ClaudeSessionMonitor(directory: profile.sessionsDirectory)
+            let monitor = ClaudeSessionMonitor(
+                directory: profile.sessionsDirectory,
+                projects: profile.projectsDirectory
+            )
+            claudeMonitors.append(monitor)
+            monitors[profile.id] = monitor
+        }
+
+        // Renewing the token runs the Claude command, which registers a session
+        // of its own for the second it lives. Every Claude monitor is told to
+        // step over that pid, so it never reaches the notch and never counts as
+        // work in progress.
+        //
+        // Only the default profile is renewed. The command writes whichever
+        // directory `CLAUDE_CONFIG_DIR` names, so a second profile would need
+        // that passed through — behaviour nobody has been able to try on a Mac
+        // with two of them, and an unverified guess is worse here than a ring
+        // that ages the way it already does.
+        if let defaultProvider = claudeProviders.first(where: { $0.profile.slug == nil }) {
+            let refresher = ClaudeTokenRefresher(
+                expiry: { await defaultProvider.tokenExpiry },
+                reload: { await defaultProvider.reloadTokenExpiry() }
+            )
+            for monitor in claudeMonitors {
+                monitor.ignoredPIDs = { [weak refresher] in
+                    guard let pid = refresher?.launchedPID else { return [] }
+                    return [pid]
+                }
+            }
+            // The one place the failure becomes visible. The store carries the
+            // fact; nothing here retries, and the warning clears itself the
+            // moment a reading comes back.
+            refresher.$outcome
+                .receive(on: RunLoop.main)
+                .sink { [weak self] outcome in
+                    guard case .failed = outcome else { return }
+                    self?.store?.reportRenewalFailed(providerID: defaultProvider.id)
+                }
+                .store(in: &cancellables)
+
+            refresher.start()
+            tokenRefresher = refresher
         }
         for (id, monitor) in monitors {
             monitor.sessionsPublisher
@@ -235,6 +286,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     func applicationWillTerminate(_ notification: Notification) {
+        tokenRefresher?.stop()
         store?.stop()
         monitors.values.forEach { $0.stop() }
         notchController?.stop()

--- a/Sources/Model/UsageStore.swift
+++ b/Sources/Model/UsageStore.swift
@@ -61,11 +61,47 @@ final class UsageStore: ObservableObject {
     private var isRefreshing = false
     private var wakeObserver: NSObjectProtocol?
 
+    /// How long one pass gets before the store stops waiting for it.
+    ///
+    /// **Not a cancellation, and it cannot be one.** At the bottom of a Claude
+    /// fetch is `SecItemCopyMatching`, which is synchronous and blocks its
+    /// thread until macOS resolves the authorization prompt sitting in front of
+    /// it. `Task.cancel()` sets a flag; it does not reach into a blocked C
+    /// call. What the deadline buys is that *the store* stops waiting — which
+    /// is the part that was broken.
+    ///
+    /// It happened for real: a keychain prompt went unanswered, the pass never
+    /// returned, `isRefreshing` stayed true, and every tick after it logged
+    /// "refresh skipped: one already in flight" for eighty minutes. The app
+    /// looked alive and had silently stopped reading anything.
+    ///
+    /// The blocked read is not on the main actor — providers are actors, so it
+    /// blocks one cooperative thread and the UI keeps running. Left to finish
+    /// whenever it finishes; `generation` stops its late answer overwriting a
+    /// newer one.
+    private let refreshDeadline: TimeInterval
+    private var deadlineTask: Task<Void, Never>?
+    /// Bumped for every pass. A pass that outlived its deadline finds its
+    /// number stale and writes nothing.
+    private var generation = 0
+    /// Providers whose fetch has not come back yet.
+    ///
+    /// An abandoned pass leaves one here and the next pass skips it, rather
+    /// than queueing a second call behind the first: a provider is an actor, so
+    /// the second call would simply wait on the blocked one and take the new
+    /// pass down with it. That is how one stuck provider used to stop all of
+    /// them.
+    private var inFlight: Set<String> = []
+
     init(
         providers: [UsageProvider],
         refreshInterval: TimeInterval = 60,
         idleRefreshInterval: TimeInterval = 5 * 60,
         staleAfter: TimeInterval = 15 * 60,
+        // Thirty times a normal pass, which is a second or two. High enough
+        // never to fire on a slow network, low enough that a wedged read costs
+        // one tick rather than the rest of the day.
+        refreshDeadline: TimeInterval = 60,
         archive: UsageArchive = UsageArchive(),
         disconnected: Set<String> = []
     ) {
@@ -73,6 +109,7 @@ final class UsageStore: ObservableObject {
         self.refreshInterval = refreshInterval
         self.idleRefreshInterval = idleRefreshInterval
         self.staleAfter = staleAfter
+        self.refreshDeadline = refreshDeadline
         self.archive = archive
 
         // Open on what we knew last time rather than on an empty ring; the
@@ -135,7 +172,10 @@ final class UsageStore: ObservableObject {
         timer?.invalidate()
         timer = nil
         refreshTask?.cancel()
+        deadlineTask?.cancel()
+        deadlineTask = nil
         isRefreshing = false
+        inFlight = []
         // Block-based observers are not removed by `removeObserver(self)`.
         if let wakeObserver {
             NSWorkspace.shared.notificationCenter.removeObserver(wakeObserver)
@@ -171,21 +211,90 @@ final class UsageStore: ObservableObject {
         }
         isRefreshing = true
         lastAttempt = Date()
+        generation &+= 1
+        let mine = generation
+
         refreshTask = Task { [weak self] in
             await self?.refresh()
-            self?.isRefreshing = false
+            self?.finish(pass: mine)
+        }
+        armDeadline(for: mine)
+    }
+
+    /// Stops waiting for a pass that has not come back, so the next tick can
+    /// run. Deliberately does not touch the pass itself — there is nothing here
+    /// that could stop it.
+    private func armDeadline(for pass: Int) {
+        let deadline = refreshDeadline
+        deadlineTask?.cancel()
+        deadlineTask = Task { [weak self] in
+            try? await Task.sleep(nanoseconds: UInt64(deadline * 1_000_000_000))
+            guard !Task.isCancelled else { return }
+            self?.abandon(pass: pass)
         }
     }
 
+    /// A pass came back. Clears the flag whatever the outcome — success, thrown
+    /// error, or cancellation — because the one thing that must never happen is
+    /// the flag outliving the work.
+    ///
+    /// `refreshing` is not this function's to clear: `refresh()` already does,
+    /// under the same `pass == generation` guard this one uses, so a second
+    /// write here would only ever repeat what that one just did or be skipped
+    /// alongside it — never disagree with it.
+    private func finish(pass: Int) {
+        guard pass == generation else { return }   // already given up on; a newer pass owns the flag
+        deadlineTask?.cancel()
+        deadlineTask = nil
+        isRefreshing = false
+    }
+
+    /// A pass outlived its deadline.
+    ///
+    /// Says so on the providers that never answered, using the same degrading
+    /// path as any other failure: a remembered reading is re-shown and ages,
+    /// and a provider with nothing to show says it got no response. Then frees
+    /// the flag so the schedule resumes.
+    private func abandon(pass: Int) {
+        guard pass == generation, isRefreshing else { return }
+        let stuck = inFlight.sorted()
+        Log.usage.error("refresh abandoned after \(self.refreshDeadline, format: .fixed(precision: 0))s; no answer from: \(stuck.joined(separator: ", "), privacy: .public)")
+        for id in stuck {
+            guard let provider = providers.first(where: { $0.id == id }),
+                  let index = snapshots.firstIndex(where: { $0.id == id })
+            else { continue }
+            snapshots[index] = degraded(provider: provider, error: UsageProviderError.timedOut)
+        }
+        isRefreshing = false
+        refreshing = []
+    }
+
     func refresh() async {
+        let mine = generation
         let live = providers.filter { !disconnected.contains($0.id) }
         refreshing = Set(live.map(\.id))
-        defer { refreshing = [] }
         var next: [ProviderSnapshot] = []
         for provider in live {
-            next.append(await snapshot(from: provider))
+            // Still stuck from an earlier pass: leave it exactly as it is
+            // rather than queueing behind it.
+            guard !inFlight.contains(provider.id) else {
+                next.append(snapshots.first { $0.id == provider.id } ?? Self.placeholder(provider))
+                continue
+            }
+            inFlight.insert(provider.id)
+            let fresh = await snapshot(from: provider)
+            inFlight.remove(provider.id)
+            next.append(fresh)
         }
+        // A pass that was abandoned mid-flight must not touch state a newer
+        // pass owns — not the snapshots it drew, and not "still refreshing"
+        // either. That second part is not optional: this used to be a `defer`,
+        // which runs on every return regardless of this guard, so an abandoned
+        // pass that finally resolved could clear the spinner out from under a
+        // newer pass that was still genuinely fetching something else.
+        guard mine == generation else { return }
         snapshots = next
+        refreshing = []
     }
 
     /// Refetch one provider, leaving the others alone.
@@ -375,6 +484,10 @@ final class UsageStore: ObservableObject {
     /// Exposed so a test can hold the shipped defaults to the margin they are
     /// supposed to keep, without re-typing the numbers on both sides.
     var staleAfterForTesting: TimeInterval { staleAfter }
+    /// Exposed so a test can prove the flag was released rather than infer it
+    /// from a second refresh happening to work.
+    var isRefreshingForTesting: Bool { isRefreshing }
+    var inFlightForTesting: Set<String> { inFlight }
     var idleRefreshIntervalForTesting: TimeInterval { idleRefreshInterval }
 
     private static func status(for error: Error) -> ProviderStatus {
@@ -392,6 +505,11 @@ final class UsageStore: ObservableObject {
             return .stale(since: Date())
         case UsageProviderError.accessDenied:
             return .accessDenied
+        case UsageProviderError.timedOut:
+            // Nothing is known about the account, so a remembered reading stays
+            // and simply ages. `degraded` handles that; this is only what a
+            // provider with nothing to show says.
+            return .error("no response")
         case UsageProviderError.nothingMetered(let why):
             return .unsupported(why)
         case UsageProviderError.badResponse(let code):

--- a/Sources/Model/UsageStore.swift
+++ b/Sources/Model/UsageStore.swift
@@ -12,6 +12,15 @@ final class UsageStore: ObservableObject {
     /// Providers whose last fetch was refused by macOS, cleared as soon as one
     /// succeeds. The settings row's only honest basis for offering to ask again.
     @Published private(set) var refusedAccess: Set<String> = []
+    /// Providers whose saved login has aged out and could not be renewed.
+    ///
+    /// Kept beside `refusedAccess`, and for the same reason: it is a fact about
+    /// the *credential*, not about the numbers on screen. An expired token
+    /// leaves the last reading standing and still roughly true, so nothing in
+    /// any snapshot says anything is wrong — which is exactly how a frozen
+    /// reading went unnoticed for twelve hours. Reading it off the snapshot
+    /// would reproduce the bug.
+    @Published private(set) var needsRenewal: Set<String> = []
 
     private let providers: [UsageProvider]
     /// Providers the user has switched off. They are not fetched at all — their
@@ -147,7 +156,8 @@ final class UsageStore: ObservableObject {
             ProviderSummary(id: provider.id, name: provider.displayName,
                             glyph: provider.glyph, account: provider.account(),
                             signIn: provider.signInRoute,
-                            wasRefusedAccess: refusedAccess.contains(provider.id))
+                            wasRefusedAccess: refusedAccess.contains(provider.id),
+                            needsSignInRenewal: needsRenewal.contains(provider.id))
         }
     }
 
@@ -366,6 +376,17 @@ final class UsageStore: ObservableObject {
         return openAccountSource(providerID: providerID)
     }
 
+    /// Say that a provider's saved login needs renewing by hand.
+    ///
+    /// Called by `ClaudeTokenRefresher` when it tried and the expiry did not
+    /// move. The store only carries the fact so Settings can show it; it starts
+    /// nothing and retries nothing.
+    func reportRenewalFailed(providerID: String) {
+        guard !needsRenewal.contains(providerID) else { return }
+        needsRenewal.insert(providerID)
+        Log.usage.notice("\(providerID, privacy: .public): saved login needs renewing by hand")
+    }
+
     /// Ask macOS for this provider's credential again.
     ///
     /// The remedy for a declined keychain prompt. Dropping the in-memory copy
@@ -412,6 +433,10 @@ final class UsageStore: ObservableObject {
             lastGood[provider.id] = (fresh, Date())
             archive.save(lastGood)
             refusedAccess.remove(provider.id)
+            // A reading that actually came back is proof the credential works,
+            // whatever was thought a moment ago. The only way this clears —
+            // there is no timer and nothing retries.
+            needsRenewal.remove(provider.id)
             Log.usage.debug("\(provider.id, privacy: .public): \(fresh.windows.count) window(s)")
             return fresh
         } catch {

--- a/Sources/Providers/ClaudeCLI.swift
+++ b/Sources/Providers/ClaudeCLI.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+/// Where the standalone Claude Code command lives, if it is installed.
+///
+/// Deliberately *not* the copy inside the Claude desktop app, under
+/// `~/Library/Application Support/Claude/claude-code/<version>/`. Checked on a
+/// real machine: that copy keeps its OAuth token in the desktop app's own
+/// store (`config.json`, `oauth:tokenCacheV2`) and never writes the login
+/// keychain — which is the item Codenotch reads. Renewing with it would look
+/// like it worked and change nothing here, so the search refuses to return it.
+enum ClaudeCLI {
+    /// The usual install locations, in the order a shell would find them.
+    static let candidates = [
+        "/opt/homebrew/bin/claude",      // Homebrew on Apple silicon
+        "/usr/local/bin/claude",         // Homebrew on Intel, and the installer
+        "~/.local/bin/claude",           // the standalone installer's default
+        "/usr/bin/claude"
+    ]
+
+    /// Anything under here belongs to the desktop app and is not usable for
+    /// this. Matched on the resolved path, so a symlink into it is caught too.
+    static let desktopOwned = "/Library/Application Support/Claude/"
+
+    static func standalone(candidates: [String] = candidates,
+                           fileManager: FileManager = .default) -> URL? {
+        for path in candidates {
+            let expanded = (path as NSString).expandingTildeInPath
+            guard fileManager.isExecutableFile(atPath: expanded) else { continue }
+            // `resolvingSymlinksInPath` because the Homebrew entry is a symlink
+            // into the Caskroom, and the desktop app's copy could equally be
+            // linked somewhere on PATH.
+            let resolved = URL(fileURLWithPath: expanded).resolvingSymlinksInPath()
+            guard !isDesktopOwned(resolved) else { continue }
+            return resolved
+        }
+        return nil
+    }
+
+    static func isDesktopOwned(_ url: URL) -> Bool {
+        url.path.contains(desktopOwned)
+    }
+}

--- a/Sources/Providers/ClaudeCredentials.swift
+++ b/Sources/Providers/ClaudeCredentials.swift
@@ -128,7 +128,19 @@ final class ClaudeKeychain: @unchecked Sendable {
     /// Read once, then held until the token expires — see `CredentialCache`.
     /// Claude Code rotates this roughly hourly, so this is about one keychain
     /// read an hour instead of two a minute.
-    private let cache = CredentialCache<ClaudeCredentials> { $0.isExpired }
+    ///
+    /// Only `.accessDenied` is permanent — a real "Deny" on the ACL prompt.
+    /// Everything else `ClaudeCredentials.read` can throw, `needsAuth`
+    /// included, gets retried after the cache's own backoff even while the
+    /// item's `mdat` has not moved: found on a real machine, a single keychain
+    /// read landing during `errSecInDarkWake` — the Mac in a brief low-power
+    /// wake with no UI possible, nothing to do with the credential at all —
+    /// was cached as `needsAuth` and replayed for the next three hours, since
+    /// nothing else ever touched the item again once it held a valid token.
+    private let cache = CredentialCache<ClaudeCredentials>(
+        isPermanentFailure: { if case UsageProviderError.accessDenied = $0 { return true }; return false },
+        isExpired: { $0.isExpired }
+    )
 
     init(service: String) {
         self.service = service

--- a/Sources/Providers/ClaudeOAuthProvider.swift
+++ b/Sources/Providers/ClaudeOAuthProvider.swift
@@ -206,7 +206,14 @@ actor ClaudeOAuthProvider: UsageProvider {
     nonisolated func forgetCachedCredential() { keychain.forgetCached() }
 
     nonisolated func account() -> ProviderAccount? {
-        guard let credentials = try? keychain.load() else { return nil }
+        // Through the injected source, not `keychain` directly. In production
+        // the source *is* `keychain.load()` — the default set in `init` — so
+        // nothing about how this reads, caches or prompts changes. What it buys
+        // is that a test can build a real provider without the call reaching
+        // the login keychain: it used to, and a test host rebuilt with a fresh
+        // ad-hoc signature would sit behind an authorization prompt nobody was
+        // there to answer, hanging the whole suite on `providerSummaries`.
+        guard let credentials = try? loadCredentials() else { return nil }
         return ProviderAccount(
             label: nil,   // the credential carries no address
             plan: credentials.subscriptionType,

--- a/Sources/Providers/ClaudeOAuthProvider.swift
+++ b/Sources/Providers/ClaudeOAuthProvider.swift
@@ -24,6 +24,13 @@ actor ClaudeOAuthProvider: UsageProvider {
     /// Held between refreshes so the keychain is read once per token, not once
     /// per minute — a keychain read can put a prompt in front of the user.
     private var credentials: ClaudeCredentials?
+    /// When the token runs out, as of the last keychain read — expired or not.
+    ///
+    /// Read-only bookkeeping for `ClaudeTokenRefresher`, which has to know how
+    /// long is left *before* deciding to do anything. Kept here because this is
+    /// already the one place that reads the item, so exposing it costs no extra
+    /// keychain traffic and no extra prompt.
+    private(set) var tokenExpiry: Date?
     /// Set when the endpoint returns 429. Until it passes, refreshes are
     /// skipped without touching the network — a poll that keeps firing into a
     /// rate limit is how you stay rate limited.
@@ -153,6 +160,7 @@ actor ClaudeOAuthProvider: UsageProvider {
         // own window never expired and the keychain was never read again.
         let fresh = try loadCredentials()
         Log.usage.debug("\(self.id, privacy: .public): read keychain token, expires \(fresh.expiresAt, privacy: .public)")
+        tokenExpiry = fresh.expiresAt
         // Expired is not signed out. Claude Code rotates this token whenever it
         // runs, and this app deliberately does not — minting one would mean
         // writing a credential it does not own, and racing the owner for it. So
@@ -204,6 +212,19 @@ actor ClaudeOAuthProvider: UsageProvider {
     }
 
     nonisolated func forgetCachedCredential() { keychain.forgetCached() }
+
+    /// Read the keychain again, ignoring anything held, and report the expiry.
+    ///
+    /// The after-check for `ClaudeTokenRefresher`, and the only caller that
+    /// should want it: everything else is served from the cache precisely so
+    /// that the keychain — and its prompt — is touched as rarely as possible.
+    func reloadTokenExpiry() -> Date? {
+        keychain.forgetCached()
+        credentials = nil
+        guard let fresh = try? loadCredentials() else { return nil }
+        tokenExpiry = fresh.expiresAt
+        return fresh.expiresAt
+    }
 
     nonisolated func account() -> ProviderAccount? {
         // Through the injected source, not `keychain` directly. In production

--- a/Sources/Providers/ClaudeProfile.swift
+++ b/Sources/Providers/ClaudeProfile.swift
@@ -117,6 +117,11 @@ struct ClaudeProfile: Equatable, Hashable {
     /// Where Claude Code writes one file per running process.
     var sessionsDirectory: URL { configDirectory.appendingPathComponent("sessions") }
 
+    /// Where it writes each session's transcript, one directory per working
+    /// directory. The registry says which sessions exist; this says what they
+    /// are doing — see `ClaudeTranscript`.
+    var projectsDirectory: URL { configDirectory.appendingPathComponent("projects") }
+
     /// The keychain service the OAuth token is filed under.
     ///
     /// The default directory uses the bare name. Any other `CLAUDE_CONFIG_DIR`

--- a/Sources/Providers/ClaudeTokenRefresher.swift
+++ b/Sources/Providers/ClaudeTokenRefresher.swift
@@ -1,0 +1,251 @@
+import Foundation
+
+/// Keeps the Claude OAuth token in the login keychain from ageing out.
+///
+/// Codenotch reads that item; only the standalone Claude Code command ever
+/// writes it. On a Mac where Claude Code is used through the desktop app the
+/// item is therefore written once and then rots — the desktop app renews its
+/// own copy elsewhere — and eight hours later every usage reading stops, with
+/// nothing the user can do from inside Codenotch. That is the hole this fills.
+///
+/// **How it renews, and why that is a compatibility mechanism rather than an
+/// interface.** Running `claude -p` with an empty stdin makes the command go
+/// through its whole start-up — which is where it checks the token's age and
+/// renews it — and then exit non-zero with "Input must be provided…", because
+/// no prompt ever arrives. Verified on a real machine: the keychain item's
+/// modification date moves, the expiry advances by eight hours, no transcript
+/// is written, no conversation is created, and the debug log shows no call to
+/// the messages endpoint.
+///
+/// None of that is promised by anyone. A future release could stop renewing at
+/// start-up, or stop rejecting an empty prompt. Both are handled by judging the
+/// *outcome* instead of trusting the command: unless the expiry actually moved,
+/// this reports failure and stops trying. And because it never supplies a
+/// prompt, a version that started accepting empty input could not be talked
+/// into answering one by accident — the failure mode is a wasted launch, never
+/// an invented conversation.
+@MainActor
+final class ClaudeTokenRefresher: ObservableObject {
+    enum Outcome: Equatable {
+        case idle
+        case refreshed(until: Date)
+        /// Ran, or could not be run, and the token is still going to expire.
+        /// The string is what the user should be told.
+        case failed(String)
+    }
+
+    /// A started command: its pid, known synchronously so the session monitor
+    /// can be told to ignore it before it can ever be scanned, and a way to
+    /// wait for it.
+    typealias Launcher = @MainActor (URL, TimeInterval) throws
+        -> (pid: Int32, exit: () async -> Int32?)
+
+    @Published private(set) var outcome: Outcome = .idle
+    /// Set while the command runs. `ClaudeSessionMonitor.ignoredPIDs` reads
+    /// this: the CLI registers a session file of its own for the second it
+    /// lives, and it must never show up in the notch as work.
+    private(set) var launchedPID: Int32?
+
+    /// How close to expiry is close enough.
+    ///
+    /// **Must stay under Claude Code's own five minutes.** Its start-up renews
+    /// the token only when `Date.now() + 300s >= expiresAt`; launching it any
+    /// earlier than that is a no-op, which this would then correctly report as
+    /// a failure and stop retrying. Four minutes leaves room for a slow start
+    /// without crossing that line.
+    private let margin: TimeInterval
+    private let cooldown: TimeInterval
+    private let timeout: TimeInterval
+    private let interval: TimeInterval
+
+    private let cli: URL?
+    private let launcher: Launcher
+    /// The token's expiry as the usage provider last read it. Cheap: it is the
+    /// value already in hand, so asking costs no keychain traffic and no prompt.
+    private let expiry: @MainActor () async -> Date?
+    /// Drop the held copy and read the keychain again — the after-check.
+    private let reload: @MainActor () async -> Date?
+
+    private var timer: Timer?
+    private var isRunning = false
+    /// Exposed for the test that proves `isRunning` is claimed *before* the
+    /// first `await` — not after, which is what would leave a window for two
+    /// overlapping calls to both pass the guard.
+    var isRunningForTesting: Bool { isRunning }
+    private var lastAttempt: Date?
+    /// The expiry a launch was already spent on. One attempt per token, which
+    /// is what makes a failure stop instead of looping: a token that did not
+    /// renew has the same expiry next tick, and is refused.
+    private var attemptedFor: Date?
+
+    init(
+        expiry: @escaping @MainActor () async -> Date?,
+        reload: @escaping @MainActor () async -> Date?,
+        cli: URL? = ClaudeCLI.standalone(),
+        margin: TimeInterval = 4 * 60,
+        cooldown: TimeInterval = 10 * 60,
+        timeout: TimeInterval = 30,
+        interval: TimeInterval = 60,
+        launcher: @escaping Launcher = ClaudeTokenRefresher.run
+    ) {
+        self.expiry = expiry
+        self.reload = reload
+        self.cli = cli
+        self.margin = margin
+        self.cooldown = cooldown
+        self.timeout = timeout
+        self.interval = interval
+        self.launcher = launcher
+    }
+
+    func start() {
+        let timer = Timer(timeInterval: interval, repeats: true) { [weak self] _ in
+            MainActor.assumeIsolated { self?.tick() }
+        }
+        RunLoop.main.add(timer, forMode: .common)
+        self.timer = timer
+    }
+
+    func stop() {
+        timer?.invalidate()
+        timer = nil
+    }
+
+    private func tick() {
+        Task { await considerRenewing() }
+    }
+
+    // MARK: - The gate
+
+    /// Whether a launch is worth making. Pure, so every branch is testable
+    /// without a clock, a keychain or a subprocess.
+    static func shouldRenew(
+        expiry: Date?,
+        now: Date,
+        margin: TimeInterval,
+        attemptedFor: Date?,
+        lastAttempt: Date?,
+        cooldown: TimeInterval
+    ) -> Bool {
+        // Nothing read yet: never launch on a guess.
+        guard let expiry else { return false }
+        // Plenty of time left. Also the case where launching would do nothing,
+        // because the command's own gate has not opened either.
+        guard expiry.timeIntervalSince(now) < margin else { return false }
+        // Already spent an attempt on this exact token. This is the whole
+        // no-retry-loop guarantee: a launch that failed to move the expiry
+        // leaves the same value here next tick, and never runs again.
+        guard expiry != attemptedFor else { return false }
+        if let lastAttempt, now.timeIntervalSince(lastAttempt) < cooldown { return false }
+        return true
+    }
+
+    func considerRenewing(now: Date = Date()) async {
+        // Claimed here, synchronously, before anything is awaited — not after
+        // deciding there is something to do. `shouldRenew` also happens to
+        // block a second overlapping call in the common case (it shares
+        // `attemptedFor` and the cooldown, both written moments from now), but
+        // both of those depend on the two calls agreeing on roughly the same
+        // token and the same `now`. `isRunning` does not: it is what makes "at
+        // most one launch" true unconditionally, and it can only do that by
+        // being set before the first `await` — set any later and a second
+        // overlapping call reaches this same guard while `isRunning` is still
+        // false, exactly as `expiry()` below is what it would be waiting on.
+        guard !isRunning else { return }
+        isRunning = true
+        defer { isRunning = false; launchedPID = nil }
+
+        let current = await expiry()
+        guard Self.shouldRenew(expiry: current, now: now, margin: margin,
+                               attemptedFor: attemptedFor, lastAttempt: lastAttempt,
+                               cooldown: cooldown),
+              let current
+        else { return }
+
+        lastAttempt = now
+        attemptedFor = current
+
+        let remaining = current.timeIntervalSince(now)
+        guard let cli else {
+            fail("Claude's saved login is about to expire and the `claude` command "
+               + "isn't installed to renew it. Run Claude Code once to sign in again.")
+            return
+        }
+        Log.usage.notice("claude token expires in \(remaining, format: .fixed(precision: 0))s; renewing via \(cli.path, privacy: .public)")
+
+        let status: Int32?
+        do {
+            let (pid, exit) = try launcher(cli, timeout)
+            launchedPID = pid          // synchronously, before it can be scanned
+            status = await exit()
+        } catch {
+            fail("Couldn't run `claude` to renew Claude's saved login.")
+            Log.usage.error("token renewal could not start: \(String(describing: error), privacy: .public)")
+            return
+        }
+
+        // Judged on the outcome, never on the exit status: refusing an empty
+        // prompt is a *non-zero* exit and a successful renewal at the same time.
+        let after = await reload()
+        guard let after, after > current else {
+            fail("Claude usage needs its sign-in renewed — run `claude` once in a terminal.")
+            Log.usage.error("token renewal ran (exit \(status ?? -1)) but the expiry did not move; still \(String(describing: after), privacy: .public)")
+            return
+        }
+        outcome = .refreshed(until: after)
+        Log.usage.notice("claude token renewed, now expires \(after, privacy: .public)")
+    }
+
+    private func fail(_ message: String) {
+        outcome = .failed(message)
+    }
+
+    // MARK: - Running it
+
+    /// Starts the command and hands back its pid plus a way to wait for it.
+    ///
+    /// `nullDevice` on stdin is the whole trick: the command gets an immediate
+    /// end-of-input, so it starts up, renews, and refuses for want of a prompt.
+    /// Output goes nowhere — there is nothing in it worth keeping, and a token
+    /// could in principle be echoed into it.
+    static func run(_ cli: URL, timeout: TimeInterval) throws
+        -> (pid: Int32, exit: () async -> Int32?) {
+        let process = Process()
+        process.executableURL = cli
+        process.arguments = ["-p"]
+        process.standardInput = FileHandle.nullDevice
+        process.standardOutput = FileHandle.nullDevice
+        process.standardError = FileHandle.nullDevice
+        try process.run()
+
+        let wait: () async -> Int32? = {
+            let deadline = Date().addingTimeInterval(timeout)
+            while process.isRunning, Date() < deadline {
+                try? await Task.sleep(nanoseconds: 100_000_000)
+            }
+            guard !process.isRunning else {
+                // Never left to linger: a renewal that hangs is exactly the
+                // shape of the bug this app just had to fix elsewhere.
+                process.terminate()
+                try? await Task.sleep(nanoseconds: 500_000_000)
+                if process.isRunning {
+                    kill(process.processIdentifier, SIGKILL)
+                    // Confirmed rather than assumed: every other process this
+                    // app spawns is waited on after asking it to stop
+                    // (`CodexBridge`, `AntigravityBridge`, both via the
+                    // synchronous `waitUntilExit()`). That call would block
+                    // this function's caller — MainActor, since `run` is
+                    // isolated to it — so the same guarantee is reached by
+                    // polling instead, at the cost of a few more lines for the
+                    // one path that needs it.
+                    while process.isRunning {
+                        try? await Task.sleep(nanoseconds: 50_000_000)
+                    }
+                }
+                return nil
+            }
+            return process.terminationStatus
+        }
+        return (process.processIdentifier, wait)
+    }
+}

--- a/Sources/Providers/CredentialCache.swift
+++ b/Sources/Providers/CredentialCache.swift
@@ -37,17 +37,37 @@ final class CredentialCache<Credential>: @unchecked Sendable {
     /// picked up while you are still looking at the notch.
     private let recheckAfter: TimeInterval
     /// How long to leave macOS alone after it has said no, where there is no
-    /// probe to be more precise with.
+    /// probe to be more precise with — and, since the fix below, the same
+    /// wait a *transient* failure gets even when the probe says nothing moved.
     private let retryAfterFailure: TimeInterval
     private let now: () -> Date
+    /// Whether a failure is a verdict about the credential itself, rather than
+    /// about the moment it happened to be asked for.
+    ///
+    /// The distinction this app actually has is real refusal vs. everything
+    /// else: `errSecAuthFailed`/`errSecUserCanceled`/`errSecInteractionNotAllowed`
+    /// mean someone was asked and said no, and asking again on a timer would
+    /// mean putting the same dialogue back in front of them unprompted. Every
+    /// other failure — `errSecInDarkWake` chief among them, from a real
+    /// incident: one read landed during it, and every read for the next three
+    /// hours replayed that single failure because the item's `mdat` never
+    /// moved in between — has nothing to say about the credential at all, and
+    /// defaults to being retried after `retryAfterFailure` precisely because
+    /// nothing here can prove it wasn't transient.
+    private let isPermanentFailure: (Error) -> Bool
 
+    // `isExpired` stays the last parameter, defaultless, so every existing
+    // call site's trailing closure — `CredentialCache<Token> { $0.expired }`
+    // — keeps binding to it rather than to the new, defaulted parameter.
     init(recheckAfter: TimeInterval = 5 * 60,
          retryAfterFailure: TimeInterval = 5 * 60,
          now: @escaping () -> Date = Date.init,
+         isPermanentFailure: @escaping (Error) -> Bool = { _ in false },
          isExpired: @escaping (Credential) -> Bool) {
         self.recheckAfter = recheckAfter
         self.retryAfterFailure = retryAfterFailure
         self.now = now
+        self.isPermanentFailure = isPermanentFailure
         self.isExpired = isExpired
     }
 
@@ -76,10 +96,21 @@ final class CredentialCache<Credential>: @unchecked Sendable {
 
         // Have we already put this exact version of the item to macOS?
         let alreadyAsked: Bool
-        if let current, let askedStamp {
-            // The probe settles it outright: the same item can only give the
-            // same answer, whether that answer was a token or a refusal.
-            alreadyAsked = current == askedStamp
+        if let current, let askedStamp, current == askedStamp {
+            // The probe settles it outright for a success, or for a failure
+            // that is a verdict about the credential: the same item can only
+            // give the same answer. A *transient* failure is not that — dark
+            // wake says nothing about what the item holds — so it falls
+            // through to the same backoff a failure with no probe gets below,
+            // even though the item has not moved.
+            if let failure, !isPermanentFailure(failure) {
+                alreadyAsked = askedAt.map { now().timeIntervalSince($0) < retryAfterFailure } ?? false
+            } else {
+                alreadyAsked = true
+            }
+        } else if let current, let askedStamp {
+            // Different versions: nothing to reuse, whatever the last answer was.
+            alreadyAsked = false
         } else if let askedAt {
             // Nothing to compare against, so wait it out instead — and wait
             // longer after a refusal, because a refusal retried on a timer is

--- a/Sources/Providers/ProviderAccount.swift
+++ b/Sources/Providers/ProviderAccount.swift
@@ -129,4 +129,12 @@ struct ProviderSummary: Identifiable, Equatable {
     /// cure for an illness the provider does not have, and a button that does
     /// nothing is indistinguishable from a broken one.
     var wasRefusedAccess: Bool = false
+    /// Whether this provider's saved login has aged out and Codenotch could not
+    /// renew it, so someone has to run the tool that owns it.
+    ///
+    /// Deliberately *not* read off the snapshot's status, for the same reason
+    /// `wasRefusedAccess` is not: an expired token leaves the last reading in
+    /// place and looking fine. Tying the warning to "is there a reading" would
+    /// hide it behind exactly the stale number it is warning about.
+    var needsSignInRenewal: Bool = false
 }

--- a/Sources/Providers/UsageProvider.swift
+++ b/Sources/Providers/UsageProvider.swift
@@ -55,6 +55,10 @@ enum UsageProviderError: Error {
     /// refresh it the next time it runs. Not the same as being signed out: the
     /// last reading is still true, just old.
     case credentialExpired
+    /// The fetch never came back inside the store's deadline. Says nothing
+    /// about the account — the usual cause is a keychain read sitting behind an
+    /// authorization prompt nobody has answered yet.
+    case timedOut
     /// The endpoint answered, but not with anything we understand.
     case badResponse(status: Int)
     /// Asked to slow down. Carries the server's own retry hint when it gave one.

--- a/Sources/Sessions/ClaudeSessionMonitor.swift
+++ b/Sources/Sessions/ClaudeSessionMonitor.swift
@@ -23,6 +23,19 @@ final class ClaudeSessionMonitor: ObservableObject, AgentActivityMonitor {
     /// the tests that only care about the registry want.
     private let transcripts: ClaudeTranscriptReader?
 
+    /// Sessions to leave out because Codenotch started them, not the user.
+    ///
+    /// Renewing the OAuth token runs the Claude CLI, and the CLI registers a
+    /// session file for the second or so it is alive, exactly like any other
+    /// session. Without this the notch grows a seventh row that nobody asked
+    /// for, and — worse — `isBusy` can read it as work in progress and start
+    /// polling usage hard on the strength of it.
+    ///
+    /// The pid alone is enough: checked on this machine, the file the CLI
+    /// writes carries the pid of the process Codenotch spawned, with no fork in
+    /// between. See `ClaudeTokenRefresher`.
+    var ignoredPIDs: () -> Set<Int32> = { [] }
+
     private var source: DispatchSourceFileSystemObject?
     private var descriptor: CInt = -1
     private var livenessTimer: Timer?
@@ -94,7 +107,8 @@ final class ClaudeSessionMonitor: ObservableObject, AgentActivityMonitor {
     }
 
     private func rescan() {
-        let found = Self.read(directory: directory, transcripts: transcripts)
+        let found = Self.read(directory: directory, transcripts: transcripts,
+                              ignoring: ignoredPIDs())
         guard found != sessions else { return }   // don't churn SwiftUI for nothing
         // Only on a change, so this is a handful of lines an hour rather than a
         // firehose. It is the one way to see what the notch thinks is running
@@ -107,7 +121,8 @@ final class ClaudeSessionMonitor: ObservableObject, AgentActivityMonitor {
     }
 
     static func read(directory: URL,
-                     transcripts: ClaudeTranscriptReader? = nil) -> [AgentSession] {
+                     transcripts: ClaudeTranscriptReader? = nil,
+                     ignoring: Set<Int32> = []) -> [AgentSession] {
         let names = (try? FileManager.default.contentsOfDirectory(atPath: directory.path)) ?? []
         let live = names
             .filter { $0.hasSuffix(".json") }
@@ -116,6 +131,7 @@ final class ClaudeSessionMonitor: ObservableObject, AgentActivityMonitor {
                 guard let data = try? Data(contentsOf: url),
                       let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
                       let record = ClaudeSessionRecord(json: json),
+                      !ignoring.contains(record.pid),
                       ProcessLiveness.isAlive(pid: record.pid, startedAt: record.startedAt)
                 else { return nil }
                 return record

--- a/Sources/Sessions/ClaudeSessionMonitor.swift
+++ b/Sources/Sessions/ClaudeSessionMonitor.swift
@@ -6,10 +6,12 @@ import Foundation
 /// default — and publishes the Claude Code sessions that are actually running.
 /// One monitor per `ClaudeProfile`; see `AppDelegate`.
 ///
-/// The directory is watched rather than polled, because Claude Code writes a
-/// session file the moment its state changes — so "Claude just finished" shows
-/// up immediately. A slow timer runs alongside purely to notice processes that
-/// died without touching the directory, which no file event will ever report.
+/// The directory is watched rather than polled, because a session file appears
+/// and disappears the moment a session starts and stops. The timer alongside it
+/// covers the two things no file event will report: a process that died without
+/// touching the directory, and — for sessions the Claude desktop app hosts —
+/// what the session is *doing*, which is not in the directory at all and has to
+/// be read from the transcript. See `ClaudeTranscript` for why.
 @MainActor
 final class ClaudeSessionMonitor: ObservableObject, AgentActivityMonitor {
     @Published private(set) var sessions: [AgentSession] = []
@@ -17,6 +19,9 @@ final class ClaudeSessionMonitor: ObservableObject, AgentActivityMonitor {
 
     private let directory: URL
     private let livenessInterval: TimeInterval
+    /// Nil leaves the monitor reading nothing but the registry, which is what
+    /// the tests that only care about the registry want.
+    private let transcripts: ClaudeTranscriptReader?
 
     private var source: DispatchSourceFileSystemObject?
     private var descriptor: CInt = -1
@@ -24,13 +29,20 @@ final class ClaudeSessionMonitor: ObservableObject, AgentActivityMonitor {
     private var debounce: DispatchWorkItem?
     private var wakeObserver: NSObjectProtocol?
 
+    /// `livenessInterval` doubles as how often a running session's transcript
+    /// is looked at, so it matches the Codex monitor's two seconds rather than
+    /// the five it used when the registry was the only thing being read. The
+    /// cost of a tick is a `stat` per live session; the tail is read only when
+    /// the file has grown.
     init(
         directory: URL = URL(fileURLWithPath: NSHomeDirectory())
             .appendingPathComponent(".claude/sessions"),
-        livenessInterval: TimeInterval = 5
+        projects: URL? = nil,
+        livenessInterval: TimeInterval = 2
     ) {
         self.directory = directory
         self.livenessInterval = livenessInterval
+        self.transcripts = projects.map { ClaudeTranscriptReader(projects: $0) }
     }
 
     func start() {
@@ -82,24 +94,67 @@ final class ClaudeSessionMonitor: ObservableObject, AgentActivityMonitor {
     }
 
     private func rescan() {
-        let found = Self.read(directory: directory)
+        let found = Self.read(directory: directory, transcripts: transcripts)
         guard found != sessions else { return }   // don't churn SwiftUI for nothing
+        // Only on a change, so this is a handful of lines an hour rather than a
+        // firehose. It is the one way to see what the notch thinks is running
+        // without hovering over it:
+        //
+        //     log stream --predicate 'category == "sessions"' --level debug
+        let summary = found.map { "\($0.name)=\($0.state)" }.joined(separator: " ")
+        Log.sessions.debug("\(ClaudeProfile.tilde(self.directory.path), privacy: .public): \(summary, privacy: .public)")
         sessions = found
     }
 
-    static func read(directory: URL) -> [AgentSession] {
+    static func read(directory: URL,
+                     transcripts: ClaudeTranscriptReader? = nil) -> [AgentSession] {
         let names = (try? FileManager.default.contentsOfDirectory(atPath: directory.path)) ?? []
-        return names
+        let live = names
             .filter { $0.hasSuffix(".json") }
-            .compactMap { name -> AgentSession? in
+            .compactMap { name -> ClaudeSessionRecord? in
                 let url = directory.appendingPathComponent(name)
                 guard let data = try? Data(contentsOf: url),
                       let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
                       let record = ClaudeSessionRecord(json: json),
                       ProcessLiveness.isAlive(pid: record.pid, startedAt: record.startedAt)
                 else { return nil }
-                return record.session
+                return record
             }
-            .sorted { $0.since > $1.since }
+        return deduplicated(live)
+            .map { record in state(of: record, transcripts: transcripts) }
+            // The id breaks ties so the order cannot flicker between two ticks
+            // that read the same thing.
+            .sorted { $0.since == $1.since ? $0.id < $1.id : $0.since > $1.since }
+    }
+
+    /// The record's own answer where it has one, the transcript's where it does
+    /// not. Desktop sessions always take the second path; terminal ones never
+    /// do, which is what keeps their `waiting` state — the one thing only the
+    /// terminal interface knows — exactly as it was.
+    static func state(of record: ClaudeSessionRecord,
+                      transcripts: ClaudeTranscriptReader?) -> AgentSession {
+        guard !record.reportsStatus,
+              let sessionID = record.sessionID,
+              let activity = transcripts?.activity(sessionID: sessionID, cwd: record.cwd)
+        else { return record.session }
+        return record.session(state: activity.turn == .inFlight ? .busy : .idle,
+                              since: activity.since)
+    }
+
+    /// One session can hold two registry records at once: resuming after a
+    /// crash registers a new pid while the old process is still winding down,
+    /// and for a moment both files pass the liveness check. Claude Code settles
+    /// this by keeping the most recently started record, so the notch does the
+    /// same rather than drawing one session twice.
+    static func deduplicated(_ records: [ClaudeSessionRecord]) -> [ClaudeSessionRecord] {
+        var newest: [String: ClaudeSessionRecord] = [:]
+        var unidentified: [ClaudeSessionRecord] = []
+        for record in records {
+            guard let id = record.sessionID else { unidentified.append(record); continue }
+            let candidate = record.startedAt ?? .distantPast
+            if let held = newest[id], (held.startedAt ?? .distantPast) >= candidate { continue }
+            newest[id] = record
+        }
+        return Array(newest.values) + unidentified
     }
 }

--- a/Sources/Sessions/ClaudeSessionRecord.swift
+++ b/Sources/Sessions/ClaudeSessionRecord.swift
@@ -9,6 +9,18 @@ struct ClaudeSessionRecord {
     let pid: Int32
     /// Roughly when the process started. Only used to notice a recycled pid.
     let startedAt: Date?
+    /// The session's own id, which is what names its transcript.
+    let sessionID: String?
+    /// Where it is running. The transcript is filed under this.
+    let cwd: String
+    /// Whether the record said anything the monitor understands about what the
+    /// session is doing.
+    ///
+    /// False for every session the Claude desktop app hosts: Claude Code fills
+    /// `status` in from its terminal interface, which a desktop session does
+    /// not have. That is the flag that sends the monitor to the transcript
+    /// instead — see `ClaudeTranscript`.
+    let reportsStatus: Bool
     let session: AgentSession
 
     /// Decoded leniently on purpose: the file is written by another program on
@@ -21,16 +33,24 @@ struct ClaudeSessionRecord {
         let raw = json["status"] as? String
         let tempo = json["tempo"] as? String        // the normalised form, when present
         let state: AgentSession.State
+        // `reportsStatus` is about whether the record *said* something, not
+        // about what it said: a word neither of us knows is no more use than no
+        // word at all, and both are better answered by the transcript.
+        let reportsStatus: Bool
         switch (tempo, raw) {
-        case ("blocked", _), (_, "waiting"): state = .waiting
-        case ("active", _), (_, "busy"):     state = .busy
-        default:                             state = .idle
+        case ("blocked", _), (_, "waiting"): (state, reportsStatus) = (.waiting, true)
+        case ("active", _), (_, "busy"):     (state, reportsStatus) = (.busy, true)
+        case ("idle", _), (_, "idle"):       (state, reportsStatus) = (.idle, true)
+        default:                             (state, reportsStatus) = (.idle, false)
         }
 
         let millis = (json["statusUpdatedAt"] as? NSNumber)?.doubleValue
             ?? (json["updatedAt"] as? NSNumber)?.doubleValue
 
         self.pid = pid
+        self.sessionID = json["sessionId"] as? String
+        self.cwd = cwd
+        self.reportsStatus = reportsStatus
         if let started = (json["startedAt"] as? NSNumber)?.doubleValue {
             self.startedAt = Date(timeIntervalSince1970: started / 1000)
         } else {
@@ -44,8 +64,24 @@ struct ClaudeSessionRecord {
             detail: "\(Self.surface(json["entrypoint"] as? String)) · \(folder)",
             state: state,
             waitingFor: (json["waitingFor"] as? String) ?? (json["needs"] as? String),
-            since: millis.map { Date(timeIntervalSince1970: $0 / 1000) } ?? Date()
+            // `startedAt` before the clock, because a desktop record carries
+            // neither `statusUpdatedAt` nor `updatedAt` and `Date()` is a
+            // different answer on every rescan — which makes the session look
+            // changed twice a second and sets the notch animating over and
+            // over. When the transcript is readable it replaces this anyway;
+            // this is what holds still until it is.
+            since: millis.map { Date(timeIntervalSince1970: $0 / 1000) }
+                ?? self.startedAt ?? Date()
         )
+    }
+
+    /// The same session, in a state read from somewhere other than the record.
+    ///
+    /// `waitingFor` is dropped on purpose: the only states that reach here come
+    /// from the transcript, and the transcript cannot see a permission prompt.
+    func session(state: AgentSession.State, since: Date) -> AgentSession {
+        AgentSession(id: session.id, name: session.name, detail: session.detail,
+                     state: state, waitingFor: nil, since: since)
     }
 
     static func surface(_ entrypoint: String?) -> String {

--- a/Sources/Sessions/ClaudeTranscript.swift
+++ b/Sources/Sessions/ClaudeTranscript.swift
@@ -1,0 +1,224 @@
+import Foundation
+
+/// What a Claude Code session is doing, read from its transcript.
+///
+/// Claude Code writes `status` into `~/.claude/sessions/<pid>.json` from one
+/// place only: an effect inside the terminal interface's render loop. A session
+/// hosted by the Claude desktop app runs the same binary with no terminal
+/// interface, so that effect never fires and the record carries no status at
+/// all — which is why every desktop session read as permanently idle, and why
+/// the usage ring never polled hard while one was working.
+///
+/// The transcript is the other thing Claude Code writes, and the engine writes
+/// it rather than the interface, so it is there for both surfaces:
+/// `~/.claude/projects/<slug>/<sessionId>.jsonl`, one JSON object per line,
+/// appended as the turn goes.
+enum ClaudeTranscript {
+    /// Whether the session is mid-turn.
+    ///
+    /// Two cases and not three, deliberately. Nothing in the transcript
+    /// separates a tool waiting on your permission from a tool that is simply
+    /// taking its time — there is no record for a permission prompt — so this
+    /// never claims `waiting`. Only the terminal interface knows that, and only
+    /// the terminal interface writes it to the registry.
+    enum Turn: Equatable { case inFlight, finished }
+
+    /// How much of the end of the file to look at. The last few records settle
+    /// it, and these transcripts run to megabytes.
+    static let tailBytes = 64 * 1024
+
+    // MARK: - Where the file is
+
+    /// The directory Claude Code files a working directory's transcripts under:
+    /// the path with every `/` and `.` turned into `-`, so
+    /// `/Users/x/app/.claude/worktrees/y` becomes
+    /// `-Users-x-app--claude-worktrees-y`.
+    static func projectSlug(forCWD cwd: String) -> String {
+        String(cwd.map { $0 == "/" || $0 == "." ? "-" : $0 })
+    }
+
+    /// The transcript for one session, or nil if it has not been written yet.
+    ///
+    /// `scanning` is what makes this affordable to call on a timer: the slug is
+    /// derived from the session's own `cwd` and is right almost always, so the
+    /// usual cost is a single `stat`. The directory scan is the fallback for a
+    /// session that has moved since it started — resumed in a worktree, say —
+    /// and keeps its transcript where it was first written.
+    static func transcript(
+        forSessionID sessionID: String,
+        cwd: String,
+        in projects: URL,
+        scanning: Bool,
+        fileManager: FileManager = .default
+    ) -> URL? {
+        let file = sessionID + ".jsonl"
+        let direct = projects
+            .appendingPathComponent(projectSlug(forCWD: cwd))
+            .appendingPathComponent(file)
+        if fileManager.fileExists(atPath: direct.path) { return direct }
+        guard scanning else { return nil }
+
+        let folders = (try? fileManager.contentsOfDirectory(atPath: projects.path)) ?? []
+        for folder in folders {
+            let candidate = projects
+                .appendingPathComponent(folder)
+                .appendingPathComponent(file)
+            if fileManager.fileExists(atPath: candidate.path) { return candidate }
+        }
+        return nil
+    }
+
+    // MARK: - What it says
+
+    static func turn(at url: URL, bytes: Int = tailBytes) -> Turn? {
+        tail(of: url, bytes: bytes).flatMap(turn(inTail:))
+    }
+
+    /// The last records of the file, without reading the rest of it.
+    static func tail(of url: URL, bytes: Int = tailBytes) -> Data? {
+        guard let handle = try? FileHandle(forReadingFrom: url) else { return nil }
+        defer { try? handle.close() }
+        guard let end = try? handle.seekToEnd() else { return nil }
+        let start = end > UInt64(bytes) ? end - UInt64(bytes) : 0
+        guard (try? handle.seek(toOffset: start)) != nil else { return nil }
+        return try? handle.readToEnd()
+    }
+
+    /// The state machine, kept pure so it can be tested without a file.
+    ///
+    /// Only `user` and `assistant` lines are allowed to decide. The transcript
+    /// also carries bookkeeping — `bridge-session`, `atis-latch`, `frame-link`,
+    /// `custom-title` and more — which Claude Code keeps appending while a
+    /// session sits doing nothing. That is why "was the file touched recently",
+    /// which is all the Codex monitor can manage, is not good enough here: on
+    /// this Mac it reported a session that had been parked for an hour as
+    /// working. An allow-list rather than a list of kinds to skip, because the
+    /// bookkeeping kinds are added to between releases.
+    ///
+    /// Nil when the tail holds no conversation at all — a session that has been
+    /// opened and not yet used. The caller leaves such a session as it found it
+    /// rather than guessing.
+    static func turn(inTail data: Data) -> Turn? {
+        let lines = data.split(separator: UInt8(ascii: "\n"), omittingEmptySubsequences: true)
+        for line in lines.reversed() {
+            // The first line of the tail is usually cut in half; it fails to
+            // parse and is skipped, which is the whole handling it needs.
+            guard let json = (try? JSONSerialization.jsonObject(with: Data(line)))
+                    as? [String: Any] else { continue }
+            // A subagent's records are interleaved with its parent's, and the
+            // parent's turn is the one being reported on.
+            if json["isSidechain"] as? Bool == true { continue }
+
+            switch json["type"] as? String {
+            case "assistant":
+                // `tool_use` is the only stop reason that means the turn goes
+                // on; `end_turn`, `stop_sequence` and `max_tokens` all end it.
+                let message = json["message"] as? [String: Any]
+                return message?["stop_reason"] as? String == "tool_use" ? .inFlight : .finished
+            case "user":
+                return isInterruption(json) ? .finished : .inFlight
+            default:
+                continue
+            }
+        }
+        return nil
+    }
+
+    /// Pressing Esc writes a user turn saying so, which is what makes "stopped"
+    /// something the notch can know rather than wait out with a timeout. Two
+    /// wordings exist, and both start the same way.
+    private static let interruption = "[Request interrupted by user"
+
+    static func isInterruption(_ json: [String: Any]) -> Bool {
+        guard let message = json["message"] as? [String: Any] else { return false }
+        switch message["content"] {
+        case let text as String:
+            return text.hasPrefix(interruption)
+        case let blocks as [Any]:
+            return blocks.contains { block in
+                ((block as? [String: Any])?["text"] as? String)?.hasPrefix(interruption) == true
+            }
+        default:
+            return false
+        }
+    }
+}
+
+/// Reads transcripts on a timer, and remembers enough not to read them twice.
+///
+/// One instance per monitor. A tick that finds a transcript untouched since the
+/// last one costs a `stat` and nothing else — the tail is read only when the
+/// file has actually grown.
+final class ClaudeTranscriptReader {
+    private struct Cached {
+        let modified: Date
+        let size: UInt64
+        let turn: ClaudeTranscript.Turn?
+    }
+
+    private let projects: URL
+    private let fileManager: FileManager
+    /// Where each session's transcript turned out to be. Sessions come and go;
+    /// this is bounded by how many have run since the app launched.
+    private var paths: [String: URL] = [:]
+    private var cache: [String: Cached] = [:]
+    /// When each session last changed what it was doing.
+    ///
+    /// The transcript's timestamp is when it was last *appended to*, which
+    /// moves every few seconds through a long turn. Reported as-is it would
+    /// hold the tooltip's elapsed time at zero for as long as the session
+    /// worked, and hand the notch a new value to animate on every tick. What
+    /// the notch means by `since` is when the state was entered, so the moment
+    /// of the change is kept and the appends in between are ignored.
+    private var entered: [String: (turn: ClaudeTranscript.Turn, at: Date)] = [:]
+    /// Sessions already looked for the hard way and not found. The directory
+    /// scan is worth doing once for a session that has moved, and never worth
+    /// repeating every two seconds for one that simply has no transcript.
+    private var scanned: Set<String> = []
+
+    init(projects: URL, fileManager: FileManager = .default) {
+        self.projects = projects
+        self.fileManager = fileManager
+    }
+
+    /// What the session is doing, and when it last moved. Nil when there is no
+    /// transcript to read, or nothing said in it yet.
+    func activity(sessionID: String, cwd: String) -> (turn: ClaudeTranscript.Turn, since: Date)? {
+        guard let url = path(sessionID: sessionID, cwd: cwd),
+              let attributes = try? fileManager.attributesOfItem(atPath: url.path),
+              let modified = attributes[.modificationDate] as? Date
+        else { return nil }
+        let size = (attributes[.size] as? NSNumber)?.uint64Value ?? 0
+
+        let turn: ClaudeTranscript.Turn?
+        if let cached = cache[sessionID], cached.modified == modified, cached.size == size {
+            turn = cached.turn
+        } else {
+            turn = ClaudeTranscript.turn(at: url)
+            cache[sessionID] = Cached(modified: modified, size: size, turn: turn)
+        }
+
+        guard let turn else { return nil }
+        if let previous = entered[sessionID], previous.turn == turn {
+            return (turn, previous.at)
+        }
+        // First sight of a change, so the file's own timestamp is the closest
+        // thing there is to when it happened.
+        entered[sessionID] = (turn, modified)
+        return (turn, modified)
+    }
+
+    private func path(sessionID: String, cwd: String) -> URL? {
+        if let known = paths[sessionID] { return known }
+        let scanning = !scanned.contains(sessionID)
+        guard let found = ClaudeTranscript.transcript(
+            forSessionID: sessionID, cwd: cwd, in: projects,
+            scanning: scanning, fileManager: fileManager
+        ) else {
+            if scanning { scanned.insert(sessionID) }
+            return nil
+        }
+        paths[sessionID] = found
+        return found
+    }
+}

--- a/Sources/Settings/SettingsView.swift
+++ b/Sources/Settings/SettingsView.swift
@@ -301,6 +301,20 @@ private struct AccountRow: View {
             detail
                 .font(.caption)
                 .padding(.leading, 26)
+
+            // Outside `detail` on purpose. That chain shows the account summary
+            // whenever there is an account, and an aged-out token still has
+            // one — the credential is there, it is simply too old to use. Put
+            // inside, this warning would be swallowed by the very row that
+            // makes everything look fine.
+            if isConnected, provider.needsSignInRenewal {
+                Text("\(provider.name) usage needs its sign-in renewed — run "
+                     + "`claude` once in a terminal.")
+                    .font(.caption)
+                    .foregroundStyle(.orange)
+                    .padding(.leading, 26)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
         }
     }
 

--- a/Tests/AntigravityTests.swift
+++ b/Tests/AntigravityTests.swift
@@ -421,15 +421,20 @@ final class CredentialCacheTests: XCTestCase {
         XCTAssertEqual(reads, 2, "it never looked again at all")
     }
 
-    /// One refusal must not become a refusal a minute. macOS said no; asking
-    /// again on the next tick is what the user experiences as "it keeps asking
-    /// even though I chose Always Allow".
+    /// One refusal must not become a refusal a minute — *when it is a real
+    /// one*. `isPermanentFailure` is what says so: without it, this same
+    /// `Denied` would default to being retried after `retryAfterFailure`,
+    /// exactly like the dark-wake case below. The distinction is real macOS
+    /// UI (`errSecAuthFailed`/`errSecUserCanceled`/`errSecInteractionNotAllowed`)
+    /// saying no, and asking again on the next tick is what the user
+    /// experiences as "it keeps asking even though I chose Always Allow".
     func testARefusalIsNeverRetriedWhileTheItemIsUnchanged() {
         struct Denied: Error {}
         var reads = 0
         var clock = Date(timeIntervalSince1970: 0)
         var stamp = Date(timeIntervalSince1970: 1_000)
-        let cache = CredentialCache<Token>(now: { clock }) { $0.expired }
+        let cache = CredentialCache<Token>(now: { clock }, isPermanentFailure: { $0 is Denied },
+                                           isExpired: { $0.expired })
 
         // A good read first, so there is something to fall back on.
         _ = try? cache.value(itemModifiedAt: { stamp }) { reads += 1; return Token(expired: true) }
@@ -521,6 +526,91 @@ final class CredentialCacheTests: XCTestCase {
         clock.addTimeInterval(10 * 60)
         _ = try? cache.value { () -> Token in reads += 1; throw Nope() }
         XCTAssertEqual(reads, 2, "it never looked again at all")
+    }
+
+    // MARK: - Transient failures: dark wake, and anything else unclassified
+
+    /// The bug this section exists to pin down. `errSecInDarkWake` — macOS
+    /// refusing a keychain read because the Mac is in a brief low-power wake
+    /// with no UI possible — used to be cached exactly like a permanent
+    /// refusal, for as long as the item's `mdat` stayed the same. Nothing
+    /// touches the item again once it holds a valid token, so on a real
+    /// machine one unlucky read landed during dark wake and every read for
+    /// the next three hours replayed that single failure — the notch said
+    /// "Sign in to Claude Code" long after the saved login was fine again,
+    /// because nothing here ever asked macOS a second time.
+    ///
+    /// An error with no `isPermanentFailure` classifier — the default, and
+    /// what `errSecInDarkWake` gets, since it says nothing about the
+    /// credential itself — is retried after `retryAfterFailure` even while
+    /// `mdat` has not moved, which a permanent refusal (above) never is.
+    func testATransientFailureIsRetriedAfterTheWindowEvenWithTheSameMdat() {
+        struct DarkWake: Error {}
+        var reads = 0
+        var clock = Date(timeIntervalSince1970: 0)
+        let stamp = Date(timeIntervalSince1970: 1_000)
+        let cache = CredentialCache<Token>(now: { clock }, isExpired: { $0.expired })
+
+        _ = try? cache.value(itemModifiedAt: { stamp }) { () -> Token in
+            reads += 1; throw DarkWake()
+        }
+        XCTAssertEqual(reads, 1)
+
+        // Before the window: the same failure, without asking macOS again.
+        clock.addTimeInterval(4 * 60 + 59)
+        XCTAssertThrowsError(try cache.value(itemModifiedAt: { stamp }) { () -> Token in
+            reads += 1; throw DarkWake()
+        }) { XCTAssertTrue($0 is DarkWake) }
+        XCTAssertEqual(reads, 1, "still cached — the window has not passed yet")
+
+        // Past it, `mdat` still exactly the same: this is the fix. The old
+        // logic only ever asked "did the item change".
+        clock.addTimeInterval(2)
+        let recovered = try? cache.value(itemModifiedAt: { stamp }) {
+            reads += 1; return Token(expired: false)
+        }
+        XCTAssertNotNil(recovered, "the window passing must trigger a real retry")
+        XCTAssertEqual(reads, 2)
+    }
+
+    /// A repeated transient failure still respects the backoff — the fix is
+    /// "eventually retry", not "retry on every call".
+    func testARepeatedTransientFailureStillBacksOff() {
+        struct DarkWake: Error {}
+        var reads = 0
+        var clock = Date(timeIntervalSince1970: 0)
+        let stamp = Date(timeIntervalSince1970: 1_000)
+        let cache = CredentialCache<Token>(now: { clock }, isExpired: { $0.expired })
+
+        for _ in 0..<20 {
+            _ = try? cache.value(itemModifiedAt: { stamp }) { () -> Token in
+                reads += 1; throw DarkWake()
+            }
+            clock.addTimeInterval(10)
+        }
+        // 200s in 10s steps, all inside the 300s default window.
+        XCTAssertEqual(reads, 1, "hammering the cache must not hammer the keychain")
+    }
+
+    /// A rotation is picked up immediately even behind a transient failure —
+    /// the same guarantee `testARotationIsStillWorthAskingForAfterARefusal`
+    /// gives a permanent one, so a real renewal is never made to wait out a
+    /// backoff that exists for the opposite case.
+    func testARotationIsPickedUpImmediatelyAfterATransientFailure() {
+        struct DarkWake: Error {}
+        var reads = 0
+        var stamp = Date(timeIntervalSince1970: 1_000)
+        let cache = CredentialCache<Token>(isExpired: { $0.expired })
+
+        _ = try? cache.value(itemModifiedAt: { stamp }) { () -> Token in
+            reads += 1; throw DarkWake()
+        }
+        stamp = Date(timeIntervalSince1970: 2_000)   // renewed moments later
+        let renewed = try? cache.value(itemModifiedAt: { stamp }) {
+            reads += 1; return Token(expired: false)
+        }
+        XCTAssertNotNil(renewed)
+        XCTAssertEqual(reads, 2, "a real renewal must not wait out a backoff that exists for a different reason")
     }
 }
 

--- a/Tests/ClaudeOAuthProviderTests.swift
+++ b/Tests/ClaudeOAuthProviderTests.swift
@@ -199,3 +199,39 @@ private final class StubEndpoint: URLProtocol {
 
     override func stopLoading() {}
 }
+
+/// `account()` must read through the injected credential source, like every
+/// other read here.
+///
+/// It used to call the keychain directly, which made it impossible for a test
+/// to build a real provider without touching the login keychain. On a test host
+/// rebuilt with a fresh ad-hoc signature that means an authorization prompt,
+/// and a prompt nobody answers hangs the whole suite — which is exactly what it
+/// did, on `providerSummaries`.
+final class ClaudeAccountSourceTests: XCTestCase {
+    private func provider(_ load: @escaping @Sendable () throws -> ClaudeCredentials)
+        -> ClaudeOAuthProvider {
+        let name = "ClaudeAccountSourceTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: name)!
+        defaults.removePersistentDomain(forName: name)
+        return ClaudeOAuthProvider(archive: UsageArchive(defaults: defaults),
+                                   loadCredentials: load)
+    }
+
+    func testTheAccountComesFromTheInjectedSource() throws {
+        var reads = 0
+        let account = provider {
+            reads += 1
+            return ClaudeCredentials(accessToken: "t", expiresAt: .distantFuture,
+                                     subscriptionType: "team")
+        }.account()
+
+        XCTAssertEqual(reads, 1, "the keychain must not be consulted behind our back")
+        XCTAssertEqual(account?.plan, "team")
+    }
+
+    /// A source that has nothing is no account, and no crash.
+    func testNoCredentialIsNoAccount() {
+        XCTAssertNil(provider { throw UsageProviderError.needsAuth }.account())
+    }
+}

--- a/Tests/ClaudeProfileTests.swift
+++ b/Tests/ClaudeProfileTests.swift
@@ -178,6 +178,18 @@ final class ClaudeProfileTests: XCTestCase {
         XCTAssertNotNil(archive.loadBackoffUntil(providerID: "claude"))
     }
 
+    /// Stands in for the keychain so the test below cannot reach it.
+    ///
+    /// Two profiles on a fictional `/Users/vinz` still resolve to the *real*
+    /// service name for the default one, so building them for real used to read
+    /// the login keychain — and on a test host rebuilt with a fresh ad-hoc
+    /// signature that means an authorization prompt, which hung the entire
+    /// suite on `providerSummaries`. What the test is about is naming and
+    /// ordering; the credential has nothing to do with it.
+    private static let noCredential: @Sendable () throws -> ClaudeCredentials = {
+        throw UsageProviderError.needsAuth
+    }
+
     /// Two providers, one id each, both drawn: the store has no idea they are
     /// the same tool and must not collapse them.
     @MainActor
@@ -188,10 +200,13 @@ final class ClaudeProfileTests: XCTestCase {
         let home = URL(fileURLWithPath: "/Users/vinz")
         let store = UsageStore(
             providers: [
-                ClaudeOAuthProvider(profile: .default(home: home), archive: UsageArchive(defaults: defaults)),
+                ClaudeOAuthProvider(profile: .default(home: home),
+                                    archive: UsageArchive(defaults: defaults),
+                                    loadCredentials: Self.noCredential),
                 ClaudeOAuthProvider(profile: ClaudeProfile(slug: "work",
                                                            configDirectory: home.appendingPathComponent(".claude-work")),
-                                    archive: UsageArchive(defaults: defaults))
+                                    archive: UsageArchive(defaults: defaults),
+                                    loadCredentials: Self.noCredential)
             ],
             archive: UsageArchive(defaults: defaults)
         )

--- a/Tests/ClaudeSessionTests.swift
+++ b/Tests/ClaudeSessionTests.swift
@@ -252,3 +252,59 @@ extension ClaudeSessionRecordTests {
         XCTAssertEqual(first.since.timeIntervalSince1970, 1788731755.247, accuracy: 0.01)
     }
 }
+
+/// The session Codenotch starts itself must never reach the notch.
+///
+/// Renewing the OAuth token runs the Claude CLI, and the CLI registers a
+/// session file for the second or so it is alive — verified on a real machine:
+/// the count under `~/.claude/sessions` goes six, seven, six, and the file
+/// carries the pid of the process Codenotch spawned. Left alone it draws a row
+/// nobody asked for, and `isBusy` reads it as work in progress and starts
+/// polling usage hard on the strength of it.
+@MainActor
+final class ClaudeOwnSessionFilterTests: XCTestCase {
+    private var directory: URL!
+
+    override func setUpWithError() throws {
+        directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("own-session-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: directory)
+    }
+
+    /// This process, so the liveness check passes and the only thing under test
+    /// is the filter.
+    private var livePID: Int32 { ProcessInfo.processInfo.processIdentifier }
+
+    private func writeSession(pid: Int32, name: String) throws {
+        let json = """
+        { "pid": \(pid), "sessionId": "\(name)", "cwd": "/Users/vinz/app",
+          "name": "\(name)", "entrypoint": "claude-desktop" }
+        """
+        try Data(json.utf8).write(to: directory.appendingPathComponent("\(pid).json"))
+    }
+
+    func testTheSessionIsReadWhenNothingIsIgnored() throws {
+        try writeSession(pid: livePID, name: "mine")
+        let found = ClaudeSessionMonitor.read(directory: directory)
+        XCTAssertEqual(found.map(\.name), ["mine"])
+    }
+
+    func testAnIgnoredPidIsLeftOut() throws {
+        try writeSession(pid: livePID, name: "mine")
+        let found = ClaudeSessionMonitor.read(directory: directory, ignoring: [livePID])
+        XCTAssertTrue(found.isEmpty, "the session Codenotch started is not the user's")
+    }
+
+    /// Ignoring one must not hide the rest — the notch still has to show every
+    /// session the user actually has open.
+    func testEveryOtherSessionSurvives() throws {
+        try writeSession(pid: livePID, name: "ours")
+        try writeSession(pid: getppid(), name: "theirs")
+        let found = ClaudeSessionMonitor.read(directory: directory, ignoring: [livePID])
+        XCTAssertEqual(found.map(\.name), ["theirs"])
+    }
+}

--- a/Tests/ClaudeSessionTests.swift
+++ b/Tests/ClaudeSessionTests.swift
@@ -92,3 +92,163 @@ final class ClaudeSessionRecordTests: XCTestCase {
         XCTAssertEqual(try XCTUnwrap(r.startedAt).timeIntervalSince1970, 1787894126.697, accuracy: 0.01)
     }
 }
+
+/// Which source gets to say what a session is doing.
+///
+/// Claude Code fills `status` in from its terminal interface, so a terminal
+/// session's record answers for itself and a desktop session's never does. The
+/// split has to hold in both directions: the desktop case is the bug being
+/// fixed, and the terminal case is the behaviour that must not change —
+/// `waiting` in particular, which nothing but the terminal interface can know.
+@MainActor
+final class ClaudeSessionStateSourceTests: XCTestCase {
+    private var projects: URL!
+
+    override func setUpWithError() throws {
+        projects = FileManager.default.temporaryDirectory
+            .appendingPathComponent("sessions-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: projects, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: projects)
+    }
+
+    private func record(_ json: String) throws -> ClaudeSessionRecord {
+        let object = try XCTUnwrap(
+            try JSONSerialization.jsonObject(with: Data(json.utf8)) as? [String: Any]
+        )
+        return try XCTUnwrap(ClaudeSessionRecord(json: object))
+    }
+
+    private func writeTranscript(_ body: String, session: String, cwd: String) throws {
+        let directory = projects
+            .appendingPathComponent(ClaudeTranscript.projectSlug(forCWD: cwd))
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        try Data(body.utf8).write(to: directory.appendingPathComponent("\(session).jsonl"))
+    }
+
+    private var reader: ClaudeTranscriptReader { ClaudeTranscriptReader(projects: projects) }
+
+    /// The real shape of a desktop session's file, trimmed. No status, no
+    /// tempo, no `statusUpdatedAt` — and the file is written once, when the
+    /// session starts, so its own timestamp says nothing either.
+    private let desktop = """
+    { "pid": 26440, "sessionId": "0b24b489", "cwd": "/Users/vinz/app",
+      "startedAt": 1788731755247, "procStart": "Sun Sep  6 21:55:54 2026",
+      "kind": "interactive", "entrypoint": "claude-desktop", "name": "app-6c",
+      "messagingSocketPath": "/tmp/cc-socks/26440.sock" }
+    """
+
+    func testADesktopRecordAdmitsItSaysNothingAboutState() throws {
+        let desktop = try record(desktop)
+        XCTAssertFalse(desktop.reportsStatus)
+        XCTAssertEqual(desktop.sessionID, "0b24b489")
+        XCTAssertEqual(desktop.cwd, "/Users/vinz/app")
+        XCTAssertEqual(desktop.session.detail, "Desktop · app")
+
+        let terminal = try record(#"{ "pid": 1, "cwd": "/tmp/x", "status": "busy" }"#)
+        XCTAssertTrue(terminal.reportsStatus)
+    }
+
+    /// A word neither of us knows is worth no more than no word at all, so it
+    /// goes to the transcript too.
+    func testAnUnrecognisedStatusIsNotAnAnswer() throws {
+        XCTAssertFalse(try record(#"{ "pid": 1, "cwd": "/tmp/x", "status": "hibernating" }"#)
+            .reportsStatus)
+        XCTAssertTrue(try record(#"{ "pid": 1, "cwd": "/tmp/x", "status": "idle" }"#)
+            .reportsStatus)
+    }
+
+    func testADesktopSessionTakesItsStateFromTheTranscript() throws {
+        try writeTranscript(#"{"type":"assistant","message":{"stop_reason":"tool_use"}}"#,
+                            session: "0b24b489", cwd: "/Users/vinz/app")
+        let session = ClaudeSessionMonitor.state(of: try record(desktop), transcripts: reader)
+        XCTAssertEqual(session.state, .busy)
+        XCTAssertEqual(session.id, "claude.26440")
+    }
+
+    func testADesktopSessionThatFinishedItsTurnIsIdle() throws {
+        try writeTranscript(#"{"type":"assistant","message":{"stop_reason":"end_turn"}}"#,
+                            session: "0b24b489", cwd: "/Users/vinz/app")
+        XCTAssertEqual(
+            ClaudeSessionMonitor.state(of: try record(desktop), transcripts: reader).state, .idle
+        )
+    }
+
+    /// With no transcript to read, the record's own answer stands — which is
+    /// exactly what the notch did before any of this existed.
+    func testWithNoTranscriptTheRecordStands() throws {
+        XCTAssertEqual(
+            ClaudeSessionMonitor.state(of: try record(desktop), transcripts: reader).state, .idle
+        )
+        XCTAssertEqual(
+            ClaudeSessionMonitor.state(of: try record(desktop), transcripts: nil).state, .idle
+        )
+    }
+
+    /// The behaviour that must not regress: a terminal session says `waiting`,
+    /// and the transcript — which cannot see a permission prompt at all — is
+    /// never allowed to talk it out of that.
+    func testATerminalSessionKeepsItsOwnStateAndItsWaitingFor() throws {
+        let waiting = try record("""
+        { "pid": 7, "sessionId": "0b24b489", "cwd": "/Users/vinz/app",
+          "status": "waiting", "waitingFor": "permission" }
+        """)
+        try writeTranscript(#"{"type":"assistant","message":{"stop_reason":"tool_use"}}"#,
+                            session: "0b24b489", cwd: "/Users/vinz/app")
+        let session = ClaudeSessionMonitor.state(of: waiting, transcripts: reader)
+        XCTAssertEqual(session.state, .waiting)
+        XCTAssertEqual(session.waitingFor, "permission")
+    }
+
+    // MARK: - Deduplication
+
+    /// Resuming after a crash registers a new pid while the old process is
+    /// still winding down, and for a moment both files are live. One session
+    /// must not be drawn twice.
+    func testTheSameSessionUnderTwoPidsIsDrawnOnce() throws {
+        let old = try record("""
+        { "pid": 1, "sessionId": "same", "cwd": "/tmp/x", "startedAt": 1000000 }
+        """)
+        let new = try record("""
+        { "pid": 2, "sessionId": "same", "cwd": "/tmp/x", "startedAt": 2000000 }
+        """)
+        for pair in [[old, new], [new, old]] {
+            let kept = ClaudeSessionMonitor.deduplicated(pair)
+            XCTAssertEqual(kept.count, 1)
+            XCTAssertEqual(kept.first?.pid, 2, "the most recently started record wins")
+        }
+    }
+
+    func testDifferentSessionsAreAllKept() throws {
+        let a = try record(#"{ "pid": 1, "sessionId": "a", "cwd": "/tmp/x" }"#)
+        let b = try record(#"{ "pid": 2, "sessionId": "b", "cwd": "/tmp/x" }"#)
+        XCTAssertEqual(ClaudeSessionMonitor.deduplicated([a, b]).count, 2)
+    }
+
+    /// A record old enough to have no session id cannot be matched against
+    /// anything, so it is kept rather than dropped or merged.
+    func testRecordsWithoutASessionIdAreKept() throws {
+        let a = try record(#"{ "pid": 1, "cwd": "/tmp/x" }"#)
+        let b = try record(#"{ "pid": 2, "cwd": "/tmp/x" }"#)
+        XCTAssertEqual(ClaudeSessionMonitor.deduplicated([a, b]).count, 2)
+    }
+}
+
+/// A record with nothing to date itself by must still answer the same thing
+/// twice. It used to answer `Date()`, so every rescan produced a session that
+/// compared unequal to the one before it and the notch re-animated at 2 Hz.
+extension ClaudeSessionRecordTests {
+    func testARecordWithNoTimestampHoldsStill() throws {
+        let json = """
+        { "pid": 1, "sessionId": "a", "cwd": "/tmp/x", "startedAt": 1788731755247,
+          "entrypoint": "claude-desktop" }
+        """
+        let first = try XCTUnwrap(session(json))
+        let second = try XCTUnwrap(session(json))
+        XCTAssertEqual(first.since, second.since)
+        XCTAssertEqual(first, second)
+        XCTAssertEqual(first.since.timeIntervalSince1970, 1788731755.247, accuracy: 0.01)
+    }
+}

--- a/Tests/ClaudeTokenRefresherTests.swift
+++ b/Tests/ClaudeTokenRefresherTests.swift
@@ -1,0 +1,350 @@
+import XCTest
+@testable import Codenotch
+
+/// Which of the several `claude` binaries on a Mac is the right one.
+final class ClaudeCLITests: XCTestCase {
+    /// The copy inside the desktop app keeps its token in the app's own store
+    /// and never writes the login keychain — the item Codenotch reads. Renewing
+    /// with it would look like it worked and change nothing at all, which is a
+    /// far worse failure than finding no command.
+    func testTheDesktopAppsOwnCopyIsRefused() {
+        let desktop = URL(fileURLWithPath: NSHomeDirectory())
+            .appendingPathComponent("Library/Application Support/Claude/claude-code/2.1.260/claude.app/Contents/MacOS/claude")
+        XCTAssertTrue(ClaudeCLI.isDesktopOwned(desktop))
+        XCTAssertFalse(ClaudeCLI.isDesktopOwned(URL(fileURLWithPath: "/opt/homebrew/bin/claude")))
+    }
+
+    func testNothingInstalledIsNotAnError() {
+        XCTAssertNil(ClaudeCLI.standalone(candidates: ["/nowhere/claude"]))
+    }
+}
+
+/// The gate, the cooldown and the failure path around renewing the token.
+@MainActor
+final class ClaudeTokenRefresherTests: XCTestCase {
+    private let now = Date(timeIntervalSince1970: 1_700_000_000)
+    private func inSeconds(_ s: TimeInterval) -> Date { now.addingTimeInterval(s) }
+
+    // MARK: - The gate
+
+    /// Under four minutes, and only then. The margin has to stay *below* Claude
+    /// Code's own five, or the command's start-up decides there is nothing to
+    /// do and the launch is wasted.
+    func testItOnlyRunsInsideTheMargin() {
+        func shouldRenew(_ remaining: TimeInterval) -> Bool {
+            ClaudeTokenRefresher.shouldRenew(
+                expiry: inSeconds(remaining), now: now, margin: 4 * 60,
+                attemptedFor: nil, lastAttempt: nil, cooldown: 600
+            )
+        }
+        XCTAssertFalse(shouldRenew(8 * 60), "eight minutes out, nothing to do")
+        XCTAssertFalse(shouldRenew(5 * 60), "five is still outside our margin")
+        XCTAssertTrue(shouldRenew(3 * 60))
+        XCTAssertTrue(shouldRenew(-60), "already expired counts too")
+    }
+
+    /// Never on a guess: no reading yet means no idea how long is left.
+    func testItNeverRunsWithoutAnExpiry() {
+        XCTAssertFalse(ClaudeTokenRefresher.shouldRenew(
+            expiry: nil, now: now, margin: 4 * 60,
+            attemptedFor: nil, lastAttempt: nil, cooldown: 600
+        ))
+    }
+
+    /// The no-retry-loop guarantee, and the reason it is expressed as "one
+    /// attempt per token" rather than as a timer: a launch that failed to move
+    /// the expiry leaves the same value here on the next tick, so it is refused
+    /// for as long as the token stays unrenewed — not merely for a cooldown.
+    func testATokenGetsOneAttemptEver() {
+        let expiry = inSeconds(60)
+        XCTAssertFalse(ClaudeTokenRefresher.shouldRenew(
+            expiry: expiry, now: now, margin: 4 * 60,
+            attemptedFor: expiry, lastAttempt: nil, cooldown: 600
+        ))
+        // A different token is a different question.
+        XCTAssertTrue(ClaudeTokenRefresher.shouldRenew(
+            expiry: inSeconds(120), now: now, margin: 4 * 60,
+            attemptedFor: expiry, lastAttempt: nil, cooldown: 600
+        ))
+    }
+
+    func testTheCooldownHoldsOffASecondLaunch() {
+        XCTAssertFalse(ClaudeTokenRefresher.shouldRenew(
+            expiry: inSeconds(60), now: now, margin: 4 * 60,
+            attemptedFor: nil, lastAttempt: now.addingTimeInterval(-60), cooldown: 600
+        ))
+        XCTAssertTrue(ClaudeTokenRefresher.shouldRenew(
+            expiry: inSeconds(60), now: now, margin: 4 * 60,
+            attemptedFor: nil, lastAttempt: now.addingTimeInterval(-900), cooldown: 600
+        ))
+    }
+
+    // MARK: - Running it
+
+    private final class Spy: @unchecked Sendable {
+        var launches = 0
+        var pidWhileRunning: Int32??
+        var exitStatus: Int32? = 1
+        var throwsOnLaunch = false
+    }
+
+    private struct Boom: Error {}
+
+    private func refresher(
+        spy: Spy,
+        before: Date?,
+        after: Date?,
+        cli: URL? = URL(fileURLWithPath: "/opt/homebrew/bin/claude"),
+        // A hook for tests that need to control *when* the expiry read
+        // resolves — the concurrency test below, specifically — without every
+        // other test having to know that hook exists.
+        wrapExpiry: (@escaping @MainActor () async -> Date?)
+            -> (@MainActor () async -> Date?) = { $0 }
+    ) -> ClaudeTokenRefresher {
+        var made: ClaudeTokenRefresher?
+        let refresher = ClaudeTokenRefresher(
+            expiry: wrapExpiry({ before }),
+            reload: { after },
+            cli: cli,
+            launcher: { _, _ in
+                spy.launches += 1
+                if spy.throwsOnLaunch { throw Boom() }
+                return (4242, {
+                    // Read where the session monitor would read it: while the
+                    // command is alive, which is the only moment it matters.
+                    await MainActor.run { spy.pidWhileRunning = made?.launchedPID }
+                    return spy.exitStatus
+                })
+            }
+        )
+        made = refresher
+        return refresher
+    }
+
+    func testItRenewsWhenTheExpiryMoves() async {
+        let spy = Spy()
+        let before = inSeconds(60)
+        let after = inSeconds(8 * 3600)
+        let refresher = refresher(spy: spy, before: before, after: after)
+
+        await refresher.considerRenewing(now: now)
+
+        XCTAssertEqual(spy.launches, 1)
+        XCTAssertEqual(refresher.outcome, .refreshed(until: after))
+    }
+
+    /// Judged on the outcome, never on the exit status. Refusing an empty
+    /// prompt *is* a non-zero exit, and it is also a successful renewal — so
+    /// reading success off the status code would get it exactly backwards.
+    func testANonZeroExitIsStillASuccessfulRenewal() async {
+        let spy = Spy()
+        spy.exitStatus = 1
+        let after = inSeconds(8 * 3600)
+        let refresher = refresher(spy: spy, before: inSeconds(60), after: after)
+
+        await refresher.considerRenewing(now: now)
+
+        XCTAssertEqual(refresher.outcome, .refreshed(until: after))
+    }
+
+    /// The compatibility guard: if a future release stops renewing at start-up,
+    /// the expiry simply does not move, and this has to say so rather than
+    /// carry on believing it worked.
+    func testAnUnmovedExpiryIsAFailure() async {
+        let spy = Spy()
+        let stuck = inSeconds(60)
+        let refresher = refresher(spy: spy, before: stuck, after: stuck)
+
+        await refresher.considerRenewing(now: now)
+
+        guard case .failed(let message) = refresher.outcome else {
+            return XCTFail("expected a failure, got \(refresher.outcome)")
+        }
+        XCTAssertTrue(message.contains("renew"), "the message has to say what to do: \(message)")
+    }
+
+    /// And having said so, it stops: the same token never gets a second launch.
+    func testAFailureDoesNotLoop() async {
+        let spy = Spy()
+        let stuck = inSeconds(60)
+        let refresher = refresher(spy: spy, before: stuck, after: stuck)
+
+        await refresher.considerRenewing(now: now)
+        await refresher.considerRenewing(now: now.addingTimeInterval(3600))
+        await refresher.considerRenewing(now: now.addingTimeInterval(7200))
+
+        XCTAssertEqual(spy.launches, 1, "one launch per token, however long it is left running")
+    }
+
+    func testACommandThatWillNotStartIsReported() async {
+        let spy = Spy()
+        spy.throwsOnLaunch = true
+        let refresher = refresher(spy: spy, before: inSeconds(60), after: inSeconds(8 * 3600))
+
+        await refresher.considerRenewing(now: now)
+
+        guard case .failed = refresher.outcome else {
+            return XCTFail("expected a failure, got \(refresher.outcome)")
+        }
+    }
+
+    func testWithNoCommandInstalledItSaysSoAndLaunchesNothing() async {
+        let spy = Spy()
+        let refresher = refresher(spy: spy, before: inSeconds(60),
+                                  after: inSeconds(8 * 3600), cli: nil)
+
+        await refresher.considerRenewing(now: now)
+
+        XCTAssertEqual(spy.launches, 0)
+        guard case .failed(let message) = refresher.outcome else {
+            return XCTFail("expected a failure, got \(refresher.outcome)")
+        }
+        XCTAssertTrue(message.contains("isn't installed"), message)
+    }
+
+    /// The pid has to be readable *while* the command runs — that is the whole
+    /// window in which the session monitor could otherwise pick it up — and
+    /// gone once it has finished.
+    func testThePidIsVisibleWhileItRunsAndClearedAfter() async {
+        let spy = Spy()
+        let refresher = refresher(spy: spy, before: inSeconds(60), after: inSeconds(8 * 3600))
+
+        await refresher.considerRenewing(now: now)
+
+        XCTAssertEqual(spy.pidWhileRunning, 4242)
+        XCTAssertNil(refresher.launchedPID)
+    }
+
+    func testItDoesNothingWhileTheTokenIsHealthy() async {
+        let spy = Spy()
+        let refresher = refresher(spy: spy, before: inSeconds(3 * 3600),
+                                  after: inSeconds(8 * 3600))
+
+        await refresher.considerRenewing(now: now)
+
+        XCTAssertEqual(spy.launches, 0)
+        XCTAssertEqual(refresher.outcome, .idle)
+    }
+
+    // MARK: - No concurrent launches
+
+    /// `isRunning` has to be claimed *before* `considerRenewing`'s only
+    /// `await`, not after it — otherwise there is a window, while that first
+    /// read is in flight, where a second overlapping call would find nothing
+    /// claimed yet and go on to launch its own process too.
+    ///
+    /// Worth being exact about what this is testing, because two *other*
+    /// mechanisms can look like they cover this from the outside: `attemptedFor`
+    /// (one attempt per token) and the cooldown (`lastAttempt`) both also end
+    /// up blocking a second overlapping call in practice, as a side effect of
+    /// MainActor being serial — whichever call resumes first runs its whole
+    /// synchronous stretch, writing both of those, before the second call ever
+    /// reaches its own check. That is real, and worth having, but it is
+    /// incidental: it depends on the two calls agreeing on roughly the same
+    /// `now` and the same token, which any two genuinely concurrent ticks would,
+    /// but which is not a guarantee `considerRenewing` itself makes. `isRunning`
+    /// is the one thing that is supposed to make "at most one launch" true by
+    /// construction, not by coincidence — so it is what gets tested directly:
+    /// claimed synchronously, before anything is awaited, full stop.
+    func testIsRunningIsClaimedBeforeTheFirstAwait() async {
+        let spy = Spy()
+        let gate = Gate()
+        let refresher = refresher(
+            spy: spy, before: inSeconds(60), after: inSeconds(8 * 3600),
+            wrapExpiry: { original in { await gate.wait(); return await original() } }
+        )
+
+        let task = Task { await refresher.considerRenewing(now: now) }
+        // Long enough for the call to reach the gate; the gate itself proves
+        // it got there, since nothing after it can run without passing through.
+        try? await Task.sleep(nanoseconds: 100_000_000)
+
+        XCTAssertTrue(refresher.isRunningForTesting,
+                      "the launch must be claimed before waiting on anything, "
+                      + "or a second overlapping call would see nothing claimed yet")
+
+        await gate.open()
+        _ = await task.value
+        XCTAssertEqual(spy.launches, 1)
+    }
+
+    /// The behavioural guarantee this all adds up to: two ticks racing over the
+    /// *same* token never start two processes. This is the outside view — it
+    /// does not care which of the three mechanisms above is the one holding,
+    /// only that the observable result is right.
+    func testTwoOverlappingTicksForTheSameTokenLaunchAtMostOnce() async {
+        let spy = Spy()
+        let gate = Gate()
+        let refresher = refresher(
+            spy: spy, before: inSeconds(60), after: inSeconds(8 * 3600),
+            wrapExpiry: { original in { await gate.wait(); return await original() } }
+        )
+
+        async let first: Void = refresher.considerRenewing(now: now)
+        async let second: Void = refresher.considerRenewing(now: now)
+        try? await Task.sleep(nanoseconds: 100_000_000)
+        await gate.open()
+        _ = await (first, second)
+
+        XCTAssertEqual(spy.launches, 1, "two overlapping ticks must start at most one process")
+    }
+
+    /// A held-open gate so a test can force two calls to overlap deterministically
+    /// rather than hoping a race happens to line up.
+    private actor Gate {
+        private var opened = false
+        private var waiters: [CheckedContinuation<Void, Never>] = []
+
+        func wait() async {
+            if opened { return }
+            await withCheckedContinuation { waiters.append($0) }
+        }
+
+        func open() {
+            opened = true
+            waiters.forEach { $0.resume() }
+            waiters = []
+        }
+    }
+
+    // MARK: - The real subprocess
+
+    /// `run(_:timeout:)` is what actually spawns `claude`, and it is the one
+    /// piece of this feature every other test above deliberately swaps out —
+    /// `refresher(...)` injects a fake `launcher` precisely so nothing else
+    /// has to spawn anything real. That leaves the timeout-and-kill path,
+    /// which is safety-critical (a wedge here would hang a *launch*, the exact
+    /// shape of bug this whole feature exists downstream of), unverified by
+    /// everything else. This is a real process, so the whole thing costs
+    /// under a second rather than a millisecond, but that is the honest price
+    /// of actually proving the kill path leaves nothing behind.
+    func testATimedOutProcessIsKilledAndReaped() async throws {
+        // Ignores SIGTERM, so the only way out is the SIGKILL fallback —
+        // exercising the exact path this test is for, not the gentler one.
+        let stubborn = try makeStubbornScript()
+        defer { try? FileManager.default.removeItem(at: stubborn) }
+
+        let start = Date()
+        let (pid, exit) = try ClaudeTokenRefresher.run(stubborn, timeout: 0.2)
+        let status = await exit()
+
+        XCTAssertNil(status, "a killed process has no exit status to report")
+        // Under a couple of seconds: 0.2s timeout + 0.5s SIGTERM grace + a
+        // moment to confirm SIGKILL landed. A hang here would mean the reap
+        // loop never noticed the process was gone.
+        XCTAssertLessThan(Date().timeIntervalSince(start), 3)
+        XCTAssertEqual(kill(pid, 0), -1, "the pid must not still exist once wait() has returned")
+        XCTAssertEqual(errno, ESRCH, "specifically gone, not merely unreachable for some other reason")
+    }
+
+    /// A script that ignores SIGTERM so a test can force the SIGKILL branch,
+    /// written fresh each time rather than checked in: it needs the executable
+    /// bit, which a git checkout does not reliably preserve.
+    private func makeStubbornScript() throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("stubborn-\(UUID().uuidString).sh")
+        try Data("#!/bin/sh\ntrap '' TERM\nsleep 30\n".utf8).write(to: url)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: url.path)
+        return url
+    }
+}

--- a/Tests/ClaudeTranscriptTests.swift
+++ b/Tests/ClaudeTranscriptTests.swift
@@ -1,0 +1,237 @@
+import XCTest
+@testable import Codenotch
+
+/// The state machine that reads a session's transcript.
+///
+/// It exists because Claude Code only writes `status` into the session registry
+/// from its terminal interface, so a session hosted by the Claude desktop app
+/// has no status at all. Every fixture here is the shape of a line found in a
+/// real transcript on a Mac running the desktop app.
+final class ClaudeTranscriptTests: XCTestCase {
+    private func turn(_ lines: String...) -> ClaudeTranscript.Turn? {
+        ClaudeTranscript.turn(inTail: Data(lines.joined(separator: "\n").utf8))
+    }
+
+    // MARK: - Where the file is
+
+    func testSlugReplacesSeparatorsAndDots() {
+        XCTAssertEqual(ClaudeTranscript.projectSlug(forCWD: "/Users/vinz/notch-app"),
+                       "-Users-vinz-notch-app")
+        // A worktree under a dot directory: both characters collapse, and the
+        // run of two dashes is what the real directory names look like.
+        XCTAssertEqual(
+            ClaudeTranscript.projectSlug(forCWD: "/Users/vinz/app/.claude/worktrees/x"),
+            "-Users-vinz-app--claude-worktrees-x"
+        )
+    }
+
+    // MARK: - What it says
+
+    func testAToolInFlightIsWork() {
+        XCTAssertEqual(turn(#"{"type":"assistant","message":{"stop_reason":"tool_use"}}"#),
+                       .inFlight)
+    }
+
+    func testTheEndOfATurnIsNotWork() {
+        XCTAssertEqual(turn(#"{"type":"assistant","message":{"stop_reason":"end_turn"}}"#),
+                       .finished)
+        XCTAssertEqual(turn(#"{"type":"assistant","message":{"stop_reason":"stop_sequence"}}"#),
+                       .finished)
+    }
+
+    /// A tool result means the tool is done and the model is thinking about it,
+    /// which is the part of a turn that looks quietest from outside.
+    func testAToolResultIsStillWork() {
+        XCTAssertEqual(turn("""
+        {"type":"user","message":{"content":[{"type":"tool_result","content":"ok"}]}}
+        """), .inFlight)
+    }
+
+    func testAFreshPromptIsWork() {
+        XCTAssertEqual(turn(#"{"type":"user","message":{"content":"build the thing"}}"#),
+                       .inFlight)
+    }
+
+    /// Esc writes a record saying so, which is why a stopped session is
+    /// something the notch knows rather than something it waits out.
+    func testAnInterruptionEndsTheTurn() {
+        XCTAssertEqual(turn("""
+        {"type":"user","message":{"content":[{"type":"text","text":"[Request interrupted by user]"}]}}
+        """), .finished)
+        XCTAssertEqual(turn("""
+        {"type":"user","message":{"content":"[Request interrupted by user for tool use]"}}
+        """), .finished)
+    }
+
+    /// The reason a plain "was the file touched recently" test cannot work
+    /// here: Claude Code keeps appending these to a session that is sitting
+    /// doing nothing, and on this Mac that made an hour-old parked session look
+    /// like it was working.
+    func testBookkeepingNeverDecides() {
+        XCTAssertEqual(turn(
+            #"{"type":"assistant","message":{"stop_reason":"end_turn"}}"#,
+            #"{"type":"attachment"}"#,
+            #"{"type":"bridge-session"}"#,
+            #"{"type":"atis-latch"}"#,
+            #"{"type":"frame-link"}"#,
+            #"{"type":"custom-title"}"#,
+            #"{"type":"queue-operation","operation":"enqueue"}"#,
+            #"{"type":"system","subtype":"stop_hook_summary"}"#
+        ), .finished)
+    }
+
+    /// An unknown kind must not be read as work either — the list of things
+    /// Claude Code writes grows between releases, so only `user` and
+    /// `assistant` are allowed to answer.
+    func testAnUnknownKindNeverDecides() {
+        XCTAssertEqual(turn(
+            #"{"type":"assistant","message":{"stop_reason":"tool_use"}}"#,
+            #"{"type":"something-shipped-next-month"}"#
+        ), .inFlight)
+    }
+
+    /// A subagent's records are interleaved with its parent's; the parent's
+    /// turn is the one being reported on.
+    func testASidechainIsIgnored() {
+        XCTAssertEqual(turn(
+            #"{"type":"assistant","message":{"stop_reason":"tool_use"}}"#,
+            #"{"type":"assistant","isSidechain":true,"message":{"stop_reason":"end_turn"}}"#
+        ), .inFlight)
+    }
+
+    /// The tail starts mid-file, so its first line is usually half a record.
+    func testAHalfLineAtTheFrontIsSkipped() {
+        XCTAssertEqual(turn(
+            #"or":"tool_use"}}"#,
+            #"{"type":"assistant","message":{"stop_reason":"end_turn"}}"#
+        ), .finished)
+    }
+
+    /// A session opened and not yet used says nothing, and the monitor leaves
+    /// it as the registry described it rather than guessing.
+    func testNothingSaidYetIsUnknown() {
+        XCTAssertNil(turn(#"{"type":"bridge-session"}"#))
+        XCTAssertNil(ClaudeTranscript.turn(inTail: Data()))
+    }
+}
+
+/// The reader that puts the state machine on a timer.
+final class ClaudeTranscriptReaderTests: XCTestCase {
+    private var projects: URL!
+
+    override func setUpWithError() throws {
+        projects = FileManager.default.temporaryDirectory
+            .appendingPathComponent("transcripts-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: projects, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: projects)
+    }
+
+    @discardableResult
+    private func write(_ body: String, folder: String, session: String) throws -> URL {
+        let directory = projects.appendingPathComponent(folder)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let url = directory.appendingPathComponent("\(session).jsonl")
+        try Data(body.utf8).write(to: url)
+        return url
+    }
+
+    private let working = #"{"type":"assistant","message":{"stop_reason":"tool_use"}}"# + "\n"
+    private let done = #"{"type":"assistant","message":{"stop_reason":"end_turn"}}"# + "\n"
+
+    func testReadsTheTranscriptUnderTheSlugForTheWorkingDirectory() throws {
+        try write(working, folder: "-Users-vinz-app", session: "abc")
+        let reader = ClaudeTranscriptReader(projects: projects)
+        XCTAssertEqual(reader.activity(sessionID: "abc", cwd: "/Users/vinz/app")?.turn, .inFlight)
+    }
+
+    /// A session resumed somewhere else keeps its transcript where it was first
+    /// written, so the slug no longer names it.
+    func testFindsATranscriptThatIsNotUnderItsOwnSlug() throws {
+        try write(done, folder: "-Users-vinz-elsewhere", session: "abc")
+        let reader = ClaudeTranscriptReader(projects: projects)
+        XCTAssertEqual(reader.activity(sessionID: "abc", cwd: "/Users/vinz/app")?.turn, .finished)
+    }
+
+    func testSaysNothingWhenThereIsNoTranscript() {
+        let reader = ClaudeTranscriptReader(projects: projects)
+        XCTAssertNil(reader.activity(sessionID: "abc", cwd: "/Users/vinz/app"))
+    }
+
+    /// `since` is when the turn last moved, which is what the tooltip counts
+    /// from — not the moment the notch happened to look.
+    func testReportsWhenTheTranscriptLastMoved() throws {
+        let url = try write(working, folder: "-Users-vinz-app", session: "abc")
+        let when = Date(timeIntervalSince1970: 1_700_000_000)
+        try FileManager.default.setAttributes([.modificationDate: when], ofItemAtPath: url.path)
+        let reader = ClaudeTranscriptReader(projects: projects)
+        XCTAssertEqual(reader.activity(sessionID: "abc", cwd: "/Users/vinz/app")?.since, when)
+    }
+
+    /// The whole point of the cache: a tick that finds the file unchanged must
+    /// not read it again. Rewriting the body without touching the timestamps
+    /// leaves the reader on its old answer.
+    func testAnUnchangedFileIsNotReadTwice() throws {
+        let url = try write(working, folder: "-Users-vinz-app", session: "abc")
+        // Pinned to the same whole second on both sides, so the only thing this
+        // can be measuring is the cache.
+        let frozen = Date(timeIntervalSince1970: 1_700_000_000)
+        try FileManager.default.setAttributes([.modificationDate: frozen], ofItemAtPath: url.path)
+        let reader = ClaudeTranscriptReader(projects: projects)
+        XCTAssertEqual(reader.activity(sessionID: "abc", cwd: "/Users/vinz/app")?.turn, .inFlight)
+
+        // Same length as well, so neither size nor date moves.
+        XCTAssertEqual(working.utf8.count, done.utf8.count)
+        try Data(done.utf8).write(to: url)
+        try FileManager.default.setAttributes([.modificationDate: frozen], ofItemAtPath: url.path)
+        XCTAssertEqual(reader.activity(sessionID: "abc", cwd: "/Users/vinz/app")?.turn, .inFlight)
+    }
+
+    func testRereadsOnceTheFileHasGrown() throws {
+        let url = try write(working, folder: "-Users-vinz-app", session: "abc")
+        let reader = ClaudeTranscriptReader(projects: projects)
+        XCTAssertEqual(reader.activity(sessionID: "abc", cwd: "/Users/vinz/app")?.turn, .inFlight)
+
+        try Data((working + done).utf8).write(to: url)
+        XCTAssertEqual(reader.activity(sessionID: "abc", cwd: "/Users/vinz/app")?.turn, .finished)
+    }
+}
+
+/// `since` means when the state was entered, not when the file was last
+/// touched. Reporting the latter froze the tooltip's elapsed time at zero for
+/// the whole of a long turn, and gave the notch a fresh value to animate every
+/// two seconds while nothing visible had changed.
+extension ClaudeTranscriptReaderTests {
+    func testTheStartOfTheStateIsHeldWhileItLasts() throws {
+        let url = try write(working, folder: "-Users-vinz-app", session: "abc")
+        let started = Date(timeIntervalSince1970: 1_700_000_000)
+        try FileManager.default.setAttributes([.modificationDate: started],
+                                              ofItemAtPath: url.path)
+        let reader = ClaudeTranscriptReader(projects: projects)
+        XCTAssertEqual(reader.activity(sessionID: "abc", cwd: "/Users/vinz/app")?.since, started)
+
+        // The turn goes on: more records, a newer timestamp, same state.
+        try Data((working + working).utf8).write(to: url)
+        try FileManager.default.setAttributes([.modificationDate: started.addingTimeInterval(30)],
+                                              ofItemAtPath: url.path)
+        XCTAssertEqual(reader.activity(sessionID: "abc", cwd: "/Users/vinz/app")?.since, started)
+    }
+
+    func testTheStartMovesWhenTheStateDoes() throws {
+        let url = try write(working, folder: "-Users-vinz-app", session: "abc")
+        let started = Date(timeIntervalSince1970: 1_700_000_000)
+        try FileManager.default.setAttributes([.modificationDate: started],
+                                              ofItemAtPath: url.path)
+        let reader = ClaudeTranscriptReader(projects: projects)
+        XCTAssertEqual(reader.activity(sessionID: "abc", cwd: "/Users/vinz/app")?.since, started)
+
+        let ended = started.addingTimeInterval(120)
+        try Data((working + done).utf8).write(to: url)
+        try FileManager.default.setAttributes([.modificationDate: ended], ofItemAtPath: url.path)
+        let after = reader.activity(sessionID: "abc", cwd: "/Users/vinz/app")
+        XCTAssertEqual(after?.turn, .finished)
+        XCTAssertEqual(after?.since, ended)
+    }
+}

--- a/Tests/RenewalWarningTests.swift
+++ b/Tests/RenewalWarningTests.swift
@@ -1,0 +1,115 @@
+import XCTest
+@testable import Codenotch
+
+/// The warning that says a saved login has aged out.
+///
+/// It exists because the failure it reports is invisible everywhere else: an
+/// expired token leaves the last reading on screen, still roughly true, and
+/// nothing about the ring says the number stopped moving. That is how a frozen
+/// reading went twelve hours without being noticed. So the warning is tied to
+/// the credential, never to whether there is a number.
+@MainActor
+final class RenewalWarningTests: XCTestCase {
+    private final class Provider: UsageProvider, @unchecked Sendable {
+        let id = "claude"
+        let displayName = "Claude"
+        let glyph = ProviderGlyph.claude
+        /// Set to make the next fetch fail the way an aged-out token does.
+        var tokenExpired = false
+
+        func fetchSnapshot() async throws -> ProviderSnapshot {
+            if tokenExpired { throw UsageProviderError.credentialExpired }
+            return ProviderSnapshot(id: id, displayName: displayName, glyph: glyph,
+                                    fidelity: .official, status: .ok,
+                                    windows: [LimitWindow(id: "w", label: "W",
+                                                          usedFraction: 0.4)])
+        }
+
+        func signOut() async {}
+    }
+
+    private func store(_ provider: Provider) -> UsageStore {
+        let name = "RenewalWarningTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: name)!
+        defaults.removePersistentDomain(forName: name)
+        return UsageStore(providers: [provider], archive: UsageArchive(defaults: defaults))
+    }
+
+    private func warning(_ store: UsageStore) -> Bool {
+        store.providerSummaries.first { $0.id == "claude" }?.needsSignInRenewal ?? false
+    }
+
+    // MARK: - Appearance
+
+    func testNothingIsShownUntilARenewalActuallyFails() async {
+        let store = store(Provider())
+        await store.refresh()
+        XCTAssertFalse(warning(store))
+    }
+
+    func testItAppearsWhenARenewalFails() {
+        let store = store(Provider())
+        store.reportRenewalFailed(providerID: "claude")
+        XCTAssertTrue(warning(store))
+    }
+
+    // MARK: - Persistence behind a stale reading
+
+    /// The regression this is really for. After the token ages out the fetch
+    /// fails, but the remembered reading stays on screen and keeps its numbers
+    /// — so anything that keyed the warning off "is there a reading" would hide
+    /// it behind exactly the stale figure it is warning about.
+    func testAStaleReadingDoesNotHideIt() async {
+        let provider = Provider()
+        let store = store(provider)
+        await store.refresh()                       // a real reading, remembered
+        XCTAssertEqual(store.snapshots.first?.windows.count, 1)
+
+        provider.tokenExpired = true
+        store.reportRenewalFailed(providerID: "claude")
+        await store.refresh()
+
+        XCTAssertTrue(store.snapshots.first?.hasReading == true,
+                      "the old number is still on screen, which is the point")
+        XCTAssertTrue(warning(store), "and the warning is still there behind it")
+    }
+
+    /// Repeated failures do not pile up or flap.
+    func testReportingTwiceChangesNothing() {
+        let store = store(Provider())
+        store.reportRenewalFailed(providerID: "claude")
+        store.reportRenewalFailed(providerID: "claude")
+        XCTAssertEqual(store.needsRenewal, ["claude"])
+    }
+
+    // MARK: - Disappearance
+
+    /// A reading that came back is proof the credential works, whatever was
+    /// believed a moment ago. This is the only thing that clears the warning —
+    /// no timer, and nothing retries on its own.
+    func testItClearsOnceAReadingComesBack() async {
+        let provider = Provider()
+        let store = store(provider)
+        provider.tokenExpired = true
+        store.reportRenewalFailed(providerID: "claude")
+        await store.refresh()
+        XCTAssertTrue(warning(store))
+
+        provider.tokenExpired = false
+        await store.refresh()
+
+        XCTAssertFalse(warning(store), "a fresh reading takes the warning away by itself")
+        XCTAssertTrue(store.needsRenewal.isEmpty)
+    }
+
+    /// A failed fetch is not proof of anything, so it must not clear it either.
+    func testAFailedFetchDoesNotClearIt() async {
+        let provider = Provider()
+        let store = store(provider)
+        provider.tokenExpired = true
+        store.reportRenewalFailed(providerID: "claude")
+        await store.refresh()
+        await store.refresh()
+        XCTAssertTrue(warning(store))
+    }
+}

--- a/Tests/UsageRefreshDeadlineTests.swift
+++ b/Tests/UsageRefreshDeadlineTests.swift
@@ -1,0 +1,228 @@
+import XCTest
+@testable import Codenotch
+
+/// A refresh must never be able to wedge the store.
+///
+/// This is from life: a keychain authorization prompt went unanswered, the
+/// Claude fetch behind it blocked on `SecItemCopyMatching`, the pass never
+/// returned, and `isRefreshing` stayed true. Every tick for the next eighty
+/// minutes logged "refresh skipped: one already in flight" and the app quietly
+/// stopped reading anything at all, while still looking perfectly alive.
+@MainActor
+final class UsageRefreshDeadlineTests: XCTestCase {
+    /// Hangs until it is let go, the way a blocked keychain read does.
+    private final class BlockingProvider: UsageProvider, @unchecked Sendable {
+        let id: String
+        let displayName = "Blocked"
+        let glyph = ProviderGlyph.claude
+        private(set) var calls = 0
+        private var resume: CheckedContinuation<Void, Never>?
+
+        init(id: String = "blocked") { self.id = id }
+
+        func fetchSnapshot() async throws -> ProviderSnapshot {
+            calls += 1
+            await withCheckedContinuation { self.resume = $0 }
+            return Self.reading(id: id, displayName: displayName, glyph: glyph, used: 0.9)
+        }
+
+        func release() { resume?.resume(); resume = nil }
+        func signOut() async {}
+
+        static func reading(id: String, displayName: String, glyph: ProviderGlyph,
+                            used: Double) -> ProviderSnapshot {
+            ProviderSnapshot(id: id, displayName: displayName, glyph: glyph,
+                             fidelity: .official, status: .ok,
+                             windows: [LimitWindow(id: "w", label: "W", usedFraction: used)])
+        }
+    }
+
+    /// Answers at once, so a pass around a blocked one can be seen to complete.
+    private final class QuickProvider: UsageProvider, @unchecked Sendable {
+        let id: String
+        let displayName = "Quick"
+        let glyph = ProviderGlyph.openai
+        private(set) var calls = 0
+        var fails = false
+
+        init(id: String = "quick") { self.id = id }
+
+        func fetchSnapshot() async throws -> ProviderSnapshot {
+            calls += 1
+            if fails { throw UsageProviderError.badResponse(status: 500) }
+            return BlockingProvider.reading(id: id, displayName: displayName,
+                                            glyph: glyph, used: 0.2)
+        }
+
+        func signOut() async {}
+    }
+
+    private func store(_ providers: [any UsageProvider],
+                       deadline: TimeInterval = 0.25) -> UsageStore {
+        let name = "UsageRefreshDeadlineTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: name)!
+        defaults.removePersistentDomain(forName: name)
+        return UsageStore(providers: providers, refreshDeadline: deadline,
+                          archive: UsageArchive(defaults: defaults))
+    }
+
+    private func settle(_ seconds: Double = 0.8) async {
+        try? await Task.sleep(nanoseconds: UInt64(seconds * 1_000_000_000))
+    }
+
+    // MARK: - Success
+
+    func testASuccessfulPassReleasesTheFlag() async {
+        let store = store([QuickProvider()])
+        store.refreshNow()
+        await settle(0.3)
+        XCTAssertFalse(store.isRefreshingForTesting)
+        XCTAssertTrue(store.inFlightForTesting.isEmpty)
+    }
+
+    // MARK: - Error
+
+    /// A thrown error is still an answer, and answers release the flag. This
+    /// path always worked; it is here so a change to the deadline cannot break
+    /// it without saying so.
+    func testAThrownErrorReleasesTheFlag() async {
+        let failing = QuickProvider()
+        failing.fails = true
+        let store = store([failing])
+        store.refreshNow()
+        await settle(0.3)
+        XCTAssertFalse(store.isRefreshingForTesting)
+        XCTAssertEqual(store.snapshots.first?.status, .error("HTTP 500"))
+    }
+
+    // MARK: - Timeout
+
+    func testABlockedPassIsAbandonedAndTheFlagReleased() async {
+        let blocked = BlockingProvider()
+        let store = store([blocked])
+        store.refreshNow()
+        XCTAssertTrue(store.isRefreshingForTesting, "the pass has started")
+
+        await settle()
+        XCTAssertFalse(store.isRefreshingForTesting, "the deadline must free the store")
+        XCTAssertTrue(store.refreshing.isEmpty, "and stop the cell spinning")
+        blocked.release()
+    }
+
+    /// The abandoned provider says so rather than sitting there looking fine.
+    func testAnAbandonedProviderSaysItGotNoResponse() async {
+        let blocked = BlockingProvider()
+        let store = store([blocked])
+        store.refreshNow()
+        await settle()
+        XCTAssertEqual(store.snapshots.first { $0.id == "blocked" }?.status,
+                       .error("no response"))
+        blocked.release()
+    }
+
+    // MARK: - No concurrency
+
+    func testASecondRefreshIsRefusedWhileOneIsRunning() async {
+        let blocked = BlockingProvider()
+        let store = store([blocked], deadline: 30)
+        store.refreshNow()
+        store.refreshNow()
+        await settle(0.2)
+        XCTAssertEqual(blocked.calls, 1, "the second must not start a second pass")
+        blocked.release()
+    }
+
+    // MARK: - Recovery
+
+    /// The point of the whole change, and the exact shape of the bug: the
+    /// blocked provider is *first*, so the wedged pass never reached the one
+    /// behind it. Before the deadline existed that was permanent — the second
+    /// provider was never read again for as long as the app ran. Now the next
+    /// pass steps over the stuck one and gets to it.
+    func testAProviderBehindAStuckOneIsReachedOnTheNextPass() async {
+        let blocked = BlockingProvider()
+        let quick = QuickProvider()
+        let store = store([blocked, quick])
+
+        store.refreshNow()
+        await settle()
+        XCTAssertFalse(store.isRefreshingForTesting)
+        XCTAssertEqual(quick.calls, 0, "the first pass never got past the blocked one")
+
+        store.refreshNow()
+        await settle(0.3)
+        XCTAssertEqual(quick.calls, 1, "the second pass reaches it")
+        XCTAssertEqual(store.snapshots.first { $0.id == "quick" }?.status, .ok)
+        blocked.release()
+    }
+
+    /// And the stuck one is stepped over rather than queued behind. Queueing is
+    /// what made a single blocked provider stop every other one: they are
+    /// actors, so the second call waits on the first.
+    func testAStuckProviderIsSkippedNotQueued() async {
+        let blocked = BlockingProvider()
+        let quick = QuickProvider()
+        let store = store([blocked, quick])
+        store.refreshNow()
+        await settle()
+        XCTAssertEqual(store.inFlightForTesting, ["blocked"])
+
+        store.refreshNow()
+        await settle(0.3)
+        XCTAssertEqual(blocked.calls, 1, "no second call queued behind the blocked one")
+        XCTAssertFalse(store.isRefreshingForTesting, "and the new pass completed")
+        blocked.release()
+    }
+
+    /// A pass that comes back after it was given up on must not redraw the
+    /// screen over whatever replaced it.
+    func testALatePassCannotOverwriteANewerOne() async {
+        let blocked = BlockingProvider()
+        let store = store([blocked])
+        store.refreshNow()
+        await settle()
+
+        store.refreshNow()          // bumps the generation
+        await settle(0.05)
+        blocked.release()           // the abandoned pass now finishes
+        await settle(0.4)
+
+        XCTAssertFalse(store.isRefreshingForTesting)
+    }
+
+    /// The same guarantee, aimed at `refreshing` rather than `isRefreshing`.
+    ///
+    /// A pass has two providers; the first hangs and gets abandoned, the second
+    /// is what a *newer* pass is legitimately still fetching when the old hang
+    /// finally lets go. The abandoned pass returning must not be able to wipe
+    /// the spinner out from under work that is genuinely still in flight —
+    /// which is exactly what an unconditional `defer { refreshing = [] }` would
+    /// do, because a `defer` runs on every return path, guarded or not.
+    func testALatePassCannotClearTheSpinnerOfAStillRunningOne() async {
+        // A longer deadline than the other tests here: pass 2's own deadline
+        // must not fire while this test is deliberately holding it in flight
+        // to observe `refreshing` mid-fetch — that would abandon pass 2 for a
+        // reason that has nothing to do with what this test is checking.
+        let deadline: TimeInterval = 1.0
+        let blocked = BlockingProvider(id: "blocked")
+        let slow = BlockingProvider(id: "slow")
+        let store = store([blocked, slow], deadline: deadline)
+
+        store.refreshNow()                       // pass 1: hangs on "blocked"
+        await settle(deadline + 0.2)              // its own deadline fires; abandoned
+        XCTAssertFalse(store.isRefreshingForTesting)
+
+        store.refreshNow()                        // pass 2: skips "blocked", starts "slow"
+        await settle(0.1)
+        XCTAssertEqual(store.refreshing, ["blocked", "slow"], "pass 2 genuinely has both in flight")
+
+        blocked.release()                         // pass 1's old hang resolves now
+        await settle(0.3)
+        XCTAssertEqual(store.refreshing, ["blocked", "slow"],
+                       "pass 1 finishing late must not touch pass 2's spinner")
+
+        slow.release()
+        await settle(0.3)
+        XCTAssertTrue(store.refreshing.isEmpty, "pass 2 clears it once it actually finishes")
+    }
+}


### PR DESCRIPTION
Fixes #67.

## Summary

Five independently-buildable, independently-tested commits:

1. **Detect Claude Code sessions launched from the Claude desktop app** — reads the transcript when a session's registry record has no `status`/`tempo`, which is every desktop-hosted session.
2. **Never let a stuck refresh wedge `UsageStore` forever** — a deadline + generation counter around the refresh pass, for a real deadlock found while investigating #1 (a blocking keychain read behind an unanswered authorization prompt).
3. **Settings warning when a saved login can't be renewed** — inert until commit 5 wires a caller into it; reuses the existing `wasRefusedAccess` pattern.
4. **Test-hermeticity fix** — `ClaudeOAuthProvider.account()` was bypassing the injectable credential source, which could hang the whole test suite behind a real keychain prompt on a freshly-signed test host.
5. **Automatic OAuth token renewal via the standalone CLI** — the main fix. See #67 for the full writeup of why this is needed and how it was verified.

## Testing

- 612 tests, 0 failures, on every commit in this branch (verified individually, not just at HEAD).
- The auto-renewal path (commit 5) was verified **end-to-end on a real Mac** across an actual token expiry, both for the renewal succeeding and for Codenotch resuming normal usage reads afterward. Full details in #67.
- `git diff --check` clean; no changes to `project.yml`.

## Scope note

Auto-renewal covers only the default `~/.claude` profile — see the "Known limitations" section of #67.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
