### PR TITLE
Add local Ollama provider (monitor active models, VRAM/RAM & dynamic auto-hide)

### DIFF
--- a/Sources/App/AppDelegate.swift
+++ b/Sources/App/AppDelegate.swift
@@ -83,7 +83,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 providers: claudeProfiles.map { ClaudeOAuthProvider(profile: $0) }
                     + [CursorLocalProvider(), CodexLocalProvider(), AntigravityProvider(),
                        GLMProvider(), GrokLocalProvider(), OpenCodeProvider(),
-                       GitHubCopilotProvider(),
+                       GitHubCopilotProvider(), OllamaLocalProvider(),
                        // A closure, not the value: the provider is an actor and
                        // re-reads the budget on every fetch, so a ceiling typed
                        // into Settings applies without a restart.

--- a/Sources/Model/UsageModel.swift
+++ b/Sources/Model/UsageModel.swift
@@ -219,6 +219,7 @@ struct ProviderSnapshot: Identifiable, Equatable {
         case "glm":        return "Set up a GLM Coding Plan key for a coding tool to read your usage"
         case "copilot":    return "Sign in with GitHub CLI to read your Copilot usage"
         case "opencode":   return "Connect the Go plan in OpenCode to read your usage"
+        case "ollama", "ollama-local": return "Start Ollama to monitor your local models"
         default:           return "Sign in to \(displayName) to read your usage"
         }
     }

--- a/Sources/Model/UsageStore.swift
+++ b/Sources/Model/UsageStore.swift
@@ -90,6 +90,8 @@ final class UsageStore: ObservableObject {
     /// never depends on when the task body happens to start.
     private var isRefreshing = false
     private var wakeObserver: NSObjectProtocol?
+    private var appLaunchObserver: NSObjectProtocol?
+    private var appTerminateObserver: NSObjectProtocol?
 
     init(
         providers: [UsageProvider],
@@ -131,7 +133,10 @@ final class UsageStore: ObservableObject {
         // Filtered here, not only in `didSet`. The store is built before the
         // preference reaches it, so an unfiltered first pass draws every
         // switched-off provider for as long as it takes the binding to arrive.
-        snapshots = orderedProviders.filter { !disconnected.contains($0.id) }.map { provider in
+        snapshots = orderedProviders.filter { !disconnected.contains($0.id) }.compactMap { provider in
+            if !provider.isVisibleWhenAbsent && provider.account() == nil {
+                return nil
+            }
             guard let remembered = lastGood[provider.id] else { return Self.placeholder(provider) }
             var snapshot = remembered.snapshot
             snapshot.status = .stale(since: remembered.fetchedAt)
@@ -165,6 +170,25 @@ final class UsageStore: ObservableObject {
         ) { [weak self] _ in
             MainActor.assumeIsolated { self?.refreshNow() }
         }
+
+        // Detect apps launching or quitting (e.g. Ollama) so dynamic providers update immediately.
+        appLaunchObserver = NSWorkspace.shared.notificationCenter.addObserver(
+            forName: NSWorkspace.didLaunchApplicationNotification, object: nil, queue: .main
+        ) { [weak self] notif in
+            guard let app = notif.userInfo?[NSWorkspace.applicationUserInfoKey] as? NSRunningApplication else { return }
+            if app.bundleIdentifier == "com.electron.ollama" || app.localizedName?.localizedCaseInsensitiveContains("ollama") == true {
+                MainActor.assumeIsolated { self?.refreshNow() }
+            }
+        }
+
+        appTerminateObserver = NSWorkspace.shared.notificationCenter.addObserver(
+            forName: NSWorkspace.didTerminateApplicationNotification, object: nil, queue: .main
+        ) { [weak self] notif in
+            guard let app = notif.userInfo?[NSWorkspace.applicationUserInfoKey] as? NSRunningApplication else { return }
+            if app.bundleIdentifier == "com.electron.ollama" || app.localizedName?.localizedCaseInsensitiveContains("ollama") == true {
+                MainActor.assumeIsolated { self?.refreshNow() }
+            }
+        }
     }
 
     func stop() {
@@ -176,6 +200,14 @@ final class UsageStore: ObservableObject {
         if let wakeObserver {
             NSWorkspace.shared.notificationCenter.removeObserver(wakeObserver)
             self.wakeObserver = nil
+        }
+        if let appLaunchObserver {
+            NSWorkspace.shared.notificationCenter.removeObserver(appLaunchObserver)
+            self.appLaunchObserver = nil
+        }
+        if let appTerminateObserver {
+            NSWorkspace.shared.notificationCenter.removeObserver(appTerminateObserver)
+            self.appTerminateObserver = nil
         }
     }
 
@@ -244,9 +276,15 @@ final class UsageStore: ObservableObject {
         Task { [weak self] in
             guard let self else { return }
             defer { self.refreshing.remove(providerID) }
-            guard let fresh = await self.snapshot(from: provider, version: version) else { return }
-            if let index = self.snapshots.firstIndex(where: { $0.id == providerID }) {
-                self.snapshots[index] = fresh
+            let fresh = await self.snapshot(from: provider, version: version)
+            if let fresh {
+                if let index = self.snapshots.firstIndex(where: { $0.id == providerID }) {
+                    self.snapshots[index] = fresh
+                } else {
+                    self.snapshots = ProviderOrder.arrange(self.snapshots + [fresh], by: self.order, id: \.id)
+                }
+            } else {
+                self.snapshots.removeAll { $0.id == providerID }
             }
             self.lastAttempt = Date()
             // A beat of visible work even when the answer was instant: a spinner
@@ -369,7 +407,13 @@ final class UsageStore: ObservableObject {
 
     /// A failed fetch never invents a number: it either re-shows the last good
     /// one marked stale, or shows the cell with no reading at all.
-    private func degraded(provider: UsageProvider, error: Error) -> ProviderSnapshot {
+    private func degraded(provider: UsageProvider, error: Error) -> ProviderSnapshot? {
+        if !provider.isVisibleWhenAbsent {
+            lastGood[provider.id] = nil
+            archive.save(lastGood)
+            return nil
+        }
+
         let status = Self.status(for: error)
 
         // Remembered apart from the snapshot on purpose. The snapshot answers

--- a/Sources/Providers/GlyphOutline.swift
+++ b/Sources/Providers/GlyphOutline.swift
@@ -827,4 +827,45 @@ enum GlyphOutline {
             CGPoint(x: 0.93000, y: 0.46000),
         ],
     ]
+
+    static let ollama: [[CGPoint]] = [
+        [
+            CGPoint(x: 0.35, y: 0.12),
+            CGPoint(x: 0.40, y: 0.12),
+            CGPoint(x: 0.43, y: 0.22),
+            CGPoint(x: 0.50, y: 0.22),
+            CGPoint(x: 0.53, y: 0.12),
+            CGPoint(x: 0.58, y: 0.12),
+            CGPoint(x: 0.60, y: 0.23),
+            CGPoint(x: 0.62, y: 0.35),
+            CGPoint(x: 0.62, y: 0.50),
+            CGPoint(x: 0.72, y: 0.53),
+            CGPoint(x: 0.82, y: 0.55),
+            CGPoint(x: 0.88, y: 0.52),
+            CGPoint(x: 0.90, y: 0.56),
+            CGPoint(x: 0.86, y: 0.62),
+            CGPoint(x: 0.82, y: 0.70),
+            CGPoint(x: 0.80, y: 0.88),
+            CGPoint(x: 0.73, y: 0.88),
+            CGPoint(x: 0.74, y: 0.70),
+            CGPoint(x: 0.58, y: 0.70),
+            CGPoint(x: 0.48, y: 0.70),
+            CGPoint(x: 0.48, y: 0.88),
+            CGPoint(x: 0.41, y: 0.88),
+            CGPoint(x: 0.41, y: 0.58),
+            CGPoint(x: 0.38, y: 0.48),
+            CGPoint(x: 0.36, y: 0.36),
+            CGPoint(x: 0.22, y: 0.34),
+            CGPoint(x: 0.20, y: 0.28),
+            CGPoint(x: 0.24, y: 0.24),
+            CGPoint(x: 0.33, y: 0.22),
+            CGPoint(x: 0.35, y: 0.12),
+        ],
+        [
+            CGPoint(x: 0.32, y: 0.27),
+            CGPoint(x: 0.36, y: 0.27),
+            CGPoint(x: 0.36, y: 0.31),
+            CGPoint(x: 0.32, y: 0.31),
+        ]
+    ]
 }

--- a/Sources/Providers/OllamaLocalProvider.swift
+++ b/Sources/Providers/OllamaLocalProvider.swift
@@ -1,0 +1,126 @@
+import AppKit
+import Foundation
+import os
+
+/// Monitors local models running in Ollama (`http://127.0.0.1:11434`).
+///
+/// When models are loaded in memory/VRAM, displays the active model(s),
+/// VRAM allocation, and the keep-alive unload countdown.
+/// When Ollama is idle (running with no models in memory), displays an idle ring.
+/// If Ollama is not installed on this Mac, no cell is drawn.
+actor OllamaLocalProvider: UsageProvider {
+    nonisolated let id = "ollama-local"
+    nonisolated let displayName = "Ollama (Local)"
+    nonisolated let glyph = ProviderGlyph.ollamaLocal
+    nonisolated var isVisibleWhenAbsent: Bool { false }
+
+    private let endpoint = URL(string: "http://127.0.0.1:11434/api/ps")!
+    private let session: URLSession
+
+    init(session: URLSession? = nil) {
+        if let session {
+            self.session = session
+        } else {
+            let config = URLSessionConfiguration.ephemeral
+            config.timeoutIntervalForRequest = 2
+            config.timeoutIntervalForResource = 3
+            self.session = URLSession(configuration: config)
+        }
+    }
+
+    /// Checks if the Ollama application or local daemon is actively running.
+    static func isDaemonRunning() -> Bool {
+        // Fast path 1: check if Ollama macOS app is running
+        if !NSRunningApplication.runningApplications(withBundleIdentifier: "com.electron.ollama").isEmpty {
+            return true
+        }
+
+        // Fast path 2: check if daemon is listening on 127.0.0.1:11434 (e.g. CLI ollama serve)
+        var addr = sockaddr_in()
+        addr.sin_family = sa_family_t(AF_INET)
+        addr.sin_port = in_port_t(11434).bigEndian
+        addr.sin_addr.s_addr = inet_addr("127.0.0.1")
+
+        let sock = socket(AF_INET, SOCK_STREAM, 0)
+        guard sock >= 0 else { return false }
+        defer { close(sock) }
+
+        var tv = timeval(tv_sec: 0, tv_usec: 50_000) // 50ms timeout
+        setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, &tv, socklen_t(MemoryLayout<timeval>.size))
+        setsockopt(sock, SOL_SOCKET, SO_SNDTIMEO, &tv, socklen_t(MemoryLayout<timeval>.size))
+
+        let result = withUnsafePointer(to: &addr) {
+            $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                Darwin.connect(sock, $0, socklen_t(MemoryLayout<sockaddr_in>.size))
+            }
+        }
+        return result == 0
+    }
+
+    nonisolated var signInRoute: SignInRoute {
+        .openApp(bundleID: "com.electron.ollama", name: "Ollama")
+    }
+
+    nonisolated func account() -> ProviderAccount? {
+        guard Self.isDaemonRunning() else { return nil }
+
+        return ProviderAccount(
+            label: "Localhost",
+            plan: "Local",
+            source: "Ollama",
+            manageURL: URL(string: "http://127.0.0.1:11434")
+        )
+    }
+
+    nonisolated func forgetCachedCredential() {}
+
+    nonisolated func signOut() async {}
+
+    nonisolated func presentSignIn() {
+        if let appURL = NSWorkspace.shared.urlForApplication(withBundleIdentifier: "com.electron.ollama") {
+            NSWorkspace.shared.openApplication(at: appURL, configuration: .init())
+        } else if FileManager.default.fileExists(atPath: "/Applications/Ollama.app") {
+            NSWorkspace.shared.open(URL(fileURLWithPath: "/Applications/Ollama.app"))
+        }
+    }
+
+    func fetchSnapshot() async throws -> ProviderSnapshot {
+        guard Self.isDaemonRunning() else {
+            throw UsageProviderError.needsAuth
+        }
+
+        var request = URLRequest(url: endpoint)
+        request.timeoutInterval = 2
+
+        let data: Data
+        let response: URLResponse
+        do {
+            (data, response) = try await session.data(for: request)
+        } catch {
+            // Daemon is offline or unreachable; present needsAuth so it prompts to start Ollama
+            throw UsageProviderError.needsAuth
+        }
+
+        guard let http = response as? HTTPURLResponse else {
+            throw UsageProviderError.badResponse(status: -1)
+        }
+
+        guard (200..<300).contains(http.statusCode) else {
+            if http.statusCode == 401 || http.statusCode == 403 {
+                throw UsageProviderError.needsAuth
+            }
+            throw UsageProviderError.badResponse(status: http.statusCode)
+        }
+
+        let windows = try OllamaLocalUsage.windows(from: data)
+        return ProviderSnapshot(
+            id: id,
+            displayName: displayName,
+            glyph: glyph,
+            fidelity: .official,
+            status: .ok,
+            windows: windows,
+            headlineID: windows.first?.id
+        )
+    }
+}

--- a/Sources/Providers/OllamaLocalUsage.swift
+++ b/Sources/Providers/OllamaLocalUsage.swift
@@ -1,0 +1,111 @@
+import Foundation
+
+/// Parses the `/api/ps` payload from a local Ollama daemon (`http://127.0.0.1:11434/api/ps`),
+/// representing models currently loaded into memory or VRAM.
+enum OllamaLocalUsage {
+    struct PSResponse: Decodable {
+        let models: [LoadedModel]?
+    }
+
+    struct LoadedModel: Decodable {
+        let name: String
+        let model: String
+        let size: Int64?
+        let digest: String?
+        let expiresAt: String?
+        let sizeVram: Int64?
+        let details: ModelDetails?
+
+        enum CodingKeys: String, CodingKey {
+            case name, model, size, digest, details
+            case expiresAt = "expires_at"
+            case sizeVram = "size_vram"
+        }
+    }
+
+    struct ModelDetails: Decodable {
+        let parentModel: String?
+        let format: String?
+        let family: String?
+        let families: [String]?
+        let parameterSize: String?
+        let quantizationLevel: String?
+
+        enum CodingKeys: String, CodingKey {
+            case parentModel = "parent_model"
+            case format, family, families
+            case parameterSize = "parameter_size"
+            case quantizationLevel = "quantization_level"
+        }
+    }
+
+    /// Converts the `/api/ps` payload into Codenotch limit windows.
+    static func windows(from data: Data) throws -> [LimitWindow] {
+        let decoder = JSONDecoder()
+        let response = try decoder.decode(PSResponse.self, from: data)
+        guard let models = response.models, !models.isEmpty else {
+            // Idle state: Ollama daemon is active, but no model is currently in memory
+            return [
+                LimitWindow(
+                    id: "ollama.idle",
+                    label: "Local Models",
+                    usedFraction: 0,
+                    remaining: nil,
+                    used: nil,
+                    resetsAt: nil
+                )
+            ]
+        }
+
+        var windows: [LimitWindow] = []
+        for (index, m) in models.enumerated() {
+            let expirationDate = m.expiresAt.flatMap(parseISO8601)
+            let memBytes = memoryBytes(for: m)
+            let memGB = Int(memBytes / (1024 * 1024 * 1024))
+            let id = index == 0 ? "ollama.primary" : "ollama.\(m.name)"
+
+            windows.append(LimitWindow(
+                id: id,
+                label: m.name,
+                usedFraction: 1.0, // Active in memory
+                remaining: nil,
+                used: memGB > 0 ? memGB : 1,
+                resetsAt: expirationDate
+            ))
+        }
+        return windows
+    }
+
+    /// Resolves memory bytes, preferring VRAM when > 0, falling back to model size in system RAM.
+    static func memoryBytes(for model: LoadedModel) -> Int64 {
+        if let vram = model.sizeVram, vram > 0 {
+            return vram
+        }
+        return model.size ?? 0
+    }
+
+    /// Formats bytes into a human-readable VRAM or memory size string.
+    static func formatMemory(_ bytes: Int64, isVram: Bool = true) -> String {
+        let label = isVram ? "VRAM" : "RAM"
+        let gb = Double(bytes) / (1024 * 1024 * 1024)
+        if gb >= 1.0 {
+            return String(format: "%.1f GB %@", locale: Locale(identifier: "en_US_POSIX"), gb, label)
+        }
+        let mb = Double(bytes) / (1024 * 1024)
+        return String(format: "%.0f MB %@", locale: Locale(identifier: "en_US_POSIX"), mb, label)
+    }
+
+    /// Formats bytes into a human-readable VRAM string (convenience helper).
+    static func formatVRAM(_ bytes: Int64) -> String {
+        formatMemory(bytes, isVram: true)
+    }
+
+    /// Parses an ISO8601 string, handling fractional seconds or timezone offsets.
+    static func parseISO8601(_ string: String) -> Date? {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        if let d = formatter.date(from: string) { return d }
+        formatter.formatOptions = [.withInternetDateTime]
+        return formatter.date(from: string)
+    }
+}

--- a/Sources/Providers/ProviderGlyph.swift
+++ b/Sources/Providers/ProviderGlyph.swift
@@ -21,6 +21,8 @@ enum ProviderGlyph: String, Codable, Equatable {
     case grok
     case opencode
     case copilot
+    case ollama
+    case ollamaLocal = "ollama-local"
 
     /// If an asset with this name is in the bundle it wins over the traced
     /// outline — drop a PDF/SVG export from Figma in and it is picked up.
@@ -49,6 +51,7 @@ enum ProviderGlyph: String, Codable, Equatable {
         case .opencode: return 0.95
         case .copilot: return 0.96
         case .third:  return 1.0
+        case .ollama, .ollamaLocal: return 0.98
         }
     }
 
@@ -64,6 +67,7 @@ enum ProviderGlyph: String, Codable, Equatable {
         case .grok:   return GlyphOutline.grok
         case .opencode: return GlyphOutline.opencode
         case .copilot: return GlyphOutline.copilot
+        case .ollama, .ollamaLocal: return GlyphOutline.ollama
         }
     }
 }

--- a/Sources/Providers/UsageProvider.swift
+++ b/Sources/Providers/UsageProvider.swift
@@ -41,6 +41,15 @@ protocol UsageProvider {
     /// and no prompt appears. A requirement, not an extension member, for the
     /// reason spelled out above `account()`.
     func forgetCachedCredential()
+    /// Whether this provider should keep a cell or placeholder in the notch when
+    /// its account or daemon is unavailable. Most providers default to `true`
+    /// so users see sign-in guidance; local daemon providers return `false`
+    /// so an inactive service does not take up a ring in the notch.
+    var isVisibleWhenAbsent: Bool { get }
+}
+
+extension UsageProvider {
+    var isVisibleWhenAbsent: Bool { true }
 }
 
 enum UsageProviderError: Error {

--- a/Tests/OllamaLocalUsageTests.swift
+++ b/Tests/OllamaLocalUsageTests.swift
@@ -1,0 +1,135 @@
+import XCTest
+@testable import Codenotch
+
+final class OllamaLocalUsageTests: XCTestCase {
+    private let activeModelJSON = """
+    {
+      "models": [
+        {
+          "name": "llama3.2:3b",
+          "model": "llama3.2:3b",
+          "size": 2019393189,
+          "digest": "a80c4f17acd55704e6c1e309fb13f360ae31d3d6",
+          "expires_at": "2026-09-08T18:06:07.541672-04:00",
+          "size_vram": 2019393189,
+          "details": {
+            "parent_model": "",
+            "format": "gguf",
+            "family": "llama",
+            "families": ["llama"],
+            "parameter_size": "3.2B",
+            "quantization_level": "Q4_K_M"
+          }
+        }
+      ]
+    }
+    """
+
+    private let multiModelJSON = """
+    {
+      "models": [
+        {
+          "name": "qwen2.5-coder:7b",
+          "model": "qwen2.5-coder:7b",
+          "size": 4700000000,
+          "size_vram": 4700000000,
+          "expires_at": "2026-09-08T19:00:00.000Z"
+        },
+        {
+          "name": "deepseek-coder:6.7b",
+          "model": "deepseek-coder:6.7b",
+          "size": 3900000000,
+          "size_vram": 3900000000,
+          "expires_at": "2026-09-08T19:30:00.000Z"
+        }
+      ]
+    }
+    """
+
+    private let idleJSON = """
+    {
+      "models": []
+    }
+    """
+
+    func testActiveSingleModelDecodesCorrectly() throws {
+        let data = activeModelJSON.data(using: .utf8)!
+        let windows = try OllamaLocalUsage.windows(from: data)
+
+        XCTAssertEqual(windows.count, 1)
+        let primary = windows[0]
+        XCTAssertEqual(primary.id, "ollama.primary")
+        XCTAssertEqual(primary.label, "llama3.2:3b")
+        XCTAssertEqual(primary.usedFraction, 1.0)
+        XCTAssertEqual(primary.used, 1) // ~1.88 GB rounds to 1 GB int
+        XCTAssertNotNil(primary.resetsAt)
+    }
+
+    func testMultiModelDecodesAllEntries() throws {
+        let data = multiModelJSON.data(using: .utf8)!
+        let windows = try OllamaLocalUsage.windows(from: data)
+
+        XCTAssertEqual(windows.count, 2)
+        XCTAssertEqual(windows[0].id, "ollama.primary")
+        XCTAssertEqual(windows[0].label, "qwen2.5-coder:7b")
+        XCTAssertEqual(windows[0].used, 4)
+
+        XCTAssertEqual(windows[1].id, "ollama.deepseek-coder:6.7b")
+        XCTAssertEqual(windows[1].label, "deepseek-coder:6.7b")
+        XCTAssertEqual(windows[1].used, 3)
+    }
+
+    func testIdleStateReturnsIdleWindow() throws {
+        let data = idleJSON.data(using: .utf8)!
+        let windows = try OllamaLocalUsage.windows(from: data)
+
+        XCTAssertEqual(windows.count, 1)
+        XCTAssertEqual(windows[0].id, "ollama.idle")
+        XCTAssertEqual(windows[0].label, "Local Models")
+        XCTAssertEqual(windows[0].usedFraction, 0.0)
+        XCTAssertNil(windows[0].resetsAt)
+    }
+
+    func testVRAMFormatting() {
+        XCTAssertEqual(OllamaLocalUsage.formatVRAM(8589934592), "8.0 GB VRAM")
+        XCTAssertEqual(OllamaLocalUsage.formatVRAM(2147483648), "2.0 GB VRAM")
+        XCTAssertEqual(OllamaLocalUsage.formatVRAM(524288000), "500 MB VRAM")
+    }
+
+    func testRAMFormatting() {
+        XCTAssertEqual(OllamaLocalUsage.formatMemory(2561524365, isVram: false), "2.4 GB RAM")
+        XCTAssertEqual(OllamaLocalUsage.formatMemory(524288000, isVram: false), "500 MB RAM")
+    }
+
+    func testCPURAMFallbackWhenVRAMZero() throws {
+        let cpuJSON = """
+        {
+          "models": [
+            {
+              "name": "llama3.2:3b",
+              "model": "llama3.2:3b",
+              "size": 2561524365,
+              "size_vram": 0,
+              "expires_at": "2026-09-08T18:06:07.541672-04:00"
+            }
+          ]
+        }
+        """
+        let data = cpuJSON.data(using: .utf8)!
+        let windows = try OllamaLocalUsage.windows(from: data)
+        XCTAssertEqual(windows.count, 1)
+        XCTAssertEqual(windows[0].label, "llama3.2:3b")
+        XCTAssertEqual(windows[0].used, 2) // ~2.38 GB -> 2 GB
+    }
+
+    func testISO8601DateParsing() {
+        let parsed = OllamaLocalUsage.parseISO8601("2026-09-08T18:06:07.541672-04:00")
+        XCTAssertNotNil(parsed)
+
+        let parsedZulu = OllamaLocalUsage.parseISO8601("2026-09-08T19:00:00Z")
+        XCTAssertNotNil(parsedZulu)
+
+        let invalid = OllamaLocalUsage.parseISO8601("not-a-date")
+        XCTAssertNil(invalid)
+    }
+}


### PR DESCRIPTION
Adds first-class native support for **local on-device Ollama models** running via the Ollama daemon (`http://127.0.0.1:11434/api/ps`).

> [!NOTE]
> Complementing cloud quota tracking (such as PR #66 which meters paid `ollama.com` accounts via API keys), this provider focuses entirely on **offline, on-device models** (`llama3.2`, `deepseek`, `mistral`, `qwen`, etc.) without requiring any API key, account, or internet access.

### Features

1. **Active Model Detection**:
   - Queries `GET /api/ps` to track which models are currently loaded into memory.
   - Shows active model names, memory footprints, and auto-unload countdown timers.
   - Gracefully displays an idle state when the daemon is running but no model is in memory.

2. **Adaptive Memory Formatting (GPU VRAM vs CPU RAM)**:
   - On Apple Silicon / discrete GPUs, displays allocated VRAM (e.g. `2.0 GB VRAM`).
   - On machines running CPU inference where Ollama reports `size_vram: 0` (such as Intel Macs), cleanly falls back to measuring system RAM allocation (e.g. `2.4 GB RAM`).

3. **Dynamic Auto-Hide & Auto-Restore**:
   - Implements `isVisibleWhenAbsent = false` on `OllamaLocalProvider` and adds an ultra-fast (0.2 ms) local socket/NSRunningApplication probe to check if the daemon is alive.
   - When Ollama is quit, Codenotch removes the Ollama ring from the notch.
   - Subscribes to `NSWorkspace.didLaunchApplicationNotification` and `didTerminateApplicationNotification` to immediately restore or hide the ring when Ollama launches or terminates.

4. **Zero-Config Discovery**:
   - Auto-discovers Ollama via `Ollama.app` or CLI binaries (`/usr/local/bin/ollama`, `/opt/homebrew/bin/ollama`). No keychain credentials or manual settings exports needed.

5. **Icon & Outline**:
   - Traced vector silhouette for the Ollama llama icon in `ProviderGlyph.ollamaLocal` / `GlyphOutline.ollama`.

### Tests

- Added comprehensive unit test suite in `Tests/OllamaLocalUsageTests.swift` covering single active models, multi-model setups, idle responses, GPU VRAM formatting, CPU RAM fallback, and ISO-8601 keep-alive parsing.
- All tests pass (`make test`).