### PR TITLE
Add Ollama session activity monitor (live notch ring for active models)

### DIFF
--- a/Sources/App/AppDelegate.swift
+++ b/Sources/App/AppDelegate.swift
@@ -266,7 +266,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             "codex": CodexActivityMonitor(),
             "gemini": AntigravityActivityMonitor(),
             "grok": GrokActivityMonitor(),
-            "gemini-api": GeminiCLIActivityMonitor()
+            "gemini-api": GeminiCLIActivityMonitor(),
+            "ollama": OllamaActivityMonitor(),
+            "ollama-local": OllamaActivityMonitor()
         ]
         for profile in claudeProfiles {
             monitors[profile.id] = ClaudeSessionMonitor(directory: profile.sessionsDirectory)

--- a/Sources/Sessions/OllamaActivityMonitor.swift
+++ b/Sources/Sessions/OllamaActivityMonitor.swift
@@ -1,0 +1,119 @@
+import Combine
+import Foundation
+
+/// Monitors active models running in memory on the local Ollama daemon (`http://127.0.0.1:11434`).
+///
+/// When an LLM is loaded or generating tokens in Ollama, feeds live `AgentSession` records
+/// into Codenotch's inner activity ring.
+@MainActor
+final class OllamaActivityMonitor: ObservableObject, AgentActivityMonitor {
+    @Published private(set) var sessions: [AgentSession] = []
+    var sessionsPublisher: AnyPublisher<[AgentSession], Never> { $sessions.eraseToAnyPublisher() }
+
+    private let endpoint: URL
+    private let interval: TimeInterval
+    private let session: URLSession
+    private var timer: Timer?
+
+    struct PSResponse: Decodable {
+        let models: [LoadedModel]?
+    }
+
+    struct LoadedModel: Decodable {
+        let name: String
+        let model: String?
+        let size: Int64?
+        let sizeVram: Int64?
+        let expiresAt: String?
+
+        enum CodingKeys: String, CodingKey {
+            case name, model, size
+            case sizeVram = "size_vram"
+            case expiresAt = "expires_at"
+        }
+    }
+
+    init(
+        endpoint: URL = URL(string: "http://127.0.0.1:11434/api/ps")!,
+        interval: TimeInterval = 3,
+        session: URLSession? = nil
+    ) {
+        self.endpoint = endpoint
+        self.interval = interval
+        if let session {
+            self.session = session
+        } else {
+            let config = URLSessionConfiguration.ephemeral
+            config.timeoutIntervalForRequest = 2
+            self.session = URLSession(configuration: config)
+        }
+    }
+
+    func start() {
+        poll()
+        let timer = Timer(timeInterval: interval, repeats: true) { [weak self] _ in
+            MainActor.assumeIsolated { self?.poll() }
+        }
+        RunLoop.main.add(timer, forMode: .common)
+        self.timer = timer
+    }
+
+    func stop() {
+        timer?.invalidate()
+        timer = nil
+    }
+
+    private func poll() {
+        Task { [weak self, endpoint, session] in
+            var request = URLRequest(url: endpoint)
+            request.timeoutInterval = 2
+            do {
+                let (data, response) = try await session.data(for: request)
+                guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
+                    await self?.updateSessions([])
+                    return
+                }
+
+                let parsed = try JSONDecoder().decode(PSResponse.self, from: data)
+                let activeSessions = Self.sessions(from: parsed)
+                await self?.updateSessions(activeSessions)
+            } catch {
+                await self?.updateSessions([])
+            }
+        }
+    }
+
+    /// Converts a PSResponse into AgentSession records.
+    static func sessions(from response: PSResponse) -> [AgentSession] {
+        guard let models = response.models else { return [] }
+        return models.map { m in
+            let isVram = (m.sizeVram ?? 0) > 0
+            let bytes = (isVram ? m.sizeVram : nil) ?? m.size ?? 0
+            return AgentSession(
+                id: "ollama.\(m.name)",
+                name: m.name,
+                detail: formatMemory(bytes, isVram: isVram),
+                state: .busy,
+                waitingFor: nil,
+                since: Date(),
+                processID: nil
+            )
+        }
+    }
+
+    /// Formats bytes into a human-readable VRAM or memory size string.
+    static func formatMemory(_ bytes: Int64, isVram: Bool = true) -> String {
+        let label = isVram ? "VRAM" : "RAM"
+        let gb = Double(bytes) / (1024 * 1024 * 1024)
+        if gb >= 1.0 {
+            return String(format: "%.1f GB %@", locale: Locale(identifier: "en_US_POSIX"), gb, label)
+        }
+        let mb = Double(bytes) / (1024 * 1024)
+        return String(format: "%.0f MB %@", locale: Locale(identifier: "en_US_POSIX"), mb, label)
+    }
+
+    private func updateSessions(_ newSessions: [AgentSession]) {
+        guard newSessions != sessions else { return }
+        self.sessions = newSessions
+    }
+}

--- a/Tests/OllamaActivityMonitorTests.swift
+++ b/Tests/OllamaActivityMonitorTests.swift
@@ -1,0 +1,79 @@
+import XCTest
+@testable import Codenotch
+
+final class OllamaActivityMonitorTests: XCTestCase {
+    private let activeModelJSON = """
+    {
+      "models": [
+        {
+          "name": "llama3.2:3b",
+          "model": "llama3.2:3b",
+          "size": 2019393189,
+          "size_vram": 2019393189,
+          "expires_at": "2026-09-08T18:06:07.541672-04:00"
+        }
+      ]
+    }
+    """
+
+    private let cpuModelJSON = """
+    {
+      "models": [
+        {
+          "name": "qwen2.5-coder:7b",
+          "model": "qwen2.5-coder:7b",
+          "size": 4700000000,
+          "size_vram": 0,
+          "expires_at": "2026-09-08T19:00:00.000Z"
+        }
+      ]
+    }
+    """
+
+    private let emptyJSON = """
+    {
+      "models": []
+    }
+    """
+
+    func testActiveModelCreatesBusySession() throws {
+        let data = activeModelJSON.data(using: .utf8)!
+        let parsed = try JSONDecoder().decode(OllamaActivityMonitor.PSResponse.self, from: data)
+        let sessions = OllamaActivityMonitor.sessions(from: parsed)
+
+        XCTAssertEqual(sessions.count, 1)
+        let session = sessions[0]
+        XCTAssertEqual(session.id, "ollama.llama3.2:3b")
+        XCTAssertEqual(session.name, "llama3.2:3b")
+        XCTAssertEqual(session.detail, "1.9 GB VRAM")
+        XCTAssertEqual(session.state, .busy)
+        XCTAssertNil(session.waitingFor)
+    }
+
+    func testCPURAMFallbackFormatting() throws {
+        let data = cpuModelJSON.data(using: .utf8)!
+        let parsed = try JSONDecoder().decode(OllamaActivityMonitor.PSResponse.self, from: data)
+        let sessions = OllamaActivityMonitor.sessions(from: parsed)
+
+        XCTAssertEqual(sessions.count, 1)
+        let session = sessions[0]
+        XCTAssertEqual(session.id, "ollama.qwen2.5-coder:7b")
+        XCTAssertEqual(session.name, "qwen2.5-coder:7b")
+        XCTAssertEqual(session.detail, "4.4 GB RAM")
+        XCTAssertEqual(session.state, .busy)
+    }
+
+    func testEmptyModelsReturnsNoSessions() throws {
+        let data = emptyJSON.data(using: .utf8)!
+        let parsed = try JSONDecoder().decode(OllamaActivityMonitor.PSResponse.self, from: data)
+        let sessions = OllamaActivityMonitor.sessions(from: parsed)
+
+        XCTAssertTrue(sessions.isEmpty)
+    }
+
+    func testMemoryFormatting() {
+        XCTAssertEqual(OllamaActivityMonitor.formatMemory(8589934592, isVram: true), "8.0 GB VRAM")
+        XCTAssertEqual(OllamaActivityMonitor.formatMemory(2147483648, isVram: false), "2.0 GB RAM")
+        XCTAssertEqual(OllamaActivityMonitor.formatMemory(524288000, isVram: false), "500 MB RAM")
+    }
+}


### PR DESCRIPTION
Adds real-time session tracking for local Ollama instances (`http://127.0.0.1:11434/api/ps`) through Codenotch's `AgentActivityMonitor` protocol.

### What it does

- **Live Activity Tracking**: When a local LLM (`llama3.2`, `qwen`, `deepseek`, etc.) is loaded or generating tokens in Ollama, `OllamaActivityMonitor` feeds active `AgentSession` records into Codenotch's inner activity ring, indicating active state.
- **Hardware-Adaptive Detail**: Shows model name and memory footprint in the tooltip / session detail (`X.X GB VRAM` on GPU/Apple Silicon, or `X.X GB RAM` on CPU inference).
- **Graceful Idle/Offline Handling**: When Ollama is idle or stopped, session lists are automatically cleared.
- **Independent & Self-Contained**: Implemented as a standalone activity monitor registered under `"ollama"` and `"ollama-local"`, with zero dependencies on external usage providers or API keys.

### Tests

- Added dedicated unit tests in `Tests/OllamaActivityMonitorTests.swift` covering single active models, CPU RAM fallback, empty idle states, and memory formatting.