### PR TITLE
Detect OpenCode GLM key stored under provider id 'glm'

### DIFF
--- a/Sources/Providers/GLMCredentials.swift
+++ b/Sources/Providers/GLMCredentials.swift
@@ -135,7 +135,7 @@ enum GLMCredentials {
     // MARK: OpenCode
 
     /// The provider names OpenCode's own sign-in writes, most specific first.
-    private static let openCodeProviderIDs = ["zai-coding-plan", "zai", "z-ai", "z.ai", "zhipu", "zhipuai"]
+    private static let openCodeProviderIDs = ["zai-coding-plan", "zai", "z-ai", "z.ai", "glm", "zhipu", "zhipuai"]
 
     static func openCode(_ url: URL) -> Credential? {
         guard let root = dictionary(at: url) else { return nil }


### PR DESCRIPTION
Adds `glm` to `openCodeProviderIDs` so codenotch detects a GLM Coding Plan key that OpenCode stores under provider id `glm`.

Fixes #73.

## Problem

`GLMCredentials.openCode(...)` scans a fixed set of OpenCode provider ids. Some OpenCode setups write the GLM Coding Plan key under provider id `glm`:

```json
// ~/.local/share/opencode/auth.json
{ "glm": { "type": "api", "key": "<redacted>" } }
```

That id was not in the list, so the credential was never found and the GLM row stayed empty even though the key is valid.

## Change

```diff
-    private static let openCodeProviderIDs = ["zai-coding-plan", "zai", "z-ai", "z.ai", "zhipu", "zhipuai"]
+    private static let openCodeProviderIDs = ["zai-coding-plan", "zai", "z-ai", "z.ai", "glm", "zhipu", "zhipuai"]
```

`glm` has no `zhipu` prefix, so `console(forProviderID:)` routes it to the global `api.z.ai` console, which is correct for a global GLM Coding Plan key.

## Verification

The key found under `glm` authenticates against the console codenotch queries:

```
GET https://api.z.ai/api/monitor/usage/quota/limit
Authorization: <key>
-> HTTP 200
{"code":200,"data":{"limits":[{"type":"CREDIT_LIMIT","unit":3,...},{"type":"CREDIT_LIMIT","unit":6,...}],"level":"pro"},"success":true}
```

After adding the id, the GLM ring populates from that response. One-line change, no behavior change for the existing ids.
