### PR TITLE
Show Grok weekly pool ring when currentPeriod has no percent yet

### DIFF
--- a/Sources/Providers/GrokUsage.swift
+++ b/Sources/Providers/GrokUsage.swift
@@ -54,6 +54,23 @@ enum GrokUsage {
             }
         }
 
+        // A weekly plan pool (X Premium+, SuperGrok) states its window in
+        // `currentPeriod` and omits `creditUsagePercent`/`productUsage` until
+        // usage lands, so the branches above find nothing on a fresh period.
+        // Grok's own `/usage` still shows this as a "Weekly limit" bar at 0%
+        // with the period end as the reset, so mirror it rather than reporting
+        // the account as unmetered.
+        if windows.isEmpty,
+           let weekly = period(credits["currentPeriod"]),
+           (weekly["type"] as? String).map({ $0.contains("WEEKLY") }) == true {
+            windows.append(LimitWindow(
+                id: "credits",
+                label: "Weekly limit",
+                usedFraction: 0,
+                resetsAt: date(weekly["end"]) ?? creditsReset
+            ))
+        }
+
         guard !windows.isEmpty else {
             throw UsageProviderError.nothingMetered("Grok has nothing metered on this account yet")
         }

--- a/Tests/GrokUsageTests.swift
+++ b/Tests/GrokUsageTests.swift
@@ -68,6 +68,29 @@ final class GrokUsageTests: XCTestCase {
         XCTAssertEqual(snap.usedFraction ?? -1, 0.33, accuracy: 0.0001)
     }
 
+    /// An X Premium+ / SuperGrok weekly pool states its window in
+    /// `currentPeriod` but carries no `creditUsagePercent` or `productUsage`
+    /// until usage lands. Grok's own `/usage` draws a "Weekly limit" bar at 0%
+    /// here, so this is a zero reading, not an absent one.
+    func testWeeklyPoolWithoutAPercentIsAZeroRing() throws {
+        let weeklyOnly = """
+        {"config":{"currentPeriod":{"type":"USAGE_PERIOD_TYPE_WEEKLY",\
+        "start":"2026-09-07T20:59:12+00:00",\
+        "end":"2026-09-14T20:59:12+00:00"},\
+        "onDemandCap":{"val":0},"onDemandUsed":{"val":0},\
+        "isUnifiedBillingUser":true,"prepaidBalance":{"val":0}}}
+        """
+        let w = try GrokUsage.windows(creditsJSON: weeklyOnly)
+        let credits = try XCTUnwrap(w.first { $0.id == "credits" })
+        XCTAssertEqual(credits.label, "Weekly limit")
+        XCTAssertEqual(credits.usedFraction ?? -1, 0, accuracy: 0.0001)
+        let reset = try XCTUnwrap(credits.resetsAt)
+        var utc = Calendar(identifier: .gregorian)
+        utc.timeZone = TimeZone(identifier: "UTC")!
+        XCTAssertEqual(utc.component(.month, from: reset), 9)
+        XCTAssertEqual(utc.component(.day, from: reset), 14)
+    }
+
     func testGarbageIsABadResponseRatherThanAGuess() {
         XCTAssertThrowsError(try GrokUsage.windows(creditsJSON: "not json")) { error in
             guard case UsageProviderError.badResponse = error else {


### PR DESCRIPTION
Draws the Grok weekly ring for accounts whose weekly pool is stated in `currentPeriod` with no `creditUsagePercent`/`productUsage` yet (X Premium+ / SuperGrok). Addresses #17.

## Problem

`GrokLocalProvider` reads `~/.grok/auth.json` and gets HTTP 200 from `cli-chat-proxy.grok.com/v1/billing?format=credits`, but for an X Premium+ weekly pool the response carries a weekly `currentPeriod` window and no `creditUsagePercent` and no `productUsage` until usage lands. `GrokUsage.windows(...)` then finds no window and throws `nothingMetered`, so the cell is blank.

Grok's own `/usage` shows this exact account as:

```
Weekly limit (X Premium+)
[                    ] 0%
Resets: September 14, 16:59
```

i.e. a 0% weekly bar with the period end as the reset. Codenotch had the same response in hand but treated a fresh (0%) period as an unmetered account.

Observed response for such an account:

```
config.currentPeriod.type   = USAGE_PERIOD_TYPE_WEEKLY
config.currentPeriod.end    = 2026-09-14T20:59:12+00:00   (= Sep 14 16:59 local, matches /usage)
config.onDemandCap.val      = 0
config.onDemandUsed.val     = 0
config.isUnifiedBillingUser = true
config.prepaidBalance.val   = 0
```

No `creditUsagePercent`, no `productUsage`.

## Change

`GrokUsage.windows(...)`: after the existing `creditUsagePercent` and `productUsage` branches produce nothing, if a weekly `currentPeriod` is present, emit a `credits` window at `usedFraction: 0` labelled `Weekly limit`, resetting at the period end. The existing `nothingMetered` guard still fires for a genuinely empty config (no `currentPeriod`), so `testAnEmptyConfigIsNotASuccessfulReading` is unchanged.

This mirrors what grok itself renders, rather than reaching for the weekly-pool total through a signed-in WebView (the approach in the closed #10). When usage lands and `creditUsagePercent` appears, the existing branch takes over and the ring fills.

## Tests

Added `testWeeklyPoolWithoutAPercentIsAZeroRing`: a weekly-`currentPeriod`, no-percent config yields one `credits` window, `label == "Weekly limit"`, `usedFraction == 0`, reset on Sep 14. Existing tests (percent ring, product-only ring, empty-config throws, garbage throws) unchanged.
