### PR TITLE
Detect Claude Code sessions launched from the Claude desktop app

### DIFF
--- a/Sources/App/AppDelegate.swift
+++ b/Sources/App/AppDelegate.swift
@@ -191,7 +191,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             "gemini": AntigravityActivityMonitor()
         ]
         for profile in claudeProfiles {
-            monitors[profile.id] = ClaudeSessionMonitor(directory: profile.sessionsDirectory)
+            monitors[profile.id] = ClaudeSessionMonitor(
+                directory: profile.sessionsDirectory,
+                projects: profile.projectsDirectory
+            )
         }
         for (id, monitor) in monitors {
             monitor.sessionsPublisher

--- a/Sources/Providers/ClaudeProfile.swift
+++ b/Sources/Providers/ClaudeProfile.swift
@@ -117,6 +117,11 @@ struct ClaudeProfile: Equatable, Hashable {
     /// Where Claude Code writes one file per running process.
     var sessionsDirectory: URL { configDirectory.appendingPathComponent("sessions") }
 
+    /// Where it writes each session's transcript, one directory per working
+    /// directory. The registry says which sessions exist; this says what they
+    /// are doing — see `ClaudeTranscript`.
+    var projectsDirectory: URL { configDirectory.appendingPathComponent("projects") }
+
     /// The keychain service the OAuth token is filed under.
     ///
     /// The default directory uses the bare name. Any other `CLAUDE_CONFIG_DIR`

--- a/Sources/Sessions/ClaudeSessionMonitor.swift
+++ b/Sources/Sessions/ClaudeSessionMonitor.swift
@@ -6,10 +6,12 @@ import Foundation
 /// default — and publishes the Claude Code sessions that are actually running.
 /// One monitor per `ClaudeProfile`; see `AppDelegate`.
 ///
-/// The directory is watched rather than polled, because Claude Code writes a
-/// session file the moment its state changes — so "Claude just finished" shows
-/// up immediately. A slow timer runs alongside purely to notice processes that
-/// died without touching the directory, which no file event will ever report.
+/// The directory is watched rather than polled, because a session file appears
+/// and disappears the moment a session starts and stops. The timer alongside it
+/// covers the two things no file event will report: a process that died without
+/// touching the directory, and — for sessions the Claude desktop app hosts —
+/// what the session is *doing*, which is not in the directory at all and has to
+/// be read from the transcript. See `ClaudeTranscript` for why.
 @MainActor
 final class ClaudeSessionMonitor: ObservableObject, AgentActivityMonitor {
     @Published private(set) var sessions: [AgentSession] = []
@@ -17,6 +19,9 @@ final class ClaudeSessionMonitor: ObservableObject, AgentActivityMonitor {
 
     private let directory: URL
     private let livenessInterval: TimeInterval
+    /// Nil leaves the monitor reading nothing but the registry, which is what
+    /// the tests that only care about the registry want.
+    private let transcripts: ClaudeTranscriptReader?
 
     private var source: DispatchSourceFileSystemObject?
     private var descriptor: CInt = -1
@@ -24,13 +29,20 @@ final class ClaudeSessionMonitor: ObservableObject, AgentActivityMonitor {
     private var debounce: DispatchWorkItem?
     private var wakeObserver: NSObjectProtocol?
 
+    /// `livenessInterval` doubles as how often a running session's transcript
+    /// is looked at, so it matches the Codex monitor's two seconds rather than
+    /// the five it used when the registry was the only thing being read. The
+    /// cost of a tick is a `stat` per live session; the tail is read only when
+    /// the file has grown.
     init(
         directory: URL = URL(fileURLWithPath: NSHomeDirectory())
             .appendingPathComponent(".claude/sessions"),
-        livenessInterval: TimeInterval = 5
+        projects: URL? = nil,
+        livenessInterval: TimeInterval = 2
     ) {
         self.directory = directory
         self.livenessInterval = livenessInterval
+        self.transcripts = projects.map { ClaudeTranscriptReader(projects: $0) }
     }
 
     func start() {
@@ -82,24 +94,67 @@ final class ClaudeSessionMonitor: ObservableObject, AgentActivityMonitor {
     }
 
     private func rescan() {
-        let found = Self.read(directory: directory)
+        let found = Self.read(directory: directory, transcripts: transcripts)
         guard found != sessions else { return }   // don't churn SwiftUI for nothing
+        // Only on a change, so this is a handful of lines an hour rather than a
+        // firehose. It is the one way to see what the notch thinks is running
+        // without hovering over it:
+        //
+        //     log stream --predicate 'category == "sessions"' --level debug
+        let summary = found.map { "\($0.name)=\($0.state)" }.joined(separator: " ")
+        Log.sessions.debug("\(ClaudeProfile.tilde(self.directory.path), privacy: .public): \(summary, privacy: .public)")
         sessions = found
     }
 
-    static func read(directory: URL) -> [AgentSession] {
+    static func read(directory: URL,
+                     transcripts: ClaudeTranscriptReader? = nil) -> [AgentSession] {
         let names = (try? FileManager.default.contentsOfDirectory(atPath: directory.path)) ?? []
-        return names
+        let live = names
             .filter { $0.hasSuffix(".json") }
-            .compactMap { name -> AgentSession? in
+            .compactMap { name -> ClaudeSessionRecord? in
                 let url = directory.appendingPathComponent(name)
                 guard let data = try? Data(contentsOf: url),
                       let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
                       let record = ClaudeSessionRecord(json: json),
                       ProcessLiveness.isAlive(pid: record.pid, startedAt: record.startedAt)
                 else { return nil }
-                return record.session
+                return record
             }
-            .sorted { $0.since > $1.since }
+        return deduplicated(live)
+            .map { record in state(of: record, transcripts: transcripts) }
+            // The id breaks ties so the order cannot flicker between two ticks
+            // that read the same thing.
+            .sorted { $0.since == $1.since ? $0.id < $1.id : $0.since > $1.since }
+    }
+
+    /// The record's own answer where it has one, the transcript's where it does
+    /// not. Desktop sessions always take the second path; terminal ones never
+    /// do, which is what keeps their `waiting` state — the one thing only the
+    /// terminal interface knows — exactly as it was.
+    static func state(of record: ClaudeSessionRecord,
+                      transcripts: ClaudeTranscriptReader?) -> AgentSession {
+        guard !record.reportsStatus,
+              let sessionID = record.sessionID,
+              let activity = transcripts?.activity(sessionID: sessionID, cwd: record.cwd)
+        else { return record.session }
+        return record.session(state: activity.turn == .inFlight ? .busy : .idle,
+                              since: activity.since)
+    }
+
+    /// One session can hold two registry records at once: resuming after a
+    /// crash registers a new pid while the old process is still winding down,
+    /// and for a moment both files pass the liveness check. Claude Code settles
+    /// this by keeping the most recently started record, so the notch does the
+    /// same rather than drawing one session twice.
+    static func deduplicated(_ records: [ClaudeSessionRecord]) -> [ClaudeSessionRecord] {
+        var newest: [String: ClaudeSessionRecord] = [:]
+        var unidentified: [ClaudeSessionRecord] = []
+        for record in records {
+            guard let id = record.sessionID else { unidentified.append(record); continue }
+            let candidate = record.startedAt ?? .distantPast
+            if let held = newest[id], (held.startedAt ?? .distantPast) >= candidate { continue }
+            newest[id] = record
+        }
+        return Array(newest.values) + unidentified
     }
 }

--- a/Sources/Sessions/ClaudeSessionRecord.swift
+++ b/Sources/Sessions/ClaudeSessionRecord.swift
@@ -9,6 +9,18 @@ struct ClaudeSessionRecord {
     let pid: Int32
     /// Roughly when the process started. Only used to notice a recycled pid.
     let startedAt: Date?
+    /// The session's own id, which is what names its transcript.
+    let sessionID: String?
+    /// Where it is running. The transcript is filed under this.
+    let cwd: String
+    /// Whether the record said anything the monitor understands about what the
+    /// session is doing.
+    ///
+    /// False for every session the Claude desktop app hosts: Claude Code fills
+    /// `status` in from its terminal interface, which a desktop session does
+    /// not have. That is the flag that sends the monitor to the transcript
+    /// instead — see `ClaudeTranscript`.
+    let reportsStatus: Bool
     let session: AgentSession
 
     /// Decoded leniently on purpose: the file is written by another program on
@@ -21,16 +33,24 @@ struct ClaudeSessionRecord {
         let raw = json["status"] as? String
         let tempo = json["tempo"] as? String        // the normalised form, when present
         let state: AgentSession.State
+        // `reportsStatus` is about whether the record *said* something, not
+        // about what it said: a word neither of us knows is no more use than no
+        // word at all, and both are better answered by the transcript.
+        let reportsStatus: Bool
         switch (tempo, raw) {
-        case ("blocked", _), (_, "waiting"): state = .waiting
-        case ("active", _), (_, "busy"):     state = .busy
-        default:                             state = .idle
+        case ("blocked", _), (_, "waiting"): (state, reportsStatus) = (.waiting, true)
+        case ("active", _), (_, "busy"):     (state, reportsStatus) = (.busy, true)
+        case ("idle", _), (_, "idle"):       (state, reportsStatus) = (.idle, true)
+        default:                             (state, reportsStatus) = (.idle, false)
         }
 
         let millis = (json["statusUpdatedAt"] as? NSNumber)?.doubleValue
             ?? (json["updatedAt"] as? NSNumber)?.doubleValue
 
         self.pid = pid
+        self.sessionID = json["sessionId"] as? String
+        self.cwd = cwd
+        self.reportsStatus = reportsStatus
         if let started = (json["startedAt"] as? NSNumber)?.doubleValue {
             self.startedAt = Date(timeIntervalSince1970: started / 1000)
         } else {
@@ -44,8 +64,24 @@ struct ClaudeSessionRecord {
             detail: "\(Self.surface(json["entrypoint"] as? String)) · \(folder)",
             state: state,
             waitingFor: (json["waitingFor"] as? String) ?? (json["needs"] as? String),
-            since: millis.map { Date(timeIntervalSince1970: $0 / 1000) } ?? Date()
+            // `startedAt` before the clock, because a desktop record carries
+            // neither `statusUpdatedAt` nor `updatedAt` and `Date()` is a
+            // different answer on every rescan — which makes the session look
+            // changed twice a second and sets the notch animating over and
+            // over. When the transcript is readable it replaces this anyway;
+            // this is what holds still until it is.
+            since: millis.map { Date(timeIntervalSince1970: $0 / 1000) }
+                ?? self.startedAt ?? Date()
         )
+    }
+
+    /// The same session, in a state read from somewhere other than the record.
+    ///
+    /// `waitingFor` is dropped on purpose: the only states that reach here come
+    /// from the transcript, and the transcript cannot see a permission prompt.
+    func session(state: AgentSession.State, since: Date) -> AgentSession {
+        AgentSession(id: session.id, name: session.name, detail: session.detail,
+                     state: state, waitingFor: nil, since: since)
     }
 
     static func surface(_ entrypoint: String?) -> String {

--- a/Sources/Sessions/ClaudeTranscript.swift
+++ b/Sources/Sessions/ClaudeTranscript.swift
@@ -1,0 +1,224 @@
+import Foundation
+
+/// What a Claude Code session is doing, read from its transcript.
+///
+/// Claude Code writes `status` into `~/.claude/sessions/<pid>.json` from one
+/// place only: an effect inside the terminal interface's render loop. A session
+/// hosted by the Claude desktop app runs the same binary with no terminal
+/// interface, so that effect never fires and the record carries no status at
+/// all — which is why every desktop session read as permanently idle, and why
+/// the usage ring never polled hard while one was working.
+///
+/// The transcript is the other thing Claude Code writes, and the engine writes
+/// it rather than the interface, so it is there for both surfaces:
+/// `~/.claude/projects/<slug>/<sessionId>.jsonl`, one JSON object per line,
+/// appended as the turn goes.
+enum ClaudeTranscript {
+    /// Whether the session is mid-turn.
+    ///
+    /// Two cases and not three, deliberately. Nothing in the transcript
+    /// separates a tool waiting on your permission from a tool that is simply
+    /// taking its time — there is no record for a permission prompt — so this
+    /// never claims `waiting`. Only the terminal interface knows that, and only
+    /// the terminal interface writes it to the registry.
+    enum Turn: Equatable { case inFlight, finished }
+
+    /// How much of the end of the file to look at. The last few records settle
+    /// it, and these transcripts run to megabytes.
+    static let tailBytes = 64 * 1024
+
+    // MARK: - Where the file is
+
+    /// The directory Claude Code files a working directory's transcripts under:
+    /// the path with every `/` and `.` turned into `-`, so
+    /// `/Users/x/app/.claude/worktrees/y` becomes
+    /// `-Users-x-app--claude-worktrees-y`.
+    static func projectSlug(forCWD cwd: String) -> String {
+        String(cwd.map { $0 == "/" || $0 == "." ? "-" : $0 })
+    }
+
+    /// The transcript for one session, or nil if it has not been written yet.
+    ///
+    /// `scanning` is what makes this affordable to call on a timer: the slug is
+    /// derived from the session's own `cwd` and is right almost always, so the
+    /// usual cost is a single `stat`. The directory scan is the fallback for a
+    /// session that has moved since it started — resumed in a worktree, say —
+    /// and keeps its transcript where it was first written.
+    static func transcript(
+        forSessionID sessionID: String,
+        cwd: String,
+        in projects: URL,
+        scanning: Bool,
+        fileManager: FileManager = .default
+    ) -> URL? {
+        let file = sessionID + ".jsonl"
+        let direct = projects
+            .appendingPathComponent(projectSlug(forCWD: cwd))
+            .appendingPathComponent(file)
+        if fileManager.fileExists(atPath: direct.path) { return direct }
+        guard scanning else { return nil }
+
+        let folders = (try? fileManager.contentsOfDirectory(atPath: projects.path)) ?? []
+        for folder in folders {
+            let candidate = projects
+                .appendingPathComponent(folder)
+                .appendingPathComponent(file)
+            if fileManager.fileExists(atPath: candidate.path) { return candidate }
+        }
+        return nil
+    }
+
+    // MARK: - What it says
+
+    static func turn(at url: URL, bytes: Int = tailBytes) -> Turn? {
+        tail(of: url, bytes: bytes).flatMap(turn(inTail:))
+    }
+
+    /// The last records of the file, without reading the rest of it.
+    static func tail(of url: URL, bytes: Int = tailBytes) -> Data? {
+        guard let handle = try? FileHandle(forReadingFrom: url) else { return nil }
+        defer { try? handle.close() }
+        guard let end = try? handle.seekToEnd() else { return nil }
+        let start = end > UInt64(bytes) ? end - UInt64(bytes) : 0
+        guard (try? handle.seek(toOffset: start)) != nil else { return nil }
+        return try? handle.readToEnd()
+    }
+
+    /// The state machine, kept pure so it can be tested without a file.
+    ///
+    /// Only `user` and `assistant` lines are allowed to decide. The transcript
+    /// also carries bookkeeping — `bridge-session`, `atis-latch`, `frame-link`,
+    /// `custom-title` and more — which Claude Code keeps appending while a
+    /// session sits doing nothing. That is why "was the file touched recently",
+    /// which is all the Codex monitor can manage, is not good enough here: on
+    /// this Mac it reported a session that had been parked for an hour as
+    /// working. An allow-list rather than a list of kinds to skip, because the
+    /// bookkeeping kinds are added to between releases.
+    ///
+    /// Nil when the tail holds no conversation at all — a session that has been
+    /// opened and not yet used. The caller leaves such a session as it found it
+    /// rather than guessing.
+    static func turn(inTail data: Data) -> Turn? {
+        let lines = data.split(separator: UInt8(ascii: "\n"), omittingEmptySubsequences: true)
+        for line in lines.reversed() {
+            // The first line of the tail is usually cut in half; it fails to
+            // parse and is skipped, which is the whole handling it needs.
+            guard let json = (try? JSONSerialization.jsonObject(with: Data(line)))
+                    as? [String: Any] else { continue }
+            // A subagent's records are interleaved with its parent's, and the
+            // parent's turn is the one being reported on.
+            if json["isSidechain"] as? Bool == true { continue }
+
+            switch json["type"] as? String {
+            case "assistant":
+                // `tool_use` is the only stop reason that means the turn goes
+                // on; `end_turn`, `stop_sequence` and `max_tokens` all end it.
+                let message = json["message"] as? [String: Any]
+                return message?["stop_reason"] as? String == "tool_use" ? .inFlight : .finished
+            case "user":
+                return isInterruption(json) ? .finished : .inFlight
+            default:
+                continue
+            }
+        }
+        return nil
+    }
+
+    /// Pressing Esc writes a user turn saying so, which is what makes "stopped"
+    /// something the notch can know rather than wait out with a timeout. Two
+    /// wordings exist, and both start the same way.
+    private static let interruption = "[Request interrupted by user"
+
+    static func isInterruption(_ json: [String: Any]) -> Bool {
+        guard let message = json["message"] as? [String: Any] else { return false }
+        switch message["content"] {
+        case let text as String:
+            return text.hasPrefix(interruption)
+        case let blocks as [Any]:
+            return blocks.contains { block in
+                ((block as? [String: Any])?["text"] as? String)?.hasPrefix(interruption) == true
+            }
+        default:
+            return false
+        }
+    }
+}
+
+/// Reads transcripts on a timer, and remembers enough not to read them twice.
+///
+/// One instance per monitor. A tick that finds a transcript untouched since the
+/// last one costs a `stat` and nothing else — the tail is read only when the
+/// file has actually grown.
+final class ClaudeTranscriptReader {
+    private struct Cached {
+        let modified: Date
+        let size: UInt64
+        let turn: ClaudeTranscript.Turn?
+    }
+
+    private let projects: URL
+    private let fileManager: FileManager
+    /// Where each session's transcript turned out to be. Sessions come and go;
+    /// this is bounded by how many have run since the app launched.
+    private var paths: [String: URL] = [:]
+    private var cache: [String: Cached] = [:]
+    /// When each session last changed what it was doing.
+    ///
+    /// The transcript's timestamp is when it was last *appended to*, which
+    /// moves every few seconds through a long turn. Reported as-is it would
+    /// hold the tooltip's elapsed time at zero for as long as the session
+    /// worked, and hand the notch a new value to animate on every tick. What
+    /// the notch means by `since` is when the state was entered, so the moment
+    /// of the change is kept and the appends in between are ignored.
+    private var entered: [String: (turn: ClaudeTranscript.Turn, at: Date)] = [:]
+    /// Sessions already looked for the hard way and not found. The directory
+    /// scan is worth doing once for a session that has moved, and never worth
+    /// repeating every two seconds for one that simply has no transcript.
+    private var scanned: Set<String> = []
+
+    init(projects: URL, fileManager: FileManager = .default) {
+        self.projects = projects
+        self.fileManager = fileManager
+    }
+
+    /// What the session is doing, and when it last moved. Nil when there is no
+    /// transcript to read, or nothing said in it yet.
+    func activity(sessionID: String, cwd: String) -> (turn: ClaudeTranscript.Turn, since: Date)? {
+        guard let url = path(sessionID: sessionID, cwd: cwd),
+              let attributes = try? fileManager.attributesOfItem(atPath: url.path),
+              let modified = attributes[.modificationDate] as? Date
+        else { return nil }
+        let size = (attributes[.size] as? NSNumber)?.uint64Value ?? 0
+
+        let turn: ClaudeTranscript.Turn?
+        if let cached = cache[sessionID], cached.modified == modified, cached.size == size {
+            turn = cached.turn
+        } else {
+            turn = ClaudeTranscript.turn(at: url)
+            cache[sessionID] = Cached(modified: modified, size: size, turn: turn)
+        }
+
+        guard let turn else { return nil }
+        if let previous = entered[sessionID], previous.turn == turn {
+            return (turn, previous.at)
+        }
+        // First sight of a change, so the file's own timestamp is the closest
+        // thing there is to when it happened.
+        entered[sessionID] = (turn, modified)
+        return (turn, modified)
+    }
+
+    private func path(sessionID: String, cwd: String) -> URL? {
+        if let known = paths[sessionID] { return known }
+        let scanning = !scanned.contains(sessionID)
+        guard let found = ClaudeTranscript.transcript(
+            forSessionID: sessionID, cwd: cwd, in: projects,
+            scanning: scanning, fileManager: fileManager
+        ) else {
+            if scanning { scanned.insert(sessionID) }
+            return nil
+        }
+        paths[sessionID] = found
+        return found
+    }
+}

--- a/Tests/ClaudeSessionTests.swift
+++ b/Tests/ClaudeSessionTests.swift
@@ -92,3 +92,163 @@ final class ClaudeSessionRecordTests: XCTestCase {
         XCTAssertEqual(try XCTUnwrap(r.startedAt).timeIntervalSince1970, 1787894126.697, accuracy: 0.01)
     }
 }
+
+/// Which source gets to say what a session is doing.
+///
+/// Claude Code fills `status` in from its terminal interface, so a terminal
+/// session's record answers for itself and a desktop session's never does. The
+/// split has to hold in both directions: the desktop case is the bug being
+/// fixed, and the terminal case is the behaviour that must not change —
+/// `waiting` in particular, which nothing but the terminal interface can know.
+@MainActor
+final class ClaudeSessionStateSourceTests: XCTestCase {
+    private var projects: URL!
+
+    override func setUpWithError() throws {
+        projects = FileManager.default.temporaryDirectory
+            .appendingPathComponent("sessions-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: projects, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: projects)
+    }
+
+    private func record(_ json: String) throws -> ClaudeSessionRecord {
+        let object = try XCTUnwrap(
+            try JSONSerialization.jsonObject(with: Data(json.utf8)) as? [String: Any]
+        )
+        return try XCTUnwrap(ClaudeSessionRecord(json: object))
+    }
+
+    private func writeTranscript(_ body: String, session: String, cwd: String) throws {
+        let directory = projects
+            .appendingPathComponent(ClaudeTranscript.projectSlug(forCWD: cwd))
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        try Data(body.utf8).write(to: directory.appendingPathComponent("\(session).jsonl"))
+    }
+
+    private var reader: ClaudeTranscriptReader { ClaudeTranscriptReader(projects: projects) }
+
+    /// The real shape of a desktop session's file, trimmed. No status, no
+    /// tempo, no `statusUpdatedAt` — and the file is written once, when the
+    /// session starts, so its own timestamp says nothing either.
+    private let desktop = """
+    { "pid": 26440, "sessionId": "0b24b489", "cwd": "/Users/vinz/app",
+      "startedAt": 1788731755247, "procStart": "Sun Sep  6 21:55:54 2026",
+      "kind": "interactive", "entrypoint": "claude-desktop", "name": "app-6c",
+      "messagingSocketPath": "/tmp/cc-socks/26440.sock" }
+    """
+
+    func testADesktopRecordAdmitsItSaysNothingAboutState() throws {
+        let desktop = try record(desktop)
+        XCTAssertFalse(desktop.reportsStatus)
+        XCTAssertEqual(desktop.sessionID, "0b24b489")
+        XCTAssertEqual(desktop.cwd, "/Users/vinz/app")
+        XCTAssertEqual(desktop.session.detail, "Desktop · app")
+
+        let terminal = try record(#"{ "pid": 1, "cwd": "/tmp/x", "status": "busy" }"#)
+        XCTAssertTrue(terminal.reportsStatus)
+    }
+
+    /// A word neither of us knows is worth no more than no word at all, so it
+    /// goes to the transcript too.
+    func testAnUnrecognisedStatusIsNotAnAnswer() throws {
+        XCTAssertFalse(try record(#"{ "pid": 1, "cwd": "/tmp/x", "status": "hibernating" }"#)
+            .reportsStatus)
+        XCTAssertTrue(try record(#"{ "pid": 1, "cwd": "/tmp/x", "status": "idle" }"#)
+            .reportsStatus)
+    }
+
+    func testADesktopSessionTakesItsStateFromTheTranscript() throws {
+        try writeTranscript(#"{"type":"assistant","message":{"stop_reason":"tool_use"}}"#,
+                            session: "0b24b489", cwd: "/Users/vinz/app")
+        let session = ClaudeSessionMonitor.state(of: try record(desktop), transcripts: reader)
+        XCTAssertEqual(session.state, .busy)
+        XCTAssertEqual(session.id, "claude.26440")
+    }
+
+    func testADesktopSessionThatFinishedItsTurnIsIdle() throws {
+        try writeTranscript(#"{"type":"assistant","message":{"stop_reason":"end_turn"}}"#,
+                            session: "0b24b489", cwd: "/Users/vinz/app")
+        XCTAssertEqual(
+            ClaudeSessionMonitor.state(of: try record(desktop), transcripts: reader).state, .idle
+        )
+    }
+
+    /// With no transcript to read, the record's own answer stands — which is
+    /// exactly what the notch did before any of this existed.
+    func testWithNoTranscriptTheRecordStands() throws {
+        XCTAssertEqual(
+            ClaudeSessionMonitor.state(of: try record(desktop), transcripts: reader).state, .idle
+        )
+        XCTAssertEqual(
+            ClaudeSessionMonitor.state(of: try record(desktop), transcripts: nil).state, .idle
+        )
+    }
+
+    /// The behaviour that must not regress: a terminal session says `waiting`,
+    /// and the transcript — which cannot see a permission prompt at all — is
+    /// never allowed to talk it out of that.
+    func testATerminalSessionKeepsItsOwnStateAndItsWaitingFor() throws {
+        let waiting = try record("""
+        { "pid": 7, "sessionId": "0b24b489", "cwd": "/Users/vinz/app",
+          "status": "waiting", "waitingFor": "permission" }
+        """)
+        try writeTranscript(#"{"type":"assistant","message":{"stop_reason":"tool_use"}}"#,
+                            session: "0b24b489", cwd: "/Users/vinz/app")
+        let session = ClaudeSessionMonitor.state(of: waiting, transcripts: reader)
+        XCTAssertEqual(session.state, .waiting)
+        XCTAssertEqual(session.waitingFor, "permission")
+    }
+
+    // MARK: - Deduplication
+
+    /// Resuming after a crash registers a new pid while the old process is
+    /// still winding down, and for a moment both files are live. One session
+    /// must not be drawn twice.
+    func testTheSameSessionUnderTwoPidsIsDrawnOnce() throws {
+        let old = try record("""
+        { "pid": 1, "sessionId": "same", "cwd": "/tmp/x", "startedAt": 1000000 }
+        """)
+        let new = try record("""
+        { "pid": 2, "sessionId": "same", "cwd": "/tmp/x", "startedAt": 2000000 }
+        """)
+        for pair in [[old, new], [new, old]] {
+            let kept = ClaudeSessionMonitor.deduplicated(pair)
+            XCTAssertEqual(kept.count, 1)
+            XCTAssertEqual(kept.first?.pid, 2, "the most recently started record wins")
+        }
+    }
+
+    func testDifferentSessionsAreAllKept() throws {
+        let a = try record(#"{ "pid": 1, "sessionId": "a", "cwd": "/tmp/x" }"#)
+        let b = try record(#"{ "pid": 2, "sessionId": "b", "cwd": "/tmp/x" }"#)
+        XCTAssertEqual(ClaudeSessionMonitor.deduplicated([a, b]).count, 2)
+    }
+
+    /// A record old enough to have no session id cannot be matched against
+    /// anything, so it is kept rather than dropped or merged.
+    func testRecordsWithoutASessionIdAreKept() throws {
+        let a = try record(#"{ "pid": 1, "cwd": "/tmp/x" }"#)
+        let b = try record(#"{ "pid": 2, "cwd": "/tmp/x" }"#)
+        XCTAssertEqual(ClaudeSessionMonitor.deduplicated([a, b]).count, 2)
+    }
+}
+
+/// A record with nothing to date itself by must still answer the same thing
+/// twice. It used to answer `Date()`, so every rescan produced a session that
+/// compared unequal to the one before it and the notch re-animated at 2 Hz.
+extension ClaudeSessionRecordTests {
+    func testARecordWithNoTimestampHoldsStill() throws {
+        let json = """
+        { "pid": 1, "sessionId": "a", "cwd": "/tmp/x", "startedAt": 1788731755247,
+          "entrypoint": "claude-desktop" }
+        """
+        let first = try XCTUnwrap(session(json))
+        let second = try XCTUnwrap(session(json))
+        XCTAssertEqual(first.since, second.since)
+        XCTAssertEqual(first, second)
+        XCTAssertEqual(first.since.timeIntervalSince1970, 1788731755.247, accuracy: 0.01)
+    }
+}

--- a/Tests/ClaudeTranscriptTests.swift
+++ b/Tests/ClaudeTranscriptTests.swift
@@ -1,0 +1,237 @@
+import XCTest
+@testable import Codenotch
+
+/// The state machine that reads a session's transcript.
+///
+/// It exists because Claude Code only writes `status` into the session registry
+/// from its terminal interface, so a session hosted by the Claude desktop app
+/// has no status at all. Every fixture here is the shape of a line found in a
+/// real transcript on a Mac running the desktop app.
+final class ClaudeTranscriptTests: XCTestCase {
+    private func turn(_ lines: String...) -> ClaudeTranscript.Turn? {
+        ClaudeTranscript.turn(inTail: Data(lines.joined(separator: "\n").utf8))
+    }
+
+    // MARK: - Where the file is
+
+    func testSlugReplacesSeparatorsAndDots() {
+        XCTAssertEqual(ClaudeTranscript.projectSlug(forCWD: "/Users/vinz/notch-app"),
+                       "-Users-vinz-notch-app")
+        // A worktree under a dot directory: both characters collapse, and the
+        // run of two dashes is what the real directory names look like.
+        XCTAssertEqual(
+            ClaudeTranscript.projectSlug(forCWD: "/Users/vinz/app/.claude/worktrees/x"),
+            "-Users-vinz-app--claude-worktrees-x"
+        )
+    }
+
+    // MARK: - What it says
+
+    func testAToolInFlightIsWork() {
+        XCTAssertEqual(turn(#"{"type":"assistant","message":{"stop_reason":"tool_use"}}"#),
+                       .inFlight)
+    }
+
+    func testTheEndOfATurnIsNotWork() {
+        XCTAssertEqual(turn(#"{"type":"assistant","message":{"stop_reason":"end_turn"}}"#),
+                       .finished)
+        XCTAssertEqual(turn(#"{"type":"assistant","message":{"stop_reason":"stop_sequence"}}"#),
+                       .finished)
+    }
+
+    /// A tool result means the tool is done and the model is thinking about it,
+    /// which is the part of a turn that looks quietest from outside.
+    func testAToolResultIsStillWork() {
+        XCTAssertEqual(turn("""
+        {"type":"user","message":{"content":[{"type":"tool_result","content":"ok"}]}}
+        """), .inFlight)
+    }
+
+    func testAFreshPromptIsWork() {
+        XCTAssertEqual(turn(#"{"type":"user","message":{"content":"build the thing"}}"#),
+                       .inFlight)
+    }
+
+    /// Esc writes a record saying so, which is why a stopped session is
+    /// something the notch knows rather than something it waits out.
+    func testAnInterruptionEndsTheTurn() {
+        XCTAssertEqual(turn("""
+        {"type":"user","message":{"content":[{"type":"text","text":"[Request interrupted by user]"}]}}
+        """), .finished)
+        XCTAssertEqual(turn("""
+        {"type":"user","message":{"content":"[Request interrupted by user for tool use]"}}
+        """), .finished)
+    }
+
+    /// The reason a plain "was the file touched recently" test cannot work
+    /// here: Claude Code keeps appending these to a session that is sitting
+    /// doing nothing, and on this Mac that made an hour-old parked session look
+    /// like it was working.
+    func testBookkeepingNeverDecides() {
+        XCTAssertEqual(turn(
+            #"{"type":"assistant","message":{"stop_reason":"end_turn"}}"#,
+            #"{"type":"attachment"}"#,
+            #"{"type":"bridge-session"}"#,
+            #"{"type":"atis-latch"}"#,
+            #"{"type":"frame-link"}"#,
+            #"{"type":"custom-title"}"#,
+            #"{"type":"queue-operation","operation":"enqueue"}"#,
+            #"{"type":"system","subtype":"stop_hook_summary"}"#
+        ), .finished)
+    }
+
+    /// An unknown kind must not be read as work either — the list of things
+    /// Claude Code writes grows between releases, so only `user` and
+    /// `assistant` are allowed to answer.
+    func testAnUnknownKindNeverDecides() {
+        XCTAssertEqual(turn(
+            #"{"type":"assistant","message":{"stop_reason":"tool_use"}}"#,
+            #"{"type":"something-shipped-next-month"}"#
+        ), .inFlight)
+    }
+
+    /// A subagent's records are interleaved with its parent's; the parent's
+    /// turn is the one being reported on.
+    func testASidechainIsIgnored() {
+        XCTAssertEqual(turn(
+            #"{"type":"assistant","message":{"stop_reason":"tool_use"}}"#,
+            #"{"type":"assistant","isSidechain":true,"message":{"stop_reason":"end_turn"}}"#
+        ), .inFlight)
+    }
+
+    /// The tail starts mid-file, so its first line is usually half a record.
+    func testAHalfLineAtTheFrontIsSkipped() {
+        XCTAssertEqual(turn(
+            #"or":"tool_use"}}"#,
+            #"{"type":"assistant","message":{"stop_reason":"end_turn"}}"#
+        ), .finished)
+    }
+
+    /// A session opened and not yet used says nothing, and the monitor leaves
+    /// it as the registry described it rather than guessing.
+    func testNothingSaidYetIsUnknown() {
+        XCTAssertNil(turn(#"{"type":"bridge-session"}"#))
+        XCTAssertNil(ClaudeTranscript.turn(inTail: Data()))
+    }
+}
+
+/// The reader that puts the state machine on a timer.
+final class ClaudeTranscriptReaderTests: XCTestCase {
+    private var projects: URL!
+
+    override func setUpWithError() throws {
+        projects = FileManager.default.temporaryDirectory
+            .appendingPathComponent("transcripts-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: projects, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: projects)
+    }
+
+    @discardableResult
+    private func write(_ body: String, folder: String, session: String) throws -> URL {
+        let directory = projects.appendingPathComponent(folder)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let url = directory.appendingPathComponent("\(session).jsonl")
+        try Data(body.utf8).write(to: url)
+        return url
+    }
+
+    private let working = #"{"type":"assistant","message":{"stop_reason":"tool_use"}}"# + "\n"
+    private let done = #"{"type":"assistant","message":{"stop_reason":"end_turn"}}"# + "\n"
+
+    func testReadsTheTranscriptUnderTheSlugForTheWorkingDirectory() throws {
+        try write(working, folder: "-Users-vinz-app", session: "abc")
+        let reader = ClaudeTranscriptReader(projects: projects)
+        XCTAssertEqual(reader.activity(sessionID: "abc", cwd: "/Users/vinz/app")?.turn, .inFlight)
+    }
+
+    /// A session resumed somewhere else keeps its transcript where it was first
+    /// written, so the slug no longer names it.
+    func testFindsATranscriptThatIsNotUnderItsOwnSlug() throws {
+        try write(done, folder: "-Users-vinz-elsewhere", session: "abc")
+        let reader = ClaudeTranscriptReader(projects: projects)
+        XCTAssertEqual(reader.activity(sessionID: "abc", cwd: "/Users/vinz/app")?.turn, .finished)
+    }
+
+    func testSaysNothingWhenThereIsNoTranscript() {
+        let reader = ClaudeTranscriptReader(projects: projects)
+        XCTAssertNil(reader.activity(sessionID: "abc", cwd: "/Users/vinz/app"))
+    }
+
+    /// `since` is when the turn last moved, which is what the tooltip counts
+    /// from — not the moment the notch happened to look.
+    func testReportsWhenTheTranscriptLastMoved() throws {
+        let url = try write(working, folder: "-Users-vinz-app", session: "abc")
+        let when = Date(timeIntervalSince1970: 1_700_000_000)
+        try FileManager.default.setAttributes([.modificationDate: when], ofItemAtPath: url.path)
+        let reader = ClaudeTranscriptReader(projects: projects)
+        XCTAssertEqual(reader.activity(sessionID: "abc", cwd: "/Users/vinz/app")?.since, when)
+    }
+
+    /// The whole point of the cache: a tick that finds the file unchanged must
+    /// not read it again. Rewriting the body without touching the timestamps
+    /// leaves the reader on its old answer.
+    func testAnUnchangedFileIsNotReadTwice() throws {
+        let url = try write(working, folder: "-Users-vinz-app", session: "abc")
+        // Pinned to the same whole second on both sides, so the only thing this
+        // can be measuring is the cache.
+        let frozen = Date(timeIntervalSince1970: 1_700_000_000)
+        try FileManager.default.setAttributes([.modificationDate: frozen], ofItemAtPath: url.path)
+        let reader = ClaudeTranscriptReader(projects: projects)
+        XCTAssertEqual(reader.activity(sessionID: "abc", cwd: "/Users/vinz/app")?.turn, .inFlight)
+
+        // Same length as well, so neither size nor date moves.
+        XCTAssertEqual(working.utf8.count, done.utf8.count)
+        try Data(done.utf8).write(to: url)
+        try FileManager.default.setAttributes([.modificationDate: frozen], ofItemAtPath: url.path)
+        XCTAssertEqual(reader.activity(sessionID: "abc", cwd: "/Users/vinz/app")?.turn, .inFlight)
+    }
+
+    func testRereadsOnceTheFileHasGrown() throws {
+        let url = try write(working, folder: "-Users-vinz-app", session: "abc")
+        let reader = ClaudeTranscriptReader(projects: projects)
+        XCTAssertEqual(reader.activity(sessionID: "abc", cwd: "/Users/vinz/app")?.turn, .inFlight)
+
+        try Data((working + done).utf8).write(to: url)
+        XCTAssertEqual(reader.activity(sessionID: "abc", cwd: "/Users/vinz/app")?.turn, .finished)
+    }
+}
+
+/// `since` means when the state was entered, not when the file was last
+/// touched. Reporting the latter froze the tooltip's elapsed time at zero for
+/// the whole of a long turn, and gave the notch a fresh value to animate every
+/// two seconds while nothing visible had changed.
+extension ClaudeTranscriptReaderTests {
+    func testTheStartOfTheStateIsHeldWhileItLasts() throws {
+        let url = try write(working, folder: "-Users-vinz-app", session: "abc")
+        let started = Date(timeIntervalSince1970: 1_700_000_000)
+        try FileManager.default.setAttributes([.modificationDate: started],
+                                              ofItemAtPath: url.path)
+        let reader = ClaudeTranscriptReader(projects: projects)
+        XCTAssertEqual(reader.activity(sessionID: "abc", cwd: "/Users/vinz/app")?.since, started)
+
+        // The turn goes on: more records, a newer timestamp, same state.
+        try Data((working + working).utf8).write(to: url)
+        try FileManager.default.setAttributes([.modificationDate: started.addingTimeInterval(30)],
+                                              ofItemAtPath: url.path)
+        XCTAssertEqual(reader.activity(sessionID: "abc", cwd: "/Users/vinz/app")?.since, started)
+    }
+
+    func testTheStartMovesWhenTheStateDoes() throws {
+        let url = try write(working, folder: "-Users-vinz-app", session: "abc")
+        let started = Date(timeIntervalSince1970: 1_700_000_000)
+        try FileManager.default.setAttributes([.modificationDate: started],
+                                              ofItemAtPath: url.path)
+        let reader = ClaudeTranscriptReader(projects: projects)
+        XCTAssertEqual(reader.activity(sessionID: "abc", cwd: "/Users/vinz/app")?.since, started)
+
+        let ended = started.addingTimeInterval(120)
+        try Data((working + done).utf8).write(to: url)
+        try FileManager.default.setAttributes([.modificationDate: ended], ofItemAtPath: url.path)
+        let after = reader.activity(sessionID: "abc", cwd: "/Users/vinz/app")
+        XCTAssertEqual(after?.turn, .finished)
+        XCTAssertEqual(after?.since, ended)
+    }
+}


### PR DESCRIPTION
Replaces #68 with a much smaller, self-contained fix. #68 also included an
OAuth auto-renewal feature and a `CredentialCache` change that, on further
testing, ran into more risk (dark-wake keychain edge cases, ad-hoc-signature
prompts on every rebuild) than the maintainer wants to take on right now.
This PR keeps only the detection half, which stands on its own.

## Problem

Codenotch never detected a Claude Code session hosted by the **Claude
desktop app** as working — the ring never spun, and usage polling never
sped up, for a session started that way. Root cause: `status`/`tempo` in
`~/.claude/sessions/<pid>.json` is only ever written by an effect inside
Claude Code's *terminal interface* render loop. A desktop-hosted session
runs the same engine with no terminal interface, so that field is simply
never populated.

## Fix

Claude Code also writes a transcript per session (JSON-lines, appended by
the engine itself, not the interface) — which exists for both surfaces.
When a session's registry record admits it has no status
(`reportsStatus == false`), Codenotch now reads the tail of its transcript
and classifies the last conversational record into "mid-turn" / "finished"
instead. A terminal session's own `status`/`waiting` — the one thing only
the terminal interface can report — is left untouched.

Also fixes a `since` timestamp that fell back to `Date()` on every record
with no `statusUpdatedAt`/`updatedAt` — true of every desktop session —
which made the record compare unequal to itself on every rescan and set
the notch re-animating twice a second for no reason.

No changes to token handling, keychain caching, or usage fetching — that
behavior is exactly what it was on `main`.

## Testing

- 575 tests, 0 failures. Clean build from scratch. `git diff --check` clean.
- Verified live on a real machine: an active desktop session read `busy`,
  and a second session was caught transitioning `idle → busy → idle`
  across three consecutive scans.

Two commits: the detection logic itself, and a one-line follow-up wiring
the transcript reader into the session monitor's actual construction site
(caught by the same live verification above — the feature was inert
without it).

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
