### PR TITLE
feat: show usage pace for timed allowances

### DIFF
--- a/Sources/Features/TooltipCard.swift
+++ b/Sources/Features/TooltipCard.swift
@@ -256,6 +256,7 @@ private struct LimitWindowRow: View {
     let fidelity: Fidelity
     let now: Date
     let resetTimeFormat: ResetTimeFormat
+    let showsUsagePace: Bool
     @Environment(\.codenotchAccentColor) private var accentColor
 
     private var band: UsageBand { UsageBand.band(for: window.usedFraction ?? 0) }
@@ -263,6 +264,14 @@ private struct LimitWindowRow: View {
     private var fillWidth: CGFloat {
         let fraction = CGFloat(min(max(window.usedFraction ?? 0, 0), 1))
         return max(NotchLayout.barHeight, trackWidth * fraction)
+    }
+
+    private var paceText: Text {
+        guard showsUsagePace, let pace = window.usagePace(now: now) else {
+            return Text("")
+        }
+        return Text(" · \(pace.summary)")
+            .foregroundColor(pace.isDeficit ? .orange : Palette.textSecondary)
     }
 
     /// Blank rather than invented: some providers never say when the window rolls.
@@ -285,9 +294,11 @@ private struct LimitWindowRow: View {
                 .padding(.top, NotchLayout.labelToBar)
             }
 
-            Text("\(window.usedFraction == nil ? "" : fidelity.qualifier)\(window.summary)")
+            Text("\(window.usedFraction == nil ? "" : fidelity.qualifier)\(window.summary)\(paceText)")
                 .font(Typography.cardBody)
                 .foregroundStyle(Palette.textPrimary)
+                .lineLimit(1)
+                .minimumScaleFactor(0.85)
                 .padding(.top, NotchLayout.barToUsed)
         }
     }
@@ -297,6 +308,7 @@ private struct ProviderTooltip: View {
     let snapshot: ProviderSnapshot
     let now: Date
     let resetTimeFormat: ResetTimeFormat
+    let showUsagePace: Bool
 
     /// Only worth saying when the numbers are not current. A remembered reading
     /// has to be dated, or it quietly passes itself off as live.
@@ -328,7 +340,8 @@ private struct ProviderTooltip: View {
             } else {
                 ForEach(Array(snapshot.windows.enumerated()), id: \.element.id) { index, window in
                     LimitWindowRow(window: window, fidelity: snapshot.fidelity, now: now,
-                                   resetTimeFormat: resetTimeFormat)
+                                   resetTimeFormat: resetTimeFormat,
+                                   showsUsagePace: showUsagePace)
                         .padding(.top, index == 0 ? NotchLayout.headerToBlock : NotchLayout.blockSpacing)
                 }
             }
@@ -462,6 +475,7 @@ struct TooltipCard: View {
     /// rather than fixed, so a big screen hides nothing.
     var sessionCap: Int = NotchLayout.defaultSessionCap
     var resetTimeFormat: ResetTimeFormat = .automatic
+    @AppStorage(Preferences.showUsagePaceKey) private var showUsagePace = false
 
     /// The same figure the hover region uses, so what is drawn and what is
     /// reachable can never drift apart.
@@ -483,7 +497,9 @@ struct TooltipCard: View {
             // drifts while the card resizes around them.
             ZStack(alignment: .topLeading) {
                 VStack(alignment: .leading, spacing: 0) {
-                    ProviderTooltip(snapshot: snapshot, now: now, resetTimeFormat: resetTimeFormat)
+                    ProviderTooltip(snapshot: snapshot, now: now,
+                                    resetTimeFormat: resetTimeFormat,
+                                    showUsagePace: showUsagePace)
                     if let activity {
                         SessionList(summary: activity, now: now, cap: sessionCap)
                     }

--- a/Sources/Features/UsagePace.swift
+++ b/Sources/Features/UsagePace.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+struct UsagePace {
+    /// Used quota minus elapsed time, expressed in percentage points.
+    let percentagePoints: Double
+
+    var isDeficit: Bool { percentagePoints > 0 }
+
+    var summary: String {
+        let magnitude = abs(percentagePoints)
+        let rounded = (magnitude * 10).rounded() / 10
+        let value = rounded == 0 && magnitude > 0
+            ? "<0.1"
+            : String(format: "%.1f", locale: Locale(identifier: "en_US_POSIX"), rounded)
+                .replacingOccurrences(of: ".0", with: "")
+        return "\(value)% \(isDeficit ? "deficit" : "reserved")"
+    }
+}
+
+extension LimitWindow {
+    func usagePace(now: Date) -> UsagePace? {
+        guard let usedFraction, usedFraction.isFinite, usedFraction >= 0,
+              let duration, duration.isFinite, duration > 0,
+              let resetsAt else { return nil }
+        let remainingTime = resetsAt.timeIntervalSince(now)
+        guard remainingTime.isFinite, remainingTime > 0 else { return nil }
+        // Provider and device clocks can put a fresh reset just beyond one full cycle.
+        let remainingFraction = min(remainingTime / duration, 1)
+        let elapsedFraction = 1 - remainingFraction
+        // Once the allowance is exhausted there is no negative quota to account for.
+        let spentFraction = min(usedFraction, 1)
+        return UsagePace(
+            percentagePoints: (spentFraction - elapsedFraction) * 100
+        )
+    }
+}

--- a/Sources/Model/UsageModel.swift
+++ b/Sources/Model/UsageModel.swift
@@ -86,14 +86,19 @@ struct LimitWindow: Identifiable, Codable, Equatable {
     /// Nil when the provider does not say when the window rolls over.
     let resetsAt: Date?
 
+    /// Exact cycle length when known; optional to keep older archives readable.
+    let duration: TimeInterval?
+
     init(id: String, label: String, usedFraction: Double? = nil,
-         remaining: Int? = nil, used: Int? = nil, resetsAt: Date? = nil) {
+         remaining: Int? = nil, used: Int? = nil, resetsAt: Date? = nil,
+         duration: TimeInterval? = nil) {
         self.id = id
         self.label = label
         self.usedFraction = usedFraction
         self.remaining = remaining
         self.used = used
         self.resetsAt = resetsAt
+        self.duration = duration
     }
 
     /// A count short enough to sit inside a 44 pt ring.

--- a/Sources/Providers/AntigravityBridge.swift
+++ b/Sources/Providers/AntigravityBridge.swift
@@ -139,6 +139,7 @@ enum AntigravityBridge {
                 let displayName: String?
                 let remainingFraction: Double?
                 let resetTime: String?
+                let window: String?
             }
             struct Group: Decodable {
                 let displayName: String?
@@ -163,7 +164,8 @@ enum AntigravityBridge {
                     // "Weekly Limit Remaining", which is the same for both.
                     label: group.displayName ?? bucket.displayName ?? "Usage",
                     usedFraction: 1 - remaining,
-                    resetsAt: bucket.resetTime.flatMap(AntigravityCredentials.parse)
+                    resetsAt: bucket.resetTime.flatMap(AntigravityCredentials.parse),
+                    duration: bucket.window == "weekly" ? 7 * 86400 : nil
                 )
             }
         }

--- a/Sources/Providers/ClaudeOAuthProvider.swift
+++ b/Sources/Providers/ClaudeOAuthProvider.swift
@@ -391,7 +391,8 @@ struct UsageResponse: Decodable {
                 id: limit.kind,
                 label: limit.windowLabel,
                 usedFraction: limit.percent / 100,
-                resetsAt: resetsAt
+                resetsAt: resetsAt,
+                duration: Self.duration(forKind: limit.kind)
             )
         }
 
@@ -407,12 +408,18 @@ struct UsageResponse: Decodable {
             else { return }
             windows.append(LimitWindow(id: id, label: label,
                                        usedFraction: window.utilization / 100,
-                                       resetsAt: resetsAt))
+                                       resetsAt: resetsAt, duration: Self.duration(forKind: id)))
         }
         merge(fiveHour, id: "session", label: "Current session")
         merge(sevenDay, id: "weekly_all", label: "All models")
 
         return windows.sorted(by: UsageResponse.displayOrder)
+    }
+
+    static func duration(forKind kind: String) -> TimeInterval? {
+        if kind == "session" { return 5 * 3600 }
+        if kind.hasPrefix("weekly_") { return 7 * 86400 }
+        return nil
     }
 
     /// The frame's wording, for the kinds it drew.

--- a/Sources/Providers/ClaudeUsageCLI.swift
+++ b/Sources/Providers/ClaudeUsageCLI.swift
@@ -181,7 +181,8 @@ struct ClaudeUsageCLI: Sendable {
                 // optional by design, and losing a percentage that parsed
                 // perfectly well because the wording of a date changed is the
                 // worse failure of the two.
-                resetsAt: group(4).flatMap { Self.resetDate(from: $0, now: now) }
+                resetsAt: group(4).flatMap { Self.resetDate(from: $0, now: now) },
+                duration: UsageResponse.duration(forKind: kind)
             ))
         }
 

--- a/Sources/Providers/CodexUsage.swift
+++ b/Sources/Providers/CodexUsage.swift
@@ -42,7 +42,8 @@ enum CodexUsage {
                 id: id,
                 label: label(windowSeconds: window.limit_window_seconds ?? 0, fallback: id),
                 usedFraction: percent / 100,
-                resetsAt: resetsAt
+                resetsAt: resetsAt,
+                duration: window.limit_window_seconds
             ))
         }
         guard !windows.isEmpty else {

--- a/Sources/Providers/CursorUsage.swift
+++ b/Sources/Providers/CursorUsage.swift
@@ -54,6 +54,9 @@ enum CursorUsage {
         else { throw UsageProviderError.badResponse(status: 0) }
 
         let resetsAt = date(root["billingCycleEnd"])
+        let duration = date(root["billingCycleStart"]).flatMap { start in
+            resetsAt.map { $0.timeIntervalSince(start) }
+        }
         let usage = root["individualUsage"] as? [String: Any] ?? [:]
         let plan = usage["plan"] as? [String: Any] ?? [:]
         let team = root["teamUsage"] as? [String: Any] ?? [:]
@@ -63,14 +66,17 @@ enum CursorUsage {
         // Zero is a reading, not an absence — a fresh month is 0% on this bar.
         if let models = percent(plan["autoPercentUsed"]) {
             windows.append(LimitWindow(id: "auto", label: modelsLabel,
-                                       usedFraction: models, resetsAt: resetsAt))
+                                       usedFraction: models, resetsAt: resetsAt,
+                                       duration: duration))
         }
         if let api = percent(plan["apiPercentUsed"]), api > 0 {
             windows.append(LimitWindow(id: "api", label: "API usage",
-                                       usedFraction: api, resetsAt: resetsAt))
+                                       usedFraction: api, resetsAt: resetsAt,
+                                       duration: duration))
         }
         if let onDemand = spendWindow(usage["onDemand"], id: "on_demand",
-                                      label: "On demand", resetsAt: resetsAt) {
+                                      label: "On demand", resetsAt: resetsAt,
+                                      duration: duration) {
             windows.append(onDemand)
         }
 
@@ -79,11 +85,13 @@ enum CursorUsage {
         // provider's headlineID still resolves.
         if windows.isEmpty,
            let overall = spendWindow(usage["overall"], id: "included",
-                                     label: "Included usage", resetsAt: resetsAt) {
+                                     label: "Included usage", resetsAt: resetsAt,
+                                     duration: duration) {
             windows.append(overall)
         }
         if let teamOnDemand = spendWindow(team["onDemand"], id: "team_on_demand",
-                                          label: "Team on demand", resetsAt: resetsAt),
+                                          label: "Team on demand", resetsAt: resetsAt,
+                                          duration: duration),
            (teamOnDemand.usedFraction ?? 0) > 0 {
             windows.append(teamOnDemand)
         }
@@ -99,14 +107,15 @@ enum CursorUsage {
 
     /// A dollar-denominated bucket, used where a plan states a real ceiling.
     private static func spendWindow(
-        _ any: Any?, id: String, label: String, resetsAt: Date?
+        _ any: Any?, id: String, label: String, resetsAt: Date?, duration: TimeInterval?
     ) -> LimitWindow? {
         guard let bucket = any as? [String: Any],
               (bucket["enabled"] as? Bool) == true,
               let limit = (bucket["limit"] as? NSNumber)?.doubleValue, limit > 0,
               let used = (bucket["used"] as? NSNumber)?.doubleValue
         else { return nil }
-        return LimitWindow(id: id, label: label, usedFraction: used / limit, resetsAt: resetsAt)
+        return LimitWindow(id: id, label: label, usedFraction: used / limit,
+                           resetsAt: resetsAt, duration: duration)
     }
 
     /// Cursor reports 0–100; the rest of the app works in 0–1.

--- a/Sources/Providers/GLMUsage.swift
+++ b/Sources/Providers/GLMUsage.swift
@@ -105,7 +105,14 @@ enum GLMUsage {
             id: Self.id(for: limit),
             label: Self.label(for: limit),
             usedFraction: percentage / 100,
-            resetsAt: limit.nextResetTime.map { Date(timeIntervalSince1970: $0 / 1000) }
+            resetsAt: limit.nextResetTime.map { Date(timeIntervalSince1970: $0 / 1000) },
+            duration: limit.number.flatMap { number in
+                switch limit.unit {
+                case 3: return Double(number) * 3600
+                case 6: return Double(number) * 7 * 86400
+                default: return nil
+                }
+            }
         )
     }
 

--- a/Sources/Providers/GeminiAPIProvider.swift
+++ b/Sources/Providers/GeminiAPIProvider.swift
@@ -109,6 +109,7 @@ actor GeminiAPIProvider: UsageProvider {
         let budget = budget.flatMap { $0 > 0 ? $0 : nil }
         let total = sources.reduce(GeminiTokenUsage.zero) { $0.adding($1.usage) }
         let calendar = GeminiTokenUsage.calendar
+        let month = calendar.dateInterval(of: .month, for: now)
 
         var windows = [
             LimitWindow(
@@ -117,7 +118,8 @@ actor GeminiAPIProvider: UsageProvider {
                     ?? "Tokens this month · billed per token, no limit",
                 usedFraction: budget.map { Double(total.tokensThisMonth) / Double($0) },
                 used: total.tokensThisMonth,
-                resetsAt: calendar.dateInterval(of: .month, for: now)?.end
+                resetsAt: month?.end,
+                duration: month?.duration
             ),
             LimitWindow(
                 id: "today",

--- a/Sources/Providers/GitHubCopilotProvider.swift
+++ b/Sources/Providers/GitHubCopilotProvider.swift
@@ -196,7 +196,8 @@ enum GitHubCopilotUsage {
         if let entitlement, entitlement > 0 {
             let consumed = used ?? max(0, entitlement - (remaining ?? entitlement))
             return LimitWindow(id: id, label: label(for: id),
-                               usedFraction: max(0, consumed / entitlement), resetsAt: reset)
+                               usedFraction: max(0, consumed / entitlement), resetsAt: reset,
+                               duration: monthlyDuration(endingAt: reset))
         }
         if let remaining, remaining >= 0, used == nil {
             return remaining == 0 && entitlement == 0 ? nil
@@ -208,6 +209,18 @@ enum GitHubCopilotUsage {
                                used: Int(used.rounded()), resetsAt: reset)
         }
         return nil
+    }
+
+    /// Copilot allowances reset at midnight UTC on the first of each month.
+    private static func monthlyDuration(endingAt reset: Date?) -> TimeInterval? {
+        guard let reset else { return nil }
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+        let parts = calendar.dateComponents([.day, .hour, .minute, .second], from: reset)
+        guard parts.day == 1, parts.hour == 0, parts.minute == 0, parts.second == 0,
+              let previousMonth = calendar.date(byAdding: .second, value: -1, to: reset)
+        else { return nil }
+        return calendar.dateInterval(of: .month, for: previousMonth)?.duration
     }
 
     private static func number(_ value: Any?) -> Double? {

--- a/Sources/Providers/GrokUsage.swift
+++ b/Sources/Providers/GrokUsage.swift
@@ -28,15 +28,20 @@ enum GrokUsage {
 
         var windows: [LimitWindow] = []
 
-        let creditsReset = date(period(credits["currentPeriod"])?["end"])
-            ?? date(credits["billingPeriodEnd"])
+        let currentPeriod = period(credits["currentPeriod"])
+        let currentEnd = date(currentPeriod?["end"])
+        let creditsReset = currentEnd ?? date(credits["billingPeriodEnd"])
+        let start = currentEnd == nil
+            ? date(credits["billingPeriodStart"]) : date(currentPeriod?["start"])
+        let duration = start.flatMap { start in creditsReset.map { $0.timeIntervalSince(start) } }
 
         if let fraction = percent(credits["creditUsagePercent"]) {
             windows.append(LimitWindow(
                 id: "credits",
                 label: productLabel(credits) ?? "Grok Build",
                 usedFraction: fraction,
-                resetsAt: creditsReset
+                resetsAt: creditsReset,
+                duration: duration
             ))
         } else if let products = credits["productUsage"] as? [[String: Any]] {
             for product in products {
@@ -49,7 +54,8 @@ enum GrokUsage {
                     id: windows.isEmpty ? "credits" : ((product["product"] as? String) ?? name),
                     label: name,
                     usedFraction: fraction,
-                    resetsAt: creditsReset
+                    resetsAt: creditsReset,
+                    duration: duration
                 ))
             }
         }

--- a/Sources/Providers/OpenCodeUsage.swift
+++ b/Sources/Providers/OpenCodeUsage.swift
@@ -36,11 +36,13 @@ enum OpenCodeUsage {
             guard let entry = usage[id] as? [String: Any],
                   let percent = (entry["percent"] as? NSNumber)?.doubleValue
             else { return nil }
+            let resetsAt = (entry["resetsAt"] as? String).flatMap(date(from:))
             return LimitWindow(
                 id: id,
                 label: label,
                 usedFraction: percent / 100,
-                resetsAt: (entry["resetsAt"] as? String).flatMap(date(from:))
+                resetsAt: resetsAt,
+                duration: duration(for: id, endingAt: resetsAt)
             )
         }
         guard !out.isEmpty else { throw UsageProviderError.badResponse(status: 0) }
@@ -52,5 +54,15 @@ enum OpenCodeUsage {
         fractional.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
         if let date = fractional.date(from: stamp) { return date }
         return ISO8601DateFormatter().date(from: stamp)
+    }
+
+    private static func duration(for id: String, endingAt reset: Date?) -> TimeInterval? {
+        if id == "rolling" { return 5 * 3600 }
+        if id == "weekly" { return 7 * 86400 }
+        guard id == "monthly", let reset else { return nil }
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+        return calendar.date(byAdding: .month, value: -1, to: reset)
+            .map { reset.timeIntervalSince($0) }
     }
 }

--- a/Sources/Settings/Preferences.swift
+++ b/Sources/Settings/Preferences.swift
@@ -6,6 +6,8 @@ import os
 /// What the user has chosen, kept in `UserDefaults`.
 @MainActor
 final class Preferences: ObservableObject {
+    static let showUsagePaceKey = "showUsagePace"
+
     /// Providers the user has switched off. Stored as the *disconnected* set
     /// rather than the connected one, so a provider added in a later version is
     /// on by default instead of silently staying dark.
@@ -87,6 +89,10 @@ final class Preferences: ObservableObject {
 
     @Published var resetTimeFormat: ResetTimeFormat {
         didSet { defaults.set(resetTimeFormat.rawValue, forKey: Keys.resetTimeFormat) }
+    }
+
+    @Published var showUsagePace: Bool {
+        didSet { defaults.set(showUsagePace, forKey: Self.showUsagePaceKey) }
     }
 
     /// The colour used for positive usage and active-work indicators.
@@ -269,6 +275,7 @@ final class Preferences: ObservableObject {
             .map(DisplayPreference.display) ?? .followActiveWindow
         self.resetTimeFormat = defaults.string(forKey: Keys.resetTimeFormat)
             .flatMap(ResetTimeFormat.init(rawValue:)) ?? .automatic
+        self.showUsagePace = defaults.bool(forKey: Self.showUsagePaceKey)
         // Absent means never chosen. Main display only, because that is what a
         // single-panel setup always did — all-displays on a fresh install
         // would put notches where none were expected.

--- a/Sources/Settings/SettingsView.swift
+++ b/Sources/Settings/SettingsView.swift
@@ -405,6 +405,13 @@ struct SettingsView: View {
                     .foregroundStyle(.secondary)
                     .fixedSize(horizontal: false, vertical: true)
 
+                Toggle("Show usage pace", isOn: $preferences.showUsagePace)
+                Text("Compares each timed allowance with the time left until reset, "
+                     + "showing quota in deficit or held in reserve.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+
                 Picker("Show", selection: $preferences.notchVisibility) {
                     ForEach(NotchVisibility.allCases) { Text($0.title).tag($0) }
                 }

--- a/Tests/AntigravityTests.swift
+++ b/Tests/AntigravityTests.swift
@@ -299,6 +299,7 @@ final class AntigravityBridgeTests: XCTestCase {
         XCTAssertEqual(windows[0].id, "gemini-weekly")
         XCTAssertEqual(windows[0].usedFraction ?? 0, 1 - 0.96262, accuracy: 0.00001)
         XCTAssertEqual(windows[0].label, "Gemini Models")
+        XCTAssertEqual(windows[0].duration, 7 * 86400)
     }
 
     /// A full bucket is 0% used, not "no reading".

--- a/Tests/ClaudeUsageCLITests.swift
+++ b/Tests/ClaudeUsageCLITests.swift
@@ -101,6 +101,7 @@ final class ClaudeUsageCLITests: XCTestCase {
 
         // 2:59pm in Jakarta is 07:59 UTC.
         XCTAssertEqual(windows[0].resetsAt, date("2026-09-07T07:59:00Z"))
+        XCTAssertEqual(windows[0].duration, 5 * 3600)
     }
 
     /// No year is printed. Read on New Year's Eve, a window resetting on Jan 2

--- a/Tests/CodexUsageTests.swift
+++ b/Tests/CodexUsageTests.swift
@@ -17,6 +17,7 @@ final class CodexUsageTests: XCTestCase {
          "code_review_rate_limit":{"primary_window":{"used_percent":90,"limit_window_seconds":604800}},
          "credits":{"balance":"100"},"model_usage":{"spark":99}}
         """)
+        XCTAssertEqual(result.map(\.duration), [18000, 604800])
         XCTAssertEqual(result.map(\.id), ["primary", "secondary"])
         XCTAssertEqual(result.map(\.label), ["5h limit", "Weekly limit"])
         XCTAssertEqual(result.map(\.usedFraction), [0.25, 0.10])
@@ -38,6 +39,20 @@ final class CodexUsageTests: XCTestCase {
         XCTAssertEqual(result.map(\.id), ["primary"])
         XCTAssertEqual(result.first?.label, "Monthly limit")
         XCTAssertEqual(result.first?.usedFraction ?? -1, 0.16, accuracy: 0.0001)
+    }
+
+    func testPaceUsesTheReportedCycleRegardlessOfPlanName() throws {
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        for seconds in [18000, 604800, 2592000] {
+            let result = try CodexUsage.windows(from: Data("""
+            {"rate_limit":{"primary_window":{"used_percent":80,
+            "limit_window_seconds":\(seconds),"reset_after_seconds":\(seconds / 2)}}}
+            """.utf8), now: now)
+            let window = try XCTUnwrap(result.first)
+            XCTAssertEqual(window.duration, Double(seconds))
+            XCTAssertEqual(try XCTUnwrap(window.usagePace(now: now)).percentagePoints, 30,
+                           accuracy: 0.00001)
+        }
     }
 
     /// A duration that is none of the named buckets still gets a usable label
@@ -66,6 +81,7 @@ final class CodexUsageTests: XCTestCase {
         "primary_window":{"used_percent":8,"limit_window_seconds":604800},
         "secondary_window":{"used_percent":0,"limit_window_seconds":18000,"reset_after_seconds":120}}}
         """)
+        XCTAssertEqual(result.map(\.duration), [604800, 18000])
         XCTAssertEqual(result.map(\.id), ["primary", "secondary"])
         XCTAssertEqual(result.first?.usedFraction, 0.08)
         XCTAssertNil(result.first?.resetsAt)
@@ -277,4 +293,3 @@ final class UsageBlockTests: XCTestCase {
         )
     }
 }
-

--- a/Tests/CursorUsageTests.swift
+++ b/Tests/CursorUsageTests.swift
@@ -29,7 +29,26 @@ final class CursorUsageTests: XCTestCase {
         XCTAssertEqual(w[0].id, "auto")
         XCTAssertEqual(w[0].label, CursorUsage.modelsLabel)
         XCTAssertEqual(w[0].usedFraction ?? -1, 0, accuracy: 0.0001)
+        XCTAssertEqual(w[0].duration, 31 * 86400)
         XCTAssertEqual(CursorUsage.headlineID(in: w), "auto")
+    }
+
+    func testMonthlyPaceUsesActualBillingDates() throws {
+        for days in [28, 29, 30, 31] {
+            let start = Date(timeIntervalSince1970: 1_800_000_000)
+            let end = start.addingTimeInterval(Double(days) * 86400)
+            let iso = ISO8601DateFormatter()
+            let result = try windows("""
+            {"billingCycleStart":"\(iso.string(from: start))",
+             "billingCycleEnd":"\(iso.string(from: end))",
+             "individualUsage":{"plan":{"autoPercentUsed":80}}}
+            """)
+            let window = try XCTUnwrap(result.first)
+            let halfway = start.addingTimeInterval(Double(days) * 43200)
+            XCTAssertEqual(window.duration, Double(days) * 86400)
+            XCTAssertEqual(try XCTUnwrap(window.usagePace(now: halfway)).percentagePoints, 30,
+                           accuracy: 0.00001)
+        }
     }
 
     func testApiUsageIsReportedSeparately() throws {

--- a/Tests/GLMUsageTests.swift
+++ b/Tests/GLMUsageTests.swift
@@ -26,6 +26,7 @@ final class GLMQuotaResponseTests: XCTestCase {
 
     func testDecodesTheLiveShape() throws {
         let payload = try parse(live)
+        XCTAssertEqual(payload.windows.map(\.duration), [18000, 604800, nil])
         XCTAssertEqual(payload.level, "pro")
         XCTAssertEqual(payload.windows.map(\.id), ["session", "weekly", "mcp"])
         XCTAssertEqual(payload.windows[0].label, "Current session")

--- a/Tests/GeminiAPITests.swift
+++ b/Tests/GeminiAPITests.swift
@@ -469,6 +469,7 @@ final class GeminiAPISnapshotTests: XCTestCase {
         )
         XCTAssertEqual(snapshot.fidelity, .manual)
         XCTAssertEqual(try XCTUnwrap(snapshot.headline?.usedFraction), 0.3255, accuracy: 0.0001)
+        XCTAssertEqual(snapshot.headline?.duration, 30 * 86400)
         XCTAssertTrue(snapshot.windows[0].label.contains("2.0M"),
                       "budget label was \(snapshot.windows[0].label)")
     }

--- a/Tests/GitHubCopilotTests.swift
+++ b/Tests/GitHubCopilotTests.swift
@@ -4,7 +4,8 @@ import XCTest
 final class GitHubCopilotUsageTests: XCTestCase {
     func testReadsCopilotQuotas() throws {
         let json = """
-        {"copilot_plan":"individual","quota_snapshots":{
+        {"copilot_plan":"individual","quota_reset_date":"2026-10-01T00:00:00Z",
+         "quota_snapshots":{
           "chat":{"entitlement":50,"remaining":48,"used":2,"unlimited":false},
           "completions":{"entitlement":2000,"remaining":1990,"used":10,"unlimited":false},
           "premium_interactions":{"entitlement":300,"remaining":294,"used":6,"unlimited":false}}}
@@ -14,6 +15,7 @@ final class GitHubCopilotUsageTests: XCTestCase {
         XCTAssertEqual(windows.map(\.id), ["premium_interactions", "chat", "completions"])
         XCTAssertEqual(windows[0].label, "Premium requests")
         XCTAssertEqual(windows[0].usedFraction ?? -1, 0.02, accuracy: 0.0001)
+        XCTAssertEqual(windows[0].duration, 30 * 86400)
         XCTAssertEqual(windows[1].usedFraction ?? -1, 0.04, accuracy: 0.0001)
     }
 

--- a/Tests/GrokUsageTests.swift
+++ b/Tests/GrokUsageTests.swift
@@ -24,6 +24,7 @@ final class GrokUsageTests: XCTestCase {
 
     func testTheRingIsTheCreditsPercentage() throws {
         let credits = try XCTUnwrap(windows().first { $0.id == "credits" })
+        XCTAssertEqual(credits.duration, 7 * 86400)
         XCTAssertEqual(credits.label, "Grok Build")
         XCTAssertEqual(credits.usedFraction ?? -1, 0.08, accuracy: 0.0001)
     }
@@ -58,6 +59,7 @@ final class GrokUsageTests: XCTestCase {
         """
         let w = try GrokUsage.windows(creditsJSON: productOnly)
         let credits = try XCTUnwrap(w.first { $0.id == "credits" })
+        XCTAssertNil(credits.duration)
         XCTAssertEqual(credits.label, "Grok Build")
         XCTAssertEqual(credits.usedFraction ?? -1, 0.33, accuracy: 0.0001)
         let snap = ProviderSnapshot(

--- a/Tests/OpenCodeUsageTests.swift
+++ b/Tests/OpenCodeUsageTests.swift
@@ -14,6 +14,7 @@ final class OpenCodeUsageTests: XCTestCase {
 
     func testReadsAllThreeWindows() throws {
         let w = try OpenCodeUsage.windows(fromJSON: payload)
+        XCTAssertEqual(w.map(\.duration), [18000, 604800, 30 * 86400])
         XCTAssertEqual(w.map(\.id), ["rolling", "weekly", "monthly"])
         XCTAssertEqual(w.map(\.label), ["5h limit", "Weekly limit", "Monthly limit"])
         XCTAssertTrue(w.allSatisfy { ($0.usedFraction ?? -1) == 0 })

--- a/Tests/TooltipRenderTests.swift
+++ b/Tests/TooltipRenderTests.swift
@@ -16,6 +16,18 @@ final class TooltipRenderTests: XCTestCase {
                      since: Date().addingTimeInterval(Double(-minutes) * 60))
     }
 
+    func testUsagePaceFitsTheExistingSummaryLine() throws {
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        let window = LimitWindow(id: "weekly", label: "Weekly limit", usedFraction: 1,
+                                 resetsAt: now.addingTimeInterval(604800), duration: 604800)
+        let pace = try XCTUnwrap(window.usagePace(now: now))
+        let summary = "\(window.summary) · \(pace.summary)"
+        XCTAssertEqual(summary, "100% Used · 0% left · 100% deficit")
+        let font = NSFont.systemFont(ofSize: Design.fontSize(capPixels: 18))
+        let width = (summary as NSString).size(withAttributes: [.font: font]).width
+        XCTAssertLessThanOrEqual(width * 0.85, NotchLayout.cardTextWidth)
+    }
+
     func testTheCardLaysOutEverySessionState() throws {
         let snapshot = ProviderSnapshot(
             id: "claude", displayName: "Claude", glyph: .claude,

--- a/Tests/UsagePaceTests.swift
+++ b/Tests/UsagePaceTests.swift
@@ -1,0 +1,76 @@
+import XCTest
+@testable import Codenotch
+
+final class UsagePaceTests: XCTestCase {
+    private let now = Date(timeIntervalSince1970: 1_800_000_000)
+
+    private func pace(
+        used: Double? = 0.5,
+        remaining: TimeInterval? = 302400,
+        duration: TimeInterval? = 604800
+    ) -> UsagePace? {
+        LimitWindow(id: "w", label: "Weekly", usedFraction: used,
+                    resetsAt: remaining.map { now.addingTimeInterval($0) }, duration: duration)
+            .usagePace(now: now)
+    }
+
+    func testCalculatesDeficitAndReserve() throws {
+        let deficit = try XCTUnwrap(pace(used: 0.98, remaining: 86400))
+        XCTAssertEqual(deficit.percentagePoints, 12.285714, accuracy: 0.00001)
+        XCTAssertEqual(deficit.summary, "12.3% deficit")
+        XCTAssertTrue(deficit.isDeficit)
+
+        let reserved = try XCTUnwrap(pace(used: 0.27))
+        XCTAssertEqual(reserved.percentagePoints, -23, accuracy: 0.00001)
+        XCTAssertEqual(reserved.summary, "23% reserved")
+        XCTAssertFalse(reserved.isDeficit)
+    }
+
+    func testUsesAnyReportedDuration() throws {
+        let result = try XCTUnwrap(pace(used: 0.8, remaining: 36 * 3600, duration: 3 * 86400))
+        XCTAssertEqual(result.percentagePoints, 30, accuracy: 0.00001)
+    }
+
+    func testAResetJustBeyondTheCycleStartsAtZeroElapsed() throws {
+        let result = try XCTUnwrap(pace(used: 0.2, remaining: 604801))
+        XCTAssertEqual(result.percentagePoints, 20, accuracy: 0.00001)
+    }
+
+    func testRequiresAValidCurrentWindow() {
+        let invalid = [
+            pace(used: nil), pace(used: .infinity), pace(used: -0.1),
+            pace(remaining: nil), pace(remaining: 0),
+            pace(duration: nil), pace(duration: 0), pace(duration: .infinity),
+        ]
+        for result in invalid { XCTAssertNil(result) }
+    }
+
+    func testFormattingKeepsTheSignAtSubTenthPrecision() throws {
+        XCTAssertEqual(try XCTUnwrap(pace(used: 0.5004)).summary, "<0.1% deficit")
+        XCTAssertEqual(try XCTUnwrap(pace(used: 0.4996)).summary, "<0.1% reserved")
+        XCTAssertEqual(try XCTUnwrap(pace()).summary, "0% reserved")
+    }
+
+    func testDurationCodingRemainsBackwardCompatible() throws {
+        let original = LimitWindow(id: "w", label: "Weekly", usedFraction: 0.98,
+                                   resetsAt: now.addingTimeInterval(86400), duration: 604800)
+        XCTAssertEqual(try JSONDecoder().decode(LimitWindow.self,
+                       from: JSONEncoder().encode(original)), original)
+
+        let archived = try JSONDecoder().decode(LimitWindow.self,
+            from: Data(#"{"id":"w","label":"Weekly","usedFraction":0.98}"#.utf8))
+        XCTAssertNil(archived.duration)
+    }
+}
+
+@MainActor
+final class UsagePacePreferenceTests: XCTestCase {
+    func testDefaultsOffAndSurvivesARelaunch() throws {
+        let name = "UsagePacePreferenceTests.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: name))
+        defer { defaults.removePersistentDomain(forName: name) }
+        XCTAssertFalse(Preferences(defaults: defaults).showUsagePace)
+        Preferences(defaults: defaults).showUsagePace = true
+        XCTAssertTrue(Preferences(defaults: defaults).showUsagePace)
+    }
+}

--- a/Tests/UsageResponseTests.swift
+++ b/Tests/UsageResponseTests.swift
@@ -44,6 +44,7 @@ final class UsageResponseTests: XCTestCase {
     func testDecodesTheLiveShape() throws {
         let windows = try decode(live).limitWindows()
         XCTAssertEqual(windows.count, 2)
+        XCTAssertEqual(windows.map(\.duration), [18000, 604800])
         XCTAssertEqual(windows[0].id, "session")
         XCTAssertEqual(windows[0].label, "Current session")
         XCTAssertEqual(windows[0].usedFraction ?? -1, 0.52, accuracy: 0.0001)


### PR DESCRIPTION
## What this adds

Adds an optional **Show usage pace** setting that compares quota usage with the time remaining for each allowance.

- `12.3% deficit` means usage is ahead of pace.
- `23% reserved` means usage is behind pace.

Deficit is shown in orange and reserved quota in gray. Windows without enough timing information remain unchanged.

This was an idea I wanted to try, although there may be a better way to implement or present it.

## Preview

<img width="574" height="501" alt="codenotch-usage-pace" src="https://github.com/user-attachments/assets/ea0bb506-cbe1-40a8-aa32-a49eeb398875" />

## Validation

- 763 tests passed
- Tooltip layout test passed
- `git diff --check` passed
