### PR TITLE
Add Codex account token activity to the usage tooltip

### DIFF
--- a/Sources/Features/TooltipCard.swift
+++ b/Sources/Features/TooltipCard.swift
@@ -336,6 +336,168 @@ private struct ProviderTooltip: View {
     }
 }
 
+private enum UsageFormat {
+    static func tokens(_ value: Int?) -> String {
+        guard let value else { return "—" }
+        switch value {
+        case 1_000_000_000...:
+            return String(format: "%.2fB", locale: Locale(identifier: "en_US_POSIX"),
+                          Double(value) / 1_000_000_000)
+        case 1_000_000...:
+            return String(format: "%.1fM", locale: Locale(identifier: "en_US_POSIX"),
+                          Double(value) / 1_000_000)
+        case 1_000...:
+            return String(format: "%.0fK", locale: Locale(identifier: "en_US_POSIX"),
+                          Double(value) / 1_000)
+        default:
+            return "\(value)"
+        }
+    }
+
+    static func duration(seconds: Double?) -> String {
+        guard let seconds, seconds.isFinite, seconds > 0 else { return "—" }
+        let minutes = max(1, Int((seconds / 60).rounded()))
+        let hours = minutes / 60
+        let remainder = minutes % 60
+        if hours > 0 {
+            return remainder == 0 ? "\(hours)h" : "\(hours)h \(remainder)m"
+        }
+        return "\(minutes)m"
+    }
+
+    static func days(_ value: Int?) -> String {
+        guard let value else { return "—" }
+        return "\(value)d"
+    }
+}
+
+private struct CodexMetric: Identifiable {
+    let id: String
+    let value: String
+    let label: String
+}
+
+private struct CodexMetricList: View {
+    let metrics: [CodexMetric]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: NotchLayout.codexMetricRowGap) {
+            ForEach(metrics) { metric in
+                HStack(alignment: .firstTextBaseline, spacing: Design.px(20)) {
+                    Text(metric.label)
+                        .font(Typography.cardBody)
+                        .foregroundStyle(Palette.textPrimary)
+                        .lineLimit(1)
+
+                    Spacer(minLength: 0)
+
+                    Text(metric.value)
+                        .font(Typography.cardBody)
+                        .foregroundStyle(Palette.textSecondary)
+                        .lineLimit(1)
+                        .monospacedDigit()
+                }
+                .frame(height: NotchLayout.codexMetricRowHeight)
+            }
+        }
+        .frame(height: NotchLayout.codexMetricHeight)
+    }
+}
+
+private struct CodexDailyUsageChart: View {
+    let buckets: [CodexTokenUsage.DailyBucket]
+    let maximum: Int
+
+    var body: some View {
+        GeometryReader { proxy in
+            ZStack(alignment: .bottomLeading) {
+                Rectangle()
+                    .fill(Palette.ringTrack)
+                    .frame(height: NotchLayout.hairline)
+
+                HStack(alignment: .bottom, spacing: Design.px(4)) {
+                    ForEach(buckets) { bucket in
+                        RoundedRectangle(cornerRadius: Design.px(3), style: .continuous)
+                            .fill(Palette.textSecondary)
+                            .frame(maxWidth: .infinity)
+                            .frame(height: proxy.size.height
+                                   * CGFloat(bucket.tokens) / CGFloat(maximum))
+                    }
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottom)
+            }
+        }
+        .frame(height: NotchLayout.codexChartHeight)
+        .clipped()
+    }
+}
+
+/// Account-wide Codex activity. Unlike the quota rows above, this is sourced
+/// from the Codex profile usage endpoint and is not a local estimate.
+private struct CodexUsageSection: View {
+    let usage: CodexTokenUsage
+    let now: Date
+
+    private var buckets: [CodexTokenUsage.DailyBucket] {
+        usage.last30Days(now: now)
+    }
+
+    private var maximum: Int {
+        max(1, buckets.map(\.tokens).max() ?? 0)
+    }
+
+    private var todayText: String {
+        usage.usageToday(now: now).map { UsageFormat.tokens($0) } ?? "Pending"
+    }
+
+    private var peakText: String {
+        "peak \(UsageFormat.tokens(usage.peakDailyTokens))"
+    }
+
+    private var metrics: [CodexMetric] {
+        let summary = usage.summary
+        return [
+            CodexMetric(id: "lifetime", value: UsageFormat.tokens(summary?.lifetimeTokens),
+                        label: "Lifetime tokens"),
+            CodexMetric(id: "peak", value: UsageFormat.tokens(summary?.peakDailyTokens),
+                        label: "Peak tokens"),
+            CodexMetric(id: "longest", value: UsageFormat.duration(
+                seconds: summary?.longestRunningTurnSeconds), label: "Longest chat"),
+            CodexMetric(id: "current-streak", value: UsageFormat.days(
+                summary?.currentStreakDays), label: "Current streak"),
+            CodexMetric(id: "longest-streak", value: UsageFormat.days(
+                summary?.longestStreakDays), label: "Longest streak")
+        ]
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Rectangle()
+                .fill(Palette.ringTrack)
+                .frame(height: NotchLayout.hairline)
+                .padding(.top, NotchLayout.codexUsageTop)
+
+            CodexMetricList(metrics: metrics)
+                .padding(.top, NotchLayout.codexMetricTop)
+                .padding(.bottom, NotchLayout.codexMetricBottom)
+
+            Rectangle()
+                .fill(Palette.ringTrack)
+                .frame(height: NotchLayout.hairline)
+
+            SplitRow(leading: "Today", trailing: todayText)
+                .padding(.top, NotchLayout.blockSpacing)
+            SplitRow(leading: "30-day tokens",
+                     trailing: UsageFormat.tokens(usage.usageInLast30Days(now: now)))
+                .padding(.top, NotchLayout.codexUsageRowGap)
+            SplitRow(leading: "Daily tokens", trailing: peakText)
+                .padding(.top, NotchLayout.codexUsageRowGap)
+            CodexDailyUsageChart(buckets: buckets, maximum: maximum)
+                .padding(.top, NotchLayout.codexChartTop)
+        }
+    }
+}
+
 /// The line that says you are stopped.
 ///
 /// Deliberately loud where the rest of the card is quiet: it is the one thing
@@ -471,7 +633,8 @@ struct TooltipCard: View {
             sessionCount: activity?.sessions.count ?? 0,
             sessionCap: sessionCap,
             statusMessage: snapshot.statusMessage,
-            blockMessage: snapshot.block?.summary(now: now)
+            blockMessage: snapshot.block?.summary(now: now),
+            hasTokenUsage: snapshot.tokenUsage != nil
         )
     }
 
@@ -484,6 +647,9 @@ struct TooltipCard: View {
             ZStack(alignment: .topLeading) {
                 VStack(alignment: .leading, spacing: 0) {
                     ProviderTooltip(snapshot: snapshot, now: now, resetTimeFormat: resetTimeFormat)
+                    if let tokenUsage = snapshot.tokenUsage {
+                        CodexUsageSection(usage: tokenUsage, now: now)
+                    }
                     if let activity {
                         SessionList(summary: activity, now: now, cap: sessionCap)
                     }

--- a/Sources/Features/TooltipCard.swift
+++ b/Sources/Features/TooltipCard.swift
@@ -450,10 +450,6 @@ private struct CodexUsageSection: View {
         usage.usageToday(now: now).map { UsageFormat.tokens($0) } ?? "Pending"
     }
 
-    private var peakText: String {
-        "peak \(UsageFormat.tokens(usage.peakDailyTokens))"
-    }
-
     private var metrics: [CodexMetric] {
         let summary = usage.summary
         return [
@@ -489,8 +485,6 @@ private struct CodexUsageSection: View {
                 .padding(.top, NotchLayout.blockSpacing)
             SplitRow(leading: "30-day tokens",
                      trailing: UsageFormat.tokens(usage.usageInLast30Days(now: now)))
-                .padding(.top, NotchLayout.codexUsageRowGap)
-            SplitRow(leading: "Daily tokens", trailing: peakText)
                 .padding(.top, NotchLayout.codexUsageRowGap)
             CodexDailyUsageChart(buckets: buckets, maximum: maximum)
                 .padding(.top, NotchLayout.codexChartTop)

--- a/Sources/Model/UsageArchive.swift
+++ b/Sources/Model/UsageArchive.swift
@@ -16,6 +16,9 @@ struct UsageArchive {
         let fetchedAt: Date
         /// Optional so archives written before this field still decode.
         let headlineID: String?
+        /// Optional so archives written before Codex token activity existed
+        /// continue to open and show their last quota reading.
+        let tokenUsage: CodexTokenUsage?
     }
 
     private let defaults: UserDefaults
@@ -80,7 +83,8 @@ struct UsageArchive {
                 fidelity: entry.fidelity,
                 status: .stale(since: entry.fetchedAt),
                 windows: entry.windows,
-                headlineID: entry.headlineID
+                headlineID: entry.headlineID,
+                tokenUsage: entry.tokenUsage
             )
             result[entry.id] = (snapshot, entry.fetchedAt)
         }
@@ -96,7 +100,8 @@ struct UsageArchive {
                 fidelity: $0.snapshot.fidelity,
                 windows: $0.snapshot.windows,
                 fetchedAt: $0.fetchedAt,
-                headlineID: $0.snapshot.headlineID
+                headlineID: $0.snapshot.headlineID,
+                tokenUsage: $0.snapshot.tokenUsage
             )
         }
         guard let data = try? JSONEncoder().encode(entries) else { return }

--- a/Sources/Model/UsageModel.swift
+++ b/Sources/Model/UsageModel.swift
@@ -169,6 +169,11 @@ struct ProviderSnapshot: Identifiable, Equatable {
     /// Set when something is blocked right now. Deliberately separate from the
     /// windows: it is not a measurement, it is a door being shut.
     var block: UsageBlock?
+    /// Codex's account-wide token activity, when its profile endpoint returned
+    /// it. The optional top model is an enrichment from the desktop breakdown
+    /// endpoint; it never changes the profile token buckets. Other providers
+    /// leave this nil because they do not expose the same account-level data.
+    var tokenUsage: CodexTokenUsage? = nil
 
     /// The number on the cell: the provider's declared primary window — for
     /// Claude, the current session.

--- a/Sources/Notch/NotchLayout.swift
+++ b/Sources/Notch/NotchLayout.swift
@@ -138,6 +138,17 @@ enum NotchLayout {
     static let statusDotGap    = Design.px(11)
     static let hairline      = Design.px(2.5)  // rule above the session list
 
+    // Codex account activity
+    static let codexUsageTop   = Design.px(20)
+    static let codexMetricTop  = Design.px(14)
+    static let codexMetricRowGap = Design.px(8)
+    static let codexMetricRowHeight = Design.px(40)
+    static let codexMetricHeight = 5 * codexMetricRowHeight + 4 * codexMetricRowGap
+    static let codexMetricBottom = Design.px(14)
+    static let codexUsageRowGap = Design.px(12)
+    static let codexChartTop   = Design.px(15)
+    static let codexChartHeight = Design.px(115)
+
     /// The percent label's line box. Fixed rather than intrinsic so the panel
     /// geometry can be worked out in AppKit before SwiftUI lays anything out.
     static let percentLineHeight: CGFloat = {
@@ -274,7 +285,8 @@ enum NotchLayout {
     static func cardHeight(windowCount: Int, sessionCount: Int = 0,
                            sessionCap: Int = defaultSessionCap,
                            statusMessage: String? = nil,
-                           blockMessage: String? = nil) -> CGFloat {
+                           blockMessage: String? = nil,
+                           hasTokenUsage: Bool = false) -> CGFloat {
         let header = max(glyphSize, cardTitleLineHeight)
         var height = 2 * cardPadding + header
 
@@ -292,6 +304,15 @@ enum NotchLayout {
         } else {
             // The status message, at whatever height it actually wraps to.
             height += headerToBlock + bodyTextHeight(statusMessage ?? "")
+        }
+
+        if hasTokenUsage {
+            height += codexUsageTop + hairline + blockSpacing
+                + codexMetricTop + codexMetricHeight + codexMetricBottom
+                + hairline
+                + 3 * cardBodyLineHeight
+                + 2 * codexUsageRowGap
+                + codexChartTop + codexChartHeight
         }
 
         if sessionCount > 0 {
@@ -356,14 +377,16 @@ enum NotchLayout {
     /// is a sum of a dozen named parts, and an inverted copy of it would have
     /// to be kept in step by hand. The range is short enough that the search
     /// costs nothing.
-    static func sessionsFitting(cardBudget: CGFloat, windowCount: Int) -> Int {
+    static func sessionsFitting(cardBudget: CGFloat, windowCount: Int,
+                                hasTokenUsage: Bool = false) -> Int {
         var fits = 0
         for n in 1...sessionCeiling {
             // Costed as though something were still hidden, so that admitting
             // the nth row can never be what pushes the summary line off the
             // bottom of the card.
             let height = cardHeight(windowCount: windowCount,
-                                    sessionCount: n + 1, sessionCap: n)
+                                    sessionCount: n + 1, sessionCap: n,
+                                    hasTokenUsage: hasTokenUsage)
             guard height <= cardBudget else { break }
             fits = n
         }
@@ -384,9 +407,10 @@ enum NotchLayout {
     /// clicks through everywhere the chrome is not — but it cannot be so
     /// generous that the panel runs off the screen, which is what the cap is
     /// solved for.
-    static func maxCardHeight(sessionCap: Int) -> CGFloat {
+    static func maxCardHeight(sessionCap: Int, hasTokenUsage: Bool = false) -> CGFloat {
         cardHeight(windowCount: maxWindowCount,
-                   sessionCount: sessionCap + 1, sessionCap: sessionCap)
+                   sessionCount: sessionCap + 1, sessionCap: sessionCap,
+                   hasTokenUsage: hasTokenUsage)
     }
 
     static let defaultMaxCardHeight = maxCardHeight(sessionCap: defaultSessionCap)

--- a/Sources/Notch/NotchLayout.swift
+++ b/Sources/Notch/NotchLayout.swift
@@ -310,8 +310,8 @@ enum NotchLayout {
             height += codexUsageTop + hairline + blockSpacing
                 + codexMetricTop + codexMetricHeight + codexMetricBottom
                 + hairline
-                + 3 * cardBodyLineHeight
-                + 2 * codexUsageRowGap
+                + 2 * cardBodyLineHeight
+                + codexUsageRowGap
                 + codexChartTop + codexChartHeight
         }
 

--- a/Sources/Notch/NotchRootView.swift
+++ b/Sources/Notch/NotchRootView.swift
@@ -206,7 +206,8 @@ struct NotchRootView: View {
                 sessionCount: model.activity(for: snapshot.id)?.sessions.count ?? 0,
                 sessionCap: model.sessionCap,
                 statusMessage: snapshot.statusMessage,
-                blockMessage: snapshot.block?.summary(now: model.now)
+                blockMessage: snapshot.block?.summary(now: model.now),
+                hasTokenUsage: snapshot.tokenUsage != nil
             )
         return place.point(
             along: model.slack + model.ringCenter(index: index),

--- a/Sources/Notch/NotchViewModel.swift
+++ b/Sources/Notch/NotchViewModel.swift
@@ -296,14 +296,20 @@ final class NotchViewModel: ObservableObject {
     /// the rest — as many as this screen has room for.
     var sessionCap: Int { sessionCap(cellCount: snapshots.count) }
 
+    private var hasTokenUsage: Bool {
+        snapshots.contains { $0.tokenUsage != nil }
+    }
+
     func sessionCap(cellCount: Int) -> Int {
         guard screenSize != .zero else { return NotchLayout.defaultSessionCap }
         return NotchLayout.sessionsFitting(cardBudget: cardBudget(cellCount: cellCount),
-                                           windowCount: NotchLayout.maxWindowCount)
+                                           windowCount: NotchLayout.maxWindowCount,
+                                           hasTokenUsage: hasTokenUsage)
     }
 
     func maxCardHeight(cellCount: Int) -> CGFloat {
-        NotchLayout.maxCardHeight(sessionCap: sessionCap(cellCount: cellCount))
+        NotchLayout.maxCardHeight(sessionCap: sessionCap(cellCount: cellCount),
+                                  hasTokenUsage: hasTokenUsage)
     }
 
     /// How tall the tallest card may be before the panel runs off the screen.

--- a/Sources/Notch/NotchWindowController.swift
+++ b/Sources/Notch/NotchWindowController.swift
@@ -290,7 +290,8 @@ final class NotchWindowController {
             sessionCount: model.activity(for: snapshot.id)?.sessions.count ?? 0,
             sessionCap: model.sessionCap,
             statusMessage: snapshot.statusMessage,
-            blockMessage: snapshot.block?.summary(now: model.now)
+            blockMessage: snapshot.block?.summary(now: model.now),
+            hasTokenUsage: snapshot.tokenUsage != nil
         )
         // Across the stack the region is the card, its tail, and the gap the
         // pointer has to cross. Along it, the card's own extent.

--- a/Sources/Providers/CodexLocalProvider.swift
+++ b/Sources/Providers/CodexLocalProvider.swift
@@ -61,13 +61,44 @@ actor CodexLocalProvider: UsageProvider {
         }
 
         let windows = try CodexUsage.windows(from: data)
+
+        // The profile page's token statistics are the source for the chart and
+        // totals.
+        let profileUsage = try? await Self.fetchProfileUsage(
+            session: session, credential: credential
+        )
         retryNoEarlierThan = nil
         archive.saveBackoffUntil(nil, providerID: id)
         return ProviderSnapshot(
             id: id, displayName: displayName, glyph: glyph,
             fidelity: .official, status: .ok, windows: windows,
-            headlineID: windows.first?.id
+            headlineID: windows.first?.id,
+            tokenUsage: profileUsage
         )
+    }
+
+    private static func fetchProfileUsage(
+        session: URLSession,
+        credential: CodexCredentials.Credential
+    ) async throws -> CodexTokenUsage {
+        var request = URLRequest(
+            url: URL(string: "https://chatgpt.com/backend-api/wham/profiles/me")!,
+            cachePolicy: .reloadIgnoringLocalCacheData,
+            timeoutInterval: 15
+        )
+        request.httpMethod = "GET"
+        request.setValue("Bearer \(credential.accessToken)", forHTTPHeaderField: "Authorization")
+        request.setValue(credential.accountID, forHTTPHeaderField: "ChatGPT-Account-Id")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.setValue("no-cache, no-store", forHTTPHeaderField: "Cache-Control")
+
+        let (data, response) = try await session.data(for: request)
+        let status = (response as? HTTPURLResponse)?.statusCode ?? 0
+        if status == 401 || status == 403 { throw UsageProviderError.needsAuth }
+        guard (200..<300).contains(status) else {
+            throw UsageProviderError.badResponse(status: status)
+        }
+        return try CodexUsage.profileUsage(from: data)
     }
 
     private static func retryAfter(from response: HTTPURLResponse?, now: Date) -> TimeInterval? {

--- a/Sources/Providers/CodexUsage.swift
+++ b/Sources/Providers/CodexUsage.swift
@@ -1,11 +1,113 @@
 import Foundation
 
+/// Account-wide Codex activity returned by the Codex profile endpoint.
+///
+/// `/wham/profiles/me` reports token totals in daily buckets and account-level
+/// summary statistics.
+struct CodexTokenUsage: Codable, Equatable, Sendable {
+    struct Summary: Codable, Equatable, Sendable {
+        let lifetimeTokens: Int?
+        let peakDailyTokens: Int?
+        let longestRunningTurnSeconds: Double?
+        let currentStreakDays: Int?
+        let longestStreakDays: Int?
+
+        init(lifetimeTokens: Int? = nil,
+             peakDailyTokens: Int? = nil,
+             longestRunningTurnSeconds: Double? = nil,
+             currentStreakDays: Int? = nil,
+             longestStreakDays: Int? = nil) {
+            self.lifetimeTokens = lifetimeTokens
+            self.peakDailyTokens = peakDailyTokens
+            self.longestRunningTurnSeconds = longestRunningTurnSeconds
+            self.currentStreakDays = currentStreakDays
+            self.longestStreakDays = longestStreakDays
+        }
+    }
+
+    struct DailyBucket: Codable, Equatable, Identifiable, Sendable {
+        let startDate: String
+        let tokens: Int
+
+        var id: String { startDate }
+
+        init(startDate: String, tokens: Int) {
+            self.startDate = startDate
+            self.tokens = tokens
+        }
+    }
+
+    let summary: Summary?
+    let dailyUsageBuckets: [DailyBucket]
+
+    init(summary: Summary? = nil,
+         dailyUsageBuckets: [DailyBucket] = []) {
+        self.summary = summary
+        self.dailyUsageBuckets = dailyUsageBuckets
+    }
+
+    /// The consecutive calendar days represented by the card's chart.
+    func last30Days(now: Date = Date(), calendar: Calendar = .current) -> [DailyBucket] {
+        let today = calendar.startOfDay(for: now)
+        var values: [String: DailyBucket] = [:]
+        for bucket in dailyUsageBuckets {
+            values[bucket.startDate] = bucket
+        }
+
+        return (0..<30).compactMap { offset in
+            guard let date = calendar.date(byAdding: .day, value: offset - 29, to: today)
+            else { return nil }
+            let key = Self.dayKey(for: date, calendar: calendar)
+            return values[key] ?? DailyBucket(startDate: key, tokens: 0)
+        }
+    }
+
+    func usageInLast30Days(now: Date = Date(), calendar: Calendar = .current) -> Int {
+        last30Days(now: now, calendar: calendar).reduce(0) { $0 + $1.tokens }
+    }
+
+    /// A missing current-day bucket means the server has not published today's
+    /// usage yet. A present zero is a real zero, not a pending value.
+    func usageToday(now: Date = Date(), calendar: Calendar = .current) -> Int? {
+        let key = Self.dayKey(for: calendar.startOfDay(for: now), calendar: calendar)
+        return dailyUsageBuckets.first(where: { $0.startDate == key })?.tokens
+    }
+
+    var peakDailyTokens: Int? {
+        summary?.peakDailyTokens ?? dailyUsageBuckets.map(\.tokens).max()
+    }
+
+    private static func dayKey(for date: Date, calendar: Calendar) -> String {
+        let components = calendar.dateComponents([.year, .month, .day], from: date)
+        return String(format: "%04d-%02d-%02d",
+                      components.year ?? 0, components.month ?? 0, components.day ?? 0)
+    }
+}
+
 /// Only the account's main rate-limit windows belong in the usage rings —
 /// `additional_rate_limits` and `code_review_rate_limit` meter something else
 /// and are deliberately left out.
 enum CodexUsage {
     private struct Response: Decodable {
         let rate_limit: RateLimit?
+    }
+
+    private struct ProfileUsageResponse: Decodable {
+        let stats: ProfileStats?
+    }
+
+    private struct ProfileStats: Decodable {
+        let lifetime_tokens: Int?
+        let peak_daily_tokens: Int?
+        let longest_running_turn_sec: Double?
+        let current_streak_days: Int?
+        let longest_streak_days: Int?
+        let daily_usage_buckets: [ProfileDailyBucket]?
+    }
+
+    private struct ProfileDailyBucket: Decodable {
+        let start_date: String
+        let tokens: Int
     }
 
     private struct RateLimit: Decodable {
@@ -49,6 +151,30 @@ enum CodexUsage {
             throw UsageProviderError.nothingMetered("Codex reported no usage windows")
         }
         return windows
+    }
+
+    /// Decode the profile endpoint's token statistics.
+    static func profileUsage(from data: Data) throws -> CodexTokenUsage {
+        do {
+            let response = try JSONDecoder().decode(ProfileUsageResponse.self, from: data)
+            let stats = response.stats
+            return CodexTokenUsage(
+                summary: stats.map {
+                    .init(lifetimeTokens: $0.lifetime_tokens,
+                          peakDailyTokens: $0.peak_daily_tokens,
+                          longestRunningTurnSeconds: $0.longest_running_turn_sec,
+                          currentStreakDays: $0.current_streak_days,
+                          longestStreakDays: $0.longest_streak_days)
+                },
+                dailyUsageBuckets: stats?.daily_usage_buckets?.map {
+                    .init(startDate: $0.start_date, tokens: $0.tokens)
+                } ?? []
+            )
+        } catch let error as UsageProviderError {
+            throw error
+        } catch {
+            throw UsageProviderError.badResponse(status: 0)
+        }
     }
 
     /// The plan an account is on decides what its primary window actually is

--- a/Tests/CodexUsageTests.swift
+++ b/Tests/CodexUsageTests.swift
@@ -152,8 +152,8 @@ final class CodexUsageTests: XCTestCase {
                 + NotchLayout.codexMetricTop + NotchLayout.codexMetricHeight
                 + NotchLayout.codexMetricBottom
                 + NotchLayout.hairline
-                + 3 * NotchLayout.cardBodyLineHeight
-                + 2 * NotchLayout.codexUsageRowGap
+                + 2 * NotchLayout.cardBodyLineHeight
+                + NotchLayout.codexUsageRowGap
                 + NotchLayout.codexChartTop + NotchLayout.codexChartHeight,
             accuracy: 0.001
         )

--- a/Tests/CodexUsageTests.swift
+++ b/Tests/CodexUsageTests.swift
@@ -110,6 +110,55 @@ final class CodexUsageTests: XCTestCase {
           "secondary_window":null}}
         """))
     }
+
+    func testDecodesProfileTokenUsageAndBuildsAThirtyDaySeries() throws {
+        let json = """
+        {"profile":{"display_name":"Test"},
+         "stats":{"lifetime_tokens":1200,"peak_daily_tokens":300,
+         "longest_running_turn_sec":4020,"current_streak_days":2,"longest_streak_days":11,
+         "daily_usage_buckets":[
+           {"start_date":"2026-08-12","tokens":100},
+           {"start_date":"2026-09-03","tokens":200},
+           {"start_date":"2026-09-08","tokens":300}
+         ]}}
+        """
+        let usage = try CodexUsage.profileUsage(from: Data(json.utf8))
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+        let now = calendar.date(from: DateComponents(year: 2026, month: 9, day: 9))!
+
+        XCTAssertEqual(usage.last30Days(now: now, calendar: calendar).count, 30)
+        XCTAssertEqual(usage.last30Days(now: now, calendar: calendar).first?.startDate,
+                       "2026-08-11")
+        XCTAssertEqual(usage.usageInLast30Days(now: now, calendar: calendar), 600)
+        XCTAssertEqual(usage.peakDailyTokens, 300)
+        XCTAssertEqual(usage.summary?.lifetimeTokens, 1200)
+        XCTAssertEqual(usage.summary?.peakDailyTokens, 300)
+        XCTAssertEqual(usage.summary?.longestRunningTurnSeconds, 4020)
+        XCTAssertEqual(usage.summary?.currentStreakDays, 2)
+        XCTAssertEqual(usage.summary?.longestStreakDays, 11)
+        XCTAssertEqual(usage.usageToday(now: now, calendar: calendar), nil,
+                       "a missing current-day bucket should be shown as Pending")
+    }
+
+    func testAccountUsageCardGetsRoomForTheActivitySection() {
+        let plain = NotchLayout.cardHeight(windowCount: 2)
+        let withTokens = NotchLayout.cardHeight(windowCount: 2, hasTokenUsage: true)
+
+        XCTAssertGreaterThan(withTokens, plain)
+        XCTAssertEqual(
+            withTokens - plain,
+            NotchLayout.codexUsageTop + NotchLayout.hairline + NotchLayout.blockSpacing
+                + NotchLayout.codexMetricTop + NotchLayout.codexMetricHeight
+                + NotchLayout.codexMetricBottom
+                + NotchLayout.hairline
+                + 3 * NotchLayout.cardBodyLineHeight
+                + 2 * NotchLayout.codexUsageRowGap
+                + NotchLayout.codexChartTop + NotchLayout.codexChartHeight,
+            accuracy: 0.001
+        )
+    }
+
 }
 
 /// The activity signal is a heuristic — a rollout written moments ago — so what
@@ -277,4 +326,3 @@ final class UsageBlockTests: XCTestCase {
         )
     }
 }
-

--- a/Tests/TooltipRenderTests.swift
+++ b/Tests/TooltipRenderTests.swift
@@ -49,4 +49,47 @@ final class TooltipRenderTests: XCTestCase {
             try png.write(to: URL(fileURLWithPath: path))
         }
     }
+
+    func testCodexCardRendersAccountActivity() throws {
+        let usage = CodexTokenUsage(
+            summary: .init(lifetimeTokens: 280_000, peakDailyTokens: 150_000,
+                            longestRunningTurnSeconds: 4020,
+                            currentStreakDays: 2, longestStreakDays: 11),
+            dailyUsageBuckets: [
+                .init(startDate: "2026-08-25", tokens: 48_000),
+                .init(startDate: "2026-09-03", tokens: 192_000),
+                .init(startDate: "2026-09-08", tokens: 40_000)
+            ]
+        )
+        let snapshot = ProviderSnapshot(
+            id: "codex", displayName: "Codex", glyph: .openai,
+            fidelity: .official, status: .ok,
+            windows: [
+                LimitWindow(id: "primary", label: "5h limit", usedFraction: 0),
+                LimitWindow(id: "secondary", label: "Weekly limit", usedFraction: 0.28)
+            ],
+            tokenUsage: usage
+        )
+        let calendar = Calendar(identifier: .gregorian)
+        let now = calendar.date(from: DateComponents(year: 2026, month: 9, day: 9))!
+        let view = TooltipCard(snapshot: snapshot, now: now)
+            .padding(20)
+            .background(Color.black)
+
+        let renderer = ImageRenderer(content: view)
+        renderer.scale = 3
+        let image = try XCTUnwrap(renderer.nsImage)
+        XCTAssertGreaterThan(
+            image.size.height,
+            NotchLayout.cardHeight(windowCount: 2) + NotchLayout.codexChartHeight,
+            "the account activity section was not included in the rendered card"
+        )
+
+        if let path = ProcessInfo.processInfo.environment["CODEX_TOOLTIP_RENDER_PATH"] {
+            let tiff = try XCTUnwrap(image.tiffRepresentation)
+            let png = try XCTUnwrap(NSBitmapImageRep(data: tiff)?
+                .representation(using: .png, properties: [:]))
+            try png.write(to: URL(fileURLWithPath: path))
+        }
+    }
 }

--- a/Tests/UsageResponseTests.swift
+++ b/Tests/UsageResponseTests.swift
@@ -218,6 +218,28 @@ final class UsageArchiveTests: XCTestCase {
         XCTAssertEqual(restored?.fetchedAt, taken)
     }
 
+    func testCodexDailyUsageRoundTripsWithTheQuotaReading() {
+        let defaults = makeDefaults()
+        let usage = CodexTokenUsage(
+            summary: .init(lifetimeTokens: 90, peakDailyTokens: 90,
+                            longestRunningTurnSeconds: 3600,
+                            currentStreakDays: 1, longestStreakDays: 3),
+            dailyUsageBuckets: [.init(
+                startDate: "2026-09-08", tokens: 90
+            )]
+        )
+        let snapshot = ProviderSnapshot(
+            id: "codex", displayName: "Codex", glyph: .openai,
+            fidelity: .official, status: .ok,
+            windows: [LimitWindow(id: "primary", label: "5h limit", usedFraction: 0.2)],
+            tokenUsage: usage
+        )
+        UsageArchive(defaults: defaults).save(["codex": (snapshot, Date())])
+
+        let restored = UsageArchive(defaults: defaults).load()["codex"]?.snapshot
+        XCTAssertEqual(restored?.tokenUsage, usage)
+    }
+
     /// A restored reading is never presented as live.
     func testRestoredReadingsComeBackStale() throws {
         let defaults = makeDefaults()


### PR DESCRIPTION
## Summary

- Add Codex account-level token activity to the usage tooltip.
- Read token history and account statistics from `/backend-api/wham/profiles/me`.
- Display lifetime tokens, peak tokens, longest chat duration, current streak, and longest streak.
- Display today's usage, 30-day token total, and a 30-day usage chart.
- Show `Pending` when the current-day bucket has not been published yet.
- Keep quota windows sourced from `/backend-api/wham/usage`.
- Use the existing card layout, typography, spacing, and color palette.

## Data source

The account activity section uses the authenticated Codex/ChatGPT web session and sends the account ID through `ChatGPT-Account-Id`.

## Verification

- `xcodebuild test -project Codenotch.xcodeproj -scheme Codenotch -destination 'platform=macOS'`\n- 757 tests passed\n- 0 failures\n- `git diff --check` passed