### PR TITLE
fix: treat the Antigravity CLI as a real install

### DIFF
--- a/Sources/Providers/AntigravityActivity.swift
+++ b/Sources/Providers/AntigravityActivity.swift
@@ -16,14 +16,40 @@ struct AntigravityActivity: Equatable {
     let requestsToday: Int
     let lastRequest: Date?
 
-    static var transcriptRoot: URL {
-        let idePath = URL(fileURLWithPath: NSHomeDirectory())
-            .appendingPathComponent(".gemini/antigravity-ide/brain")
-        if FileManager.default.fileExists(atPath: idePath.path) {
-            return idePath
+    /// Every Antigravity install's transcripts, not just the first one found.
+    ///
+    /// Antigravity keeps a directory per flavour under `~/.gemini` —
+    /// `antigravity`, `antigravity-ide`, `antigravity-cli`, `antigravity-backup`
+    /// — and each has its own `brain`. Picking the first that *exists* looked
+    /// reasonable and was not: leaving a flavour behind leaves its directory
+    /// behind too, so on a machine that has run the IDE and then moved to the
+    /// CLI all four exist and the first is empty. The count came out zero while
+    /// the transcripts sat one directory over.
+    ///
+    /// So: all of them. Trajectories are UUID-named per install, so nothing is
+    /// counted twice, and somebody who uses the IDE and the CLI in the same day
+    /// gets one number for the day rather than whichever half was looked at.
+    static var transcriptRoots: [URL] { transcriptRoots(home: URL(fileURLWithPath: NSHomeDirectory())) }
+
+    static func transcriptRoots(home: URL) -> [URL] {
+        let gemini = home.appendingPathComponent(".gemini")
+        let names = (try? FileManager.default.contentsOfDirectory(atPath: gemini.path)) ?? []
+        return names
+            .filter { $0.hasPrefix("antigravity") }
+            .sorted()
+            .map { gemini.appendingPathComponent($0).appendingPathComponent("brain") }
+            .filter { FileManager.default.fileExists(atPath: $0.path) }
+    }
+
+    /// Every install's activity, as one day's worth.
+    static func read(roots: [URL] = transcriptRoots, now: Date = Date()) -> AntigravityActivity {
+        roots.reduce(AntigravityActivity(requestsToday: 0, lastRequest: nil)) { total, root in
+            let one = read(root: root, now: now)
+            return AntigravityActivity(
+                requestsToday: total.requestsToday + one.requestsToday,
+                lastRequest: [total.lastRequest, one.lastRequest].compactMap { $0 }.max()
+            )
         }
-        return URL(fileURLWithPath: NSHomeDirectory())
-            .appendingPathComponent(".gemini/antigravity/brain")
     }
 
     /// A step the model actually answered. User input and system checkpoints
@@ -31,7 +57,8 @@ struct AntigravityActivity: Equatable {
     /// work the model never did.
     private static let modelSource = "MODEL"
 
-    static func read(root: URL = transcriptRoot, now: Date = Date()) -> AntigravityActivity {
+    /// One install's, which is what the combining read above is made of.
+    static func read(root: URL, now: Date = Date()) -> AntigravityActivity {
         let manager = FileManager.default
         guard let trajectories = try? manager.contentsOfDirectory(
             at: root, includingPropertiesForKeys: nil

--- a/Sources/Providers/AntigravityActivity.swift
+++ b/Sources/Providers/AntigravityActivity.swift
@@ -112,4 +112,43 @@ struct AntigravityActivity: Equatable {
         guard requestsToday > 0 else { return "no requests today" }
         return "~\(requestsToday) request\(requestsToday == 1 ? "" : "s") today"
     }
+
+    /// What the tooltip's row is called.
+    ///
+    /// A bare `0` on a day Antigravity has not been opened reads as the app
+    /// failing to find anything rather than as an honest nothing — and that is
+    /// exactly what a wrong directory looks like too, which is how this went
+    /// unnoticed. Saying when it *was* last used tells the two apart.
+    func label(now: Date = Date()) -> String {
+        guard requestsToday == 0, let lastRequest else {
+            return "Requests today · no limit published"
+        }
+        return "Requests today · last used \(Self.lastUsed(lastRequest, now: now))"
+    }
+
+    /// Counted in calendar days, not in elapsed time, because the number beside
+    /// it is: `requestsToday` asks whether a timestamp falls on today's date.
+    /// Measured in elapsed hours instead, a Saturday evening reads as "2 days
+    /// ago" on a Tuesday morning, and the row's two halves disagree about what
+    /// a day is.
+    ///
+    /// Inside a day it defers to `ElapsedCopy`, the same phrase the session list
+    /// uses, so the two read alike. Days are added here rather than there:
+    /// that helper answers "is this still working", where a span of days cannot
+    /// arise and would only be noise.
+    private static func lastUsed(_ date: Date, now: Date) -> String {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = .current
+        let days = calendar.dateComponents(
+            [.day],
+            from: calendar.startOfDay(for: date),
+            to: calendar.startOfDay(for: now)
+        ).day ?? 0
+
+        switch days {
+        case ..<1:  return ElapsedCopy.ago(since: date, now: now)
+        case 1:     return "yesterday"
+        default:    return "\(days) days ago"
+        }
+    }
 }

--- a/Sources/Providers/AntigravityBridge.swift
+++ b/Sources/Providers/AntigravityBridge.swift
@@ -22,7 +22,10 @@ enum AntigravityBridge {
         /// this RPC, and which is which is not advertised — so both are tried
         /// rather than guessed at.
         let ports: [Int]
-        let csrfToken: String
+        /// Nil for the CLI, which serves this RPC to anything on loopback. The
+        /// IDE's language server refuses without one, so it is still sent
+        /// wherever there is one to send.
+        let csrfToken: String?
     }
 
     /// Antigravity is built on Codeium's stack, and the header still says so.
@@ -43,13 +46,42 @@ enum AntigravityBridge {
     static func discover(processTable: String? = nil, listeningPorts: ((Int) -> [Int])? = nil)
         -> Endpoint? {
         let table = processTable ?? run("/bin/ps", ["-Ao", "pid,command"])
-        guard let line = table.split(separator: "\n").first(where: {
-            $0.contains("language_server") && $0.contains("--csrf_token")
-        }) else { return nil }
+        let lines = table.split(separator: "\n")
 
-        guard let token = value(of: "--csrf_token", in: String(line)),
-              let pid = Int(line.trimmingCharacters(in: .whitespaces)
-                  .split(separator: " ").first ?? "")
+        // The IDE's language server, which is the one that carries a token.
+        if let line = lines.first(where: {
+            $0.contains("language_server") && $0.contains("--csrf_token")
+        }),
+           let token = value(of: "--csrf_token", in: String(line)),
+           let endpoint = endpoint(for: line, token: token, ports: listeningPorts) {
+            return endpoint
+        }
+
+        // Then the CLI, which serves the same RPC and is a whole install of its
+        // own — somebody who uses `agy` and never installs the IDE has a real
+        // quota to read and was getting the counted-requests fallback instead.
+        // It asks for no token: on loopback it answers anyone.
+        if let line = lines.first(where: isCLI),
+           let endpoint = endpoint(for: line, token: nil, ports: listeningPorts) {
+            return endpoint
+        }
+        return nil
+    }
+
+    /// The CLI runs as plain `agy`, so match the executable's name rather than
+    /// looking for it anywhere in the line — "agy" is three letters and turns
+    /// up inside real words and real paths.
+    static func isCLI(_ line: Substring) -> Bool {
+        let fields = line.trimmingCharacters(in: .whitespaces).split(separator: " ")
+        guard fields.count >= 2 else { return false }
+        return URL(fileURLWithPath: String(fields[1])).lastPathComponent == "agy"
+    }
+
+    private static func endpoint(
+        for line: Substring, token: String?, ports listeningPorts: ((Int) -> [Int])?
+    ) -> Endpoint? {
+        guard let pid = Int(line.trimmingCharacters(in: .whitespaces)
+            .split(separator: " ").first ?? "")
         else { return nil }
 
         let ports = listeningPorts?(pid) ?? self.listeningPorts(ofPID: pid)
@@ -100,14 +132,16 @@ enum AntigravityBridge {
         return []
     }
 
-    private static func quota(port: Int, token: String,
+    private static func quota(port: Int, token: String?,
                               session: URLSession) async throws -> [LimitWindow] {
         var request = URLRequest(
             url: URL(string: "https://127.0.0.1:\(port)\(service)")!
         )
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.setValue(token, forHTTPHeaderField: csrfHeader)
+        // Only where there is one. Sending an empty header instead of none is
+        // not the same request, and the CLI has no token to send.
+        if let token { request.setValue(token, forHTTPHeaderField: csrfHeader) }
         // `forceRefresh` is why this reads as live rather than as whatever was
         // last looked at. The language server keeps a `QuotaSummaryCache`, and
         // an empty request is served from it — so the figure only moved when

--- a/Sources/Providers/AntigravityCredentials.swift
+++ b/Sources/Providers/AntigravityCredentials.swift
@@ -1,6 +1,6 @@
 import Foundation
+import SQLite3
 import os
-
 /// The OAuth token Antigravity holds for a Google account.
 ///
 /// Borrowed, like every other credential here — Antigravity signs in, this only
@@ -10,7 +10,17 @@ struct AntigravityCredentials {
     let expiresAt: Date
     /// `consumer` for a personal Google account; enterprise installs differ.
     let authMethod: String
+    let projectId: String?
+    let email: String?
 
+    init(accessToken: String, expiresAt: Date, authMethod: String = "consumer",
+         projectId: String? = nil, email: String? = nil) {
+        self.accessToken = accessToken
+        self.expiresAt = expiresAt
+        self.authMethod = authMethod
+        self.projectId = projectId
+        self.email = email
+    }
     var isExpired: Bool { expiresAt <= Date() }
 
     static let service = "gemini"
@@ -28,7 +38,12 @@ struct AntigravityCredentials {
     /// item's attributes rather than its contents — those are not behind the
     /// access prompt the secret is, so this can be asked freely.
     static func isSignedIn() -> Bool {
-        KeychainItem.modifiedAt(service: service, account: account) != nil
+        if KeychainItem.modifiedAt(service: service, account: account) != nil { return true }
+        let jsonPath = ("~/.gemini/oauth_creds.json" as NSString).expandingTildeInPath
+        if FileManager.default.fileExists(atPath: jsonPath) { return true }
+        let ompDBPath = ("~/.omp/agent/agent.db" as NSString).expandingTildeInPath
+        if FileManager.default.fileExists(atPath: ompDBPath) { return true }
+        return false
     }
 
     /// Antigravity stores through Go's `keyring` package, which base64-encodes
@@ -39,12 +54,22 @@ struct AntigravityCredentials {
 
     static func load() throws -> AntigravityCredentials {
         try cache.value(
-            itemModifiedAt: { KeychainItem.modifiedAt(service: service, account: account) },
+            itemModifiedAt: {
+                let keychainMod = KeychainItem.modifiedAt(service: service, account: account)
+                let jsonPath = ("~/.gemini/oauth_creds.json" as NSString).expandingTildeInPath
+                let jsonMod = (try? FileManager.default.attributesOfItem(atPath: jsonPath))?[.modificationDate] as? Date
+                let ompPath = ("~/.omp/agent/agent.db" as NSString).expandingTildeInPath
+                let ompMod = (try? FileManager.default.attributesOfItem(atPath: ompPath))?[.modificationDate] as? Date
+                return [keychainMod, jsonMod, ompMod].compactMap { $0 }.max()
+            },
             reload: read
         )
     }
 
     private static func read() throws -> AntigravityCredentials {
+        var keychainCreds: AntigravityCredentials?
+        var keychainStatus: OSStatus = 0
+
         var item: CFTypeRef?
         let status = SecItemCopyMatching([
             kSecClass: kSecClassGenericPassword,
@@ -53,20 +78,93 @@ struct AntigravityCredentials {
             kSecReturnData: true,
             kSecMatchLimit: kSecMatchLimitOne
         ] as CFDictionary, &item)
+        keychainStatus = status
 
-        guard status == errSecSuccess, let data = item as? Data else {
-            Log.usage.error("antigravity keychain read failed: OSStatus \(status)")
-            // See `ClaudeCredentials.wasTransient` — a machine just woken
-            // from sleep answers this for a read the account had nothing to
-            // do with, and it must not be treated as a sign-out.
-            if ClaudeCredentials.wasTransient(status) { throw UsageProviderError.credentialExpired }
-            throw ClaudeCredentials.wasRefused(status)
-                ? UsageProviderError.accessDenied
-                : UsageProviderError.needsAuth
+        if status == errSecSuccess, let data = item as? Data, let decoded = decode(data) {
+            keychainCreds = decoded
+            if !decoded.isExpired {
+                return decoded
+            }
         }
 
-        guard let decoded = decode(data) else { throw UsageProviderError.needsAuth }
-        return decoded
+        // If Keychain had no unexpired token, check OMP SQLite store (active agent tokens)
+        if let ompCreds = readOMPCredentials() {
+            if !ompCreds.isExpired {
+                return ompCreds
+            }
+            if keychainCreds == nil {
+                keychainCreds = ompCreds
+            }
+        }
+
+        // Then check ~/.gemini/oauth_creds.json
+        if let jsonCreds = readJSONCredentials() {
+            if !jsonCreds.isExpired {
+                return jsonCreds
+            }
+            if keychainCreds == nil {
+                keychainCreds = jsonCreds
+            }
+        }
+
+        if let creds = keychainCreds {
+            return creds
+        }
+
+        Log.usage.error("antigravity credentials read failed: OSStatus \(keychainStatus)")
+        if ClaudeCredentials.wasTransient(keychainStatus) { throw UsageProviderError.credentialExpired }
+        throw ClaudeCredentials.wasRefused(keychainStatus)
+            ? UsageProviderError.accessDenied
+            : UsageProviderError.needsAuth
+    }
+
+    private static func readOMPCredentials() -> AntigravityCredentials? {
+        let dbURL = URL(fileURLWithPath: ("~/.omp/agent/agent.db" as NSString).expandingTildeInPath)
+        guard let db = SQLiteStore.open(dbURL) else { return nil }
+        defer { sqlite3_close(db) }
+
+        let sql = "SELECT data FROM auth_credentials WHERE provider = 'google-antigravity' ORDER BY updated_at DESC LIMIT 1;"
+        let rows = SQLiteStore.rows(in: db, sql: sql)
+        guard let first = rows.first, let data = first.data(using: .utf8) else { return nil }
+
+        struct OMPPayload: Decodable {
+            let access: String?
+            let expires: Double?
+            let projectId: String?
+            let email: String?
+        }
+
+        guard let payload = try? JSONDecoder().decode(OMPPayload.self, from: data),
+              let token = payload.access else { return nil }
+
+        let expiry = payload.expires.map { Date(timeIntervalSince1970: $0 / 1000.0) } ?? Date.distantFuture
+        return AntigravityCredentials(
+            accessToken: token,
+            expiresAt: expiry,
+            authMethod: "consumer",
+            projectId: payload.projectId,
+            email: payload.email
+        )
+    }
+
+    private static func readJSONCredentials() -> AntigravityCredentials? {
+        let path = ("~/.gemini/oauth_creds.json" as NSString).expandingTildeInPath
+        guard let data = try? Data(contentsOf: URL(fileURLWithPath: path)) else { return nil }
+
+        struct JSONPayload: Decodable {
+            let access_token: String?
+            let expiry_date: Double?
+        }
+
+        guard let payload = try? JSONDecoder().decode(JSONPayload.self, from: data),
+              let token = payload.access_token else { return nil }
+
+        let expiry = payload.expiry_date.map { Date(timeIntervalSince1970: $0 / 1000.0) } ?? Date.distantFuture
+        return AntigravityCredentials(
+            accessToken: token,
+            expiresAt: expiry,
+            authMethod: "consumer"
+        )
     }
 
     /// Split out so the decoding can be tested against a real stored value

--- a/Sources/Providers/AntigravityProvider.swift
+++ b/Sources/Providers/AntigravityProvider.swift
@@ -449,17 +449,32 @@ actor AntigravityProvider: UsageProvider {
             }
         }
 
+        let standardSlots: [(id: String, group: String, label: String, isWeekly: Bool)] = [
+            ("gemini-hourly", "Gemini Models", "5-hour Limit", false),
+            ("gemini-weekly", "Gemini Models", "Weekly Limit", true),
+            ("3p-hourly", "Claude and GPT models", "5-hour Limit", false),
+            ("3p-weekly", "Claude and GPT models", "Weekly Limit", true)
+        ]
+
         var windows: [LimitWindow] = []
-        let order = ["gemini-hourly", "gemini-weekly", "3p-hourly", "3p-weekly"]
-        for key in order {
-            if let item = latestByID[key] {
+        for slot in standardSlots {
+            if let item = latestByID[slot.id] {
                 windows.append(LimitWindow(
-                    id: key,
+                    id: slot.id,
                     group: item.group,
                     label: item.label,
                     usedFraction: item.used,
                     resetsAt: item.resets,
-                    duration: key.contains("weekly") ? 7 * 86400 : nil
+                    duration: slot.isWeekly ? 7 * 86400 : nil
+                ))
+            } else {
+                windows.append(LimitWindow(
+                    id: slot.id,
+                    group: slot.group,
+                    label: slot.label,
+                    usedFraction: 0.0,
+                    resetsAt: nil,
+                    duration: slot.isWeekly ? 7 * 86400 : nil
                 ))
             }
         }

--- a/Sources/Providers/AntigravityProvider.swift
+++ b/Sources/Providers/AntigravityProvider.swift
@@ -104,7 +104,17 @@ actor AntigravityProvider: UsageProvider {
             throw UsageProviderError.credentialExpired
         }
 
-        // If local bridge is absent, try reading credentials and asking Google directly
+        // 1. Check if OMP has recorded active usage history in its SQLite store
+        let ompWindows = Self.ompUsageWindows()
+        if !ompWindows.isEmpty {
+            let hourlies = ompWindows.filter { $0.id.lowercased().contains("hour") || $0.label.lowercased().contains("hour") }
+            let mostConstrained = hourlies.max(by: { ($0.usedFraction ?? 0) < ($1.usedFraction ?? 0) }) ?? ompWindows.max(by: { ($0.usedFraction ?? 0) < ($1.usedFraction ?? 0) })
+            return ProviderSnapshot(id: id, displayName: displayName, glyph: glyph,
+                                    fidelity: .official, status: .ok, windows: ompWindows,
+                                    headlineID: mostConstrained?.id ?? "gemini-hourly")
+        }
+
+        // 2. If local bridge and OMP are absent, try reading credentials and asking Google directly
         if let credentials = try? AntigravityCredentials.load() {
             var request = URLRequest(url: endpoint)
             request.httpMethod = "POST"
@@ -144,16 +154,6 @@ actor AntigravityProvider: UsageProvider {
                                             headlineID: mostConstrained?.id ?? "gemini-hourly")
                 }
             }
-        }
-
-        // Check if OMP has recorded recent usage history in its SQLite store
-        let ompWindows = Self.ompUsageWindows()
-        if !ompWindows.isEmpty {
-            let hourlies = ompWindows.filter { $0.id.lowercased().contains("hour") || $0.label.lowercased().contains("hour") }
-            let mostConstrained = hourlies.max(by: { ($0.usedFraction ?? 0) < ($1.usedFraction ?? 0) }) ?? ompWindows.max(by: { ($0.usedFraction ?? 0) < ($1.usedFraction ?? 0) })
-            return ProviderSnapshot(id: id, displayName: displayName, glyph: glyph,
-                                    fidelity: .official, status: .ok, windows: ompWindows,
-                                    headlineID: mostConstrained?.id ?? "gemini-hourly")
         }
 
         if everBridged { throw UsageProviderError.credentialExpired }

--- a/Sources/Providers/AntigravityProvider.swift
+++ b/Sources/Providers/AntigravityProvider.swift
@@ -105,7 +105,8 @@ actor AntigravityProvider: UsageProvider {
         }
 
         // 1. Check if OMP has recorded active usage history in its SQLite store
-        let ompWindows = Self.ompUsageWindows()
+        let credentials = try? AntigravityCredentials.load()
+        let ompWindows = Self.ompUsageWindows(forEmail: credentials?.email)
         if !ompWindows.isEmpty {
             let hourlies = ompWindows.filter { $0.id.lowercased().contains("hour") || $0.label.lowercased().contains("hour") }
             let mostConstrained = hourlies.max(by: { ($0.usedFraction ?? 0) < ($1.usedFraction ?? 0) }) ?? ompWindows.max(by: { ($0.usedFraction ?? 0) < ($1.usedFraction ?? 0) })
@@ -115,7 +116,7 @@ actor AntigravityProvider: UsageProvider {
         }
 
         // 2. If local bridge and OMP are absent, try reading credentials and asking Google directly
-        if let credentials = try? AntigravityCredentials.load() {
+        if let credentials {
             var request = URLRequest(url: endpoint)
             request.httpMethod = "POST"
             request.setValue("Bearer \(credentials.accessToken)", forHTTPHeaderField: "Authorization")
@@ -383,30 +384,59 @@ actor AntigravityProvider: UsageProvider {
         return windows
     }
 
-    static func ompUsageWindows() -> [LimitWindow] {
+    static func ompUsageWindows(forEmail email: String? = nil) -> [LimitWindow] {
         let dbURL = URL(fileURLWithPath: ("~/.omp/agent/agent.db" as NSString).expandingTildeInPath)
         guard let db = SQLiteStore.open(dbURL) else { return [] }
         defer { sqlite3_close(db) }
 
-        let sql = """
-        SELECT limit_id, label, window_label, used_fraction, resets_at
-        FROM usage_history
-        WHERE provider = 'google-antigravity'
-        ORDER BY recorded_at DESC, id DESC
-        LIMIT 30;
-        """
-        let rows = SQLiteStore.rows(in: db, sql: sql, columns: 5)
+        var targetEmail = email
+        if targetEmail == nil {
+            let sql = "SELECT email FROM usage_history WHERE provider = 'google-antigravity' AND email IS NOT NULL AND email != '' ORDER BY recorded_at DESC, id DESC LIMIT 1;"
+            var stmt: OpaquePointer?
+            if sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK {
+                if sqlite3_step(stmt) == SQLITE_ROW, let em = sqlite3_column_text(stmt, 0) {
+                    targetEmail = String(cString: em)
+                }
+                sqlite3_finalize(stmt)
+            }
+        }
+
+        let sql: String
+        if let targetEmail, !targetEmail.isEmpty {
+            sql = """
+            SELECT limit_id, label, window_label, used_fraction, resets_at
+            FROM usage_history
+            WHERE provider = 'google-antigravity' AND email = ?1
+            ORDER BY recorded_at DESC, id DESC
+            LIMIT 10;
+            """
+        } else {
+            sql = """
+            SELECT limit_id, label, window_label, used_fraction, resets_at
+            FROM usage_history
+            WHERE provider = 'google-antigravity'
+            ORDER BY recorded_at DESC, id DESC
+            LIMIT 10;
+            """
+        }
+
+        var stmt: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else { return [] }
+        defer { sqlite3_finalize(stmt) }
+
+        if let targetEmail, !targetEmail.isEmpty {
+            sqlite3_bind_text(stmt, 1, targetEmail, -1, unsafeBitCast(-1, to: sqlite3_destructor_type.self))
+        }
+
         var latestByID: [String: (group: String, label: String, used: Double, resets: Date?)] = [:]
 
-        for row in rows where row.count >= 5 {
-            let limitId = row[0]
-            guard latestByID[limitId] == nil else { continue }
-
-            let rawLabel = row[1]
-            let windowLabel = row[2].lowercased()
-            guard let usedFraction = Double(row[3]) else { continue }
-            let resetsAtMs = Double(row[4])
-            let resetsAt = (resetsAtMs != nil && resetsAtMs! > 0) ? Date(timeIntervalSince1970: resetsAtMs! / 1000.0) : nil
+        while sqlite3_step(stmt) == SQLITE_ROW {
+            let limitId = String(cString: sqlite3_column_text(stmt, 0))
+            let rawLabel = String(cString: sqlite3_column_text(stmt, 1))
+            let windowLabel = sqlite3_column_text(stmt, 2).map { String(cString: $0).lowercased() } ?? ""
+            let usedFraction = sqlite3_column_double(stmt, 3)
+            let resetsAtMs = sqlite3_column_type(stmt, 4) != SQLITE_NULL ? sqlite3_column_double(stmt, 4) : 0
+            let resetsAt = (resetsAtMs > 0) ? Date(timeIntervalSince1970: resetsAtMs / 1000.0) : nil
 
             let isGemini = limitId.contains(":google:") || rawLabel.contains("Google")
             let groupName = isGemini ? "Gemini Models" : "Claude and GPT models"
@@ -435,7 +465,6 @@ actor AntigravityProvider: UsageProvider {
         }
         return windows
     }
-
     /// The plan's display name, for the message the cell shows.
     static func tier(in data: Data) -> String {
         struct Response: Decodable {

--- a/Sources/Providers/AntigravityProvider.swift
+++ b/Sources/Providers/AntigravityProvider.swift
@@ -25,8 +25,9 @@ actor AntigravityProvider: UsageProvider {
     /// which answers 403 to this token — so it is not a fallback, it is a
     /// different audience.
     private let endpoint = URL(string: "https://cloudcode-pa.googleapis.com/v1internal:loadCodeAssist")!
-    /// The real usage figure — when the account is allowed to ask for it.
-    private let quotaEndpoint = URL(string: "https://cloudcode-pa.googleapis.com/v1internal:retrieveUserQuota")!
+    /// The real usage figure — served by Cloud Code PA.
+    private let quotaEndpoint = URL(string: "https://daily-cloudcode-pa.googleapis.com/v1internal:retrieveUserQuotaSummary")!
+    private let prodQuotaEndpoint = URL(string: "https://cloudcode-pa.googleapis.com/v1internal:retrieveUserQuotaSummary")!
     private let session: URLSession
     /// A second session, trusting loopback only, for the local language server.
     private let localSession: URLSession
@@ -104,18 +105,8 @@ actor AntigravityProvider: UsageProvider {
             throw UsageProviderError.credentialExpired
         }
 
-        // 1. Check if OMP has recorded active usage history in its SQLite store
+        // 1. Try reading credentials and asking Google Cloud Code PA directly
         let credentials = try? AntigravityCredentials.load()
-        let ompWindows = Self.ompUsageWindows(forEmail: credentials?.email)
-        if !ompWindows.isEmpty {
-            let hourlies = ompWindows.filter { $0.id.lowercased().contains("hour") || $0.label.lowercased().contains("hour") }
-            let mostConstrained = hourlies.max(by: { ($0.usedFraction ?? 0) < ($1.usedFraction ?? 0) }) ?? ompWindows.max(by: { ($0.usedFraction ?? 0) < ($1.usedFraction ?? 0) })
-            return ProviderSnapshot(id: id, displayName: displayName, glyph: glyph,
-                                    fidelity: .official, status: .ok, windows: ompWindows,
-                                    headlineID: mostConstrained?.id ?? "gemini-hourly")
-        }
-
-        // 2. If local bridge and OMP are absent, try reading credentials and asking Google directly
         if let credentials {
             var request = URLRequest(url: endpoint)
             request.httpMethod = "POST"
@@ -148,13 +139,23 @@ actor AntigravityProvider: UsageProvider {
                 }
 
                 if let windows = try? await quota(token: credentials.accessToken, project: companionProject), !windows.isEmpty {
-                    let hourlies = windows.filter { $0.id.lowercased().contains("hour") || $0.label.lowercased().contains("hour") }
+                    let hourlies = windows.filter { $0.id.lowercased().contains("hour") || $0.label.lowercased().contains("hour") || $0.id.lowercased().contains("5h") }
                     let mostConstrained = hourlies.max(by: { ($0.usedFraction ?? 0) < ($1.usedFraction ?? 0) }) ?? windows.max(by: { ($0.usedFraction ?? 0) < ($1.usedFraction ?? 0) })
                     return ProviderSnapshot(id: id, displayName: displayName, glyph: glyph,
                                             fidelity: .official, status: .ok, windows: windows,
-                                            headlineID: mostConstrained?.id ?? "gemini-hourly")
+                                            headlineID: mostConstrained?.id ?? "gemini-5h")
                 }
             }
+        }
+
+        // 2. Fallback to OMP SQLite store if offline or direct call fails
+        let ompWindows = Self.ompUsageWindows(forEmail: credentials?.email)
+        if !ompWindows.isEmpty {
+            let hourlies = ompWindows.filter { $0.id.lowercased().contains("hour") || $0.label.lowercased().contains("hour") || $0.id.lowercased().contains("5h") }
+            let mostConstrained = hourlies.max(by: { ($0.usedFraction ?? 0) < ($1.usedFraction ?? 0) }) ?? ompWindows.max(by: { ($0.usedFraction ?? 0) < ($1.usedFraction ?? 0) })
+            return ProviderSnapshot(id: id, displayName: displayName, glyph: glyph,
+                                    fidelity: .official, status: .ok, windows: ompWindows,
+                                    headlineID: mostConstrained?.id ?? "gemini-5h")
         }
 
         if everBridged { throw UsageProviderError.credentialExpired }
@@ -220,19 +221,24 @@ actor AntigravityProvider: UsageProvider {
     /// formed, the entitlement is what is missing. That is not an error worth
     /// alarming anyone about, so it returns nil and the caller falls back.
     private func quota(token: String, project: String? = nil) async throws -> [LimitWindow]? {
-        var request = URLRequest(url: quotaEndpoint)
-        request.httpMethod = "POST"
-        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
-        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.setValue("antigravity/hub/2.8.0 (aidev_client; os_type=darwin; arch=arm64; cl=963137146)", forHTTPHeaderField: "User-Agent")
-        request.setValue("ideType=IDE_UNSPECIFIED,platform=PLATFORM_UNSPECIFIED,pluginType=GEMINI", forHTTPHeaderField: "Client-Metadata")
-        let bodyObj: [String: Any] = (project != nil && !project!.isEmpty) ? ["project": project!] : ["project": "aicode-consumers"]
-        request.httpBody = try? JSONSerialization.data(withJSONObject: bodyObj)
-        request.timeoutInterval = 15
+        for url in [quotaEndpoint, prodQuotaEndpoint] {
+            var request = URLRequest(url: url)
+            request.httpMethod = "POST"
+            request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+            request.setValue("antigravity/hub/2.8.0 (aidev_client; os_type=darwin; arch=arm64; cl=963137146)", forHTTPHeaderField: "User-Agent")
+            request.setValue("ideType=IDE_UNSPECIFIED,platform=PLATFORM_UNSPECIFIED,pluginType=GEMINI", forHTTPHeaderField: "Client-Metadata")
+            let bodyObj: [String: Any] = (project != nil && !project!.isEmpty) ? ["project": project!] : [:]
+            request.httpBody = try? JSONSerialization.data(withJSONObject: bodyObj)
+            request.timeoutInterval = 15
 
-        let (data, response) = try await session.data(for: request)
-        guard (response as? HTTPURLResponse)?.statusCode == 200 else { return nil }
-        return Self.windows(in: data)
+            if let (data, response) = try? await session.data(for: request),
+               (response as? HTTPURLResponse)?.statusCode == 200 {
+                let parsed = Self.windows(in: data)
+                if !parsed.isEmpty { return parsed }
+            }
+        }
+        return nil
     }
 
     /// Turns a quota summary into standard limit windows.
@@ -282,6 +288,9 @@ actor AntigravityProvider: UsageProvider {
                         var bucketLabel = bucket.displayName ?? "Usage"
                         if bucketLabel.hasSuffix(" Remaining") {
                             bucketLabel = String(bucketLabel.dropLast(" Remaining".count))
+                        }
+                        if bucketLabel == "Five Hour Limit" {
+                            bucketLabel = "5-hour Limit"
                         }
                         let groupLabel = group.displayName ?? ""
                         return LimitWindow(

--- a/Sources/Providers/AntigravityProvider.swift
+++ b/Sources/Providers/AntigravityProvider.swift
@@ -189,7 +189,7 @@ actor AntigravityProvider: UsageProvider {
             status: .ok,
             windows: [
                 LimitWindow(id: "requests",
-                            label: "Requests today · no limit published",
+                            label: activity.label(),
                             used: activity.requestsToday)
             ]
         )

--- a/Sources/Providers/AntigravityProvider.swift
+++ b/Sources/Providers/AntigravityProvider.swift
@@ -27,7 +27,6 @@ actor AntigravityProvider: UsageProvider {
     private let endpoint = URL(string: "https://cloudcode-pa.googleapis.com/v1internal:loadCodeAssist")!
     /// The real usage figure — served by Cloud Code PA.
     private let quotaEndpoint = URL(string: "https://daily-cloudcode-pa.googleapis.com/v1internal:retrieveUserQuotaSummary")!
-    private let prodQuotaEndpoint = URL(string: "https://cloudcode-pa.googleapis.com/v1internal:retrieveUserQuotaSummary")!
     private let session: URLSession
     /// A second session, trusting loopback only, for the local language server.
     private let localSession: URLSession
@@ -93,12 +92,10 @@ actor AntigravityProvider: UsageProvider {
             everBridged = true
             UserDefaults.standard.set(true, forKey: "AntigravityEverBridged")
             
-            let hourlies = windows.filter { $0.id.lowercased().contains("hour") || $0.label.lowercased().contains("hour") }
-            let mostConstrained = hourlies.max(by: { ($0.usedFraction ?? 0) < ($1.usedFraction ?? 0) }) ?? windows.max(by: { ($0.usedFraction ?? 0) < ($1.usedFraction ?? 0) })
-            
+            let mostConstrained = windows.max(by: { ($0.usedFraction ?? 0) < ($1.usedFraction ?? 0) })
             return ProviderSnapshot(id: id, displayName: displayName, glyph: glyph,
                                     fidelity: .official, status: .ok, windows: windows,
-                                    headlineID: mostConstrained?.id ?? "gemini-hourly")
+                                    headlineID: mostConstrained?.id ?? "gemini-5h")
         }
 
         if localQuotaOverride != nil && everBridged {
@@ -107,52 +104,19 @@ actor AntigravityProvider: UsageProvider {
 
         // 1. Try reading credentials and asking Google Cloud Code PA directly
         let credentials = try? AntigravityCredentials.load()
-        if let credentials {
-            var request = URLRequest(url: endpoint)
-            request.httpMethod = "POST"
-            request.setValue("Bearer \(credentials.accessToken)", forHTTPHeaderField: "Authorization")
-            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-            request.setValue("antigravity/hub/2.8.0 (aidev_client; os_type=darwin; arch=arm64; cl=963137146)", forHTTPHeaderField: "User-Agent")
-            request.setValue("ideType=IDE_UNSPECIFIED,platform=PLATFORM_UNSPECIFIED,pluginType=GEMINI", forHTTPHeaderField: "Client-Metadata")
-            request.httpBody = try? JSONSerialization.data(
-                withJSONObject: [
-                    "cloudaicompanionProject": credentials.projectId as Any,
-                    "metadata": [
-                        "ideType": "IDE_UNSPECIFIED",
-                        "platform": "PLATFORM_UNSPECIFIED",
-                        "pluginType": "GEMINI"
-                    ]
-                ]
-            )
-            request.timeoutInterval = 15
-
-            if let (data, response) = try? await session.data(for: request),
-               let httpResp = response as? HTTPURLResponse, httpResp.statusCode == 200 {
-                var companionProject = credentials.projectId
-                if let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
-                    if let p = obj["cloudaicompanionProject"] as? String {
-                        companionProject = p
-                    } else if let pObj = obj["cloudaicompanionProject"] as? [String: Any],
-                              let p = pObj["id"] as? String {
-                        companionProject = p
-                    }
-                }
-
-                if let windows = try? await quota(token: credentials.accessToken, project: companionProject), !windows.isEmpty {
-                    let hourlies = windows.filter { $0.id.lowercased().contains("hour") || $0.label.lowercased().contains("hour") || $0.id.lowercased().contains("5h") }
-                    let mostConstrained = hourlies.max(by: { ($0.usedFraction ?? 0) < ($1.usedFraction ?? 0) }) ?? windows.max(by: { ($0.usedFraction ?? 0) < ($1.usedFraction ?? 0) })
-                    return ProviderSnapshot(id: id, displayName: displayName, glyph: glyph,
-                                            fidelity: .official, status: .ok, windows: windows,
-                                            headlineID: mostConstrained?.id ?? "gemini-5h")
-                }
-            }
+        if let credentials,
+           let windows = try? await quota(token: credentials.accessToken, project: credentials.projectId),
+           !windows.isEmpty {
+            let mostConstrained = windows.max(by: { ($0.usedFraction ?? 0) < ($1.usedFraction ?? 0) })
+            return ProviderSnapshot(id: id, displayName: displayName, glyph: glyph,
+                                    fidelity: .official, status: .ok, windows: windows,
+                                    headlineID: mostConstrained?.id ?? "gemini-5h")
         }
 
         // 2. Fallback to OMP SQLite store if offline or direct call fails
         let ompWindows = Self.ompUsageWindows(forEmail: credentials?.email)
         if !ompWindows.isEmpty {
-            let hourlies = ompWindows.filter { $0.id.lowercased().contains("hour") || $0.label.lowercased().contains("hour") || $0.id.lowercased().contains("5h") }
-            let mostConstrained = hourlies.max(by: { ($0.usedFraction ?? 0) < ($1.usedFraction ?? 0) }) ?? ompWindows.max(by: { ($0.usedFraction ?? 0) < ($1.usedFraction ?? 0) })
+            let mostConstrained = ompWindows.max(by: { ($0.usedFraction ?? 0) < ($1.usedFraction ?? 0) })
             return ProviderSnapshot(id: id, displayName: displayName, glyph: glyph,
                                     fidelity: .official, status: .ok, windows: ompWindows,
                                     headlineID: mostConstrained?.id ?? "gemini-5h")
@@ -217,28 +181,20 @@ actor AntigravityProvider: UsageProvider {
     /// Ask for the account's quota, returning nil when it is not allowed to.
     ///
     /// A free or personal account answers 403 #3501, "You do not have a valid
-    /// license of this product" — the endpoint exists and the request is well
-    /// formed, the entitlement is what is missing. That is not an error worth
-    /// alarming anyone about, so it returns nil and the caller falls back.
     private func quota(token: String, project: String? = nil) async throws -> [LimitWindow]? {
-        for url in [quotaEndpoint, prodQuotaEndpoint] {
-            var request = URLRequest(url: url)
-            request.httpMethod = "POST"
-            request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
-            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-            request.setValue("antigravity/hub/2.8.0 (aidev_client; os_type=darwin; arch=arm64; cl=963137146)", forHTTPHeaderField: "User-Agent")
-            request.setValue("ideType=IDE_UNSPECIFIED,platform=PLATFORM_UNSPECIFIED,pluginType=GEMINI", forHTTPHeaderField: "Client-Metadata")
-            let bodyObj: [String: Any] = (project != nil && !project!.isEmpty) ? ["project": project!] : [:]
-            request.httpBody = try? JSONSerialization.data(withJSONObject: bodyObj)
-            request.timeoutInterval = 15
+        var request = URLRequest(url: quotaEndpoint)
+        request.httpMethod = "POST"
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("antigravity/hub/2.8.0 (aidev_client; os_type=darwin; arch=arm64; cl=963137146)", forHTTPHeaderField: "User-Agent")
+        request.setValue("ideType=IDE_UNSPECIFIED,platform=PLATFORM_UNSPECIFIED,pluginType=GEMINI", forHTTPHeaderField: "Client-Metadata")
+        let bodyObj: [String: Any] = (project != nil && !project!.isEmpty) ? ["project": project!] : [:]
+        request.httpBody = try? JSONSerialization.data(withJSONObject: bodyObj)
+        request.timeoutInterval = 15
 
-            if let (data, response) = try? await session.data(for: request),
-               (response as? HTTPURLResponse)?.statusCode == 200 {
-                let parsed = Self.windows(in: data)
-                if !parsed.isEmpty { return parsed }
-            }
-        }
-        return nil
+        guard let (data, response) = try? await session.data(for: request),
+              (response as? HTTPURLResponse)?.statusCode == 200 else { return nil }
+        return Self.windows(in: data)
     }
 
     /// Turns a quota summary into standard limit windows.

--- a/Sources/Providers/AntigravityProvider.swift
+++ b/Sources/Providers/AntigravityProvider.swift
@@ -65,27 +65,13 @@ actor AntigravityProvider: UsageProvider {
     nonisolated func forgetCachedCredential() { AntigravityCredentials.forgetCached() }
 
     nonisolated func account() -> ProviderAccount? {
-        if UserDefaults.standard.bool(forKey: "AntigravityEverBridged") {
-            return ProviderAccount(
-                label: nil,
-                plan: "IDE Session",
-                source: "Antigravity IDE",
-                manageURL: URL(string: "https://antigravity.google")
-            )
-        }
-        // Presence, not contents. This row is rebuilt every time the settings
-        // window renders, and reading the secret to print a plan name made
-        // opening Settings raise the keychain dialogue — the same interruption
-        // the readings themselves now avoid. The item's attributes answer
-        // "is there an account" without being behind that prompt.
         guard AntigravityCredentials.isSignedIn() else { return nil }
-        // Named only when a fetch has already had to read the token, which is
-        // exactly when Antigravity is not running to be asked instead. A blank
-        // plan is a smaller loss than a dialogue nobody asked for.
         let held = AntigravityCredentials.held
+        let email = held?.email
+        let plan = held.map { $0.authMethod == "consumer" ? "Personal" : $0.authMethod } ?? "Personal"
         return ProviderAccount(
-            label: nil,   // the token carries no address
-            plan: held.map { $0.authMethod == "consumer" ? "Personal" : $0.authMethod },
+            label: email,
+            plan: plan,
             source: "Antigravity",
             manageURL: URL(string: "https://antigravity.google")
         )
@@ -106,8 +92,6 @@ actor AntigravityProvider: UsageProvider {
             everBridged = true
             UserDefaults.standard.set(true, forKey: "AntigravityEverBridged")
             
-            // Antigravity now has multiple limits (Weekly, 5-hour).
-            // The user prefers the 'hour' limit to be shown as the main notch ring percentage.
             let hourlies = windows.filter { $0.id.lowercased().contains("hour") || $0.label.lowercased().contains("hour") }
             let mostConstrained = hourlies.max(by: { ($0.usedFraction ?? 0) < ($1.usedFraction ?? 0) }) ?? windows.max(by: { ($0.usedFraction ?? 0) < ($1.usedFraction ?? 0) })
             
@@ -116,85 +100,63 @@ actor AntigravityProvider: UsageProvider {
                                     headlineID: mostConstrained?.id ?? "gemini-hourly")
         }
 
-        // Antigravity has answered before and is not answering now: it has been
-        // closed or restarted. Keep the last percentage, dimmed and dated,
-        // rather than swapping in a count — and still without a prompt, which
-        // asking for the token here would have caused.
-        if everBridged { throw UsageProviderError.credentialExpired }
+        if localQuotaOverride != nil && everBridged {
+            throw UsageProviderError.credentialExpired
+        }
 
-        let credentials = try AntigravityCredentials.load()
-        // Expired is not signed out: Antigravity refreshes this on its own the
-        // next time it runs, and the last reading is still true, just old.
-        if credentials.isExpired { throw UsageProviderError.credentialExpired }
-
-        var request = URLRequest(url: endpoint)
-        request.httpMethod = "POST"
-        request.setValue("Bearer \(credentials.accessToken)", forHTTPHeaderField: "Authorization")
-        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.setValue("antigravity/hub/2.8.0 (aidev_client; os_type=darwin; arch=arm64; cl=963137146)", forHTTPHeaderField: "User-Agent")
-        request.setValue("ideType=IDE_UNSPECIFIED,platform=PLATFORM_UNSPECIFIED,pluginType=GEMINI", forHTTPHeaderField: "Client-Metadata")
-        request.httpBody = try JSONSerialization.data(
-            withJSONObject: [
-                "cloudaicompanionProject": credentials.projectId as Any,
-                "metadata": [
-                    "ideType": "IDE_UNSPECIFIED",
-                    "platform": "PLATFORM_UNSPECIFIED",
-                    "pluginType": "GEMINI"
+        // If local bridge is absent, try reading credentials and asking Google directly
+        if let credentials = try? AntigravityCredentials.load() {
+            var request = URLRequest(url: endpoint)
+            request.httpMethod = "POST"
+            request.setValue("Bearer \(credentials.accessToken)", forHTTPHeaderField: "Authorization")
+            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+            request.setValue("antigravity/hub/2.8.0 (aidev_client; os_type=darwin; arch=arm64; cl=963137146)", forHTTPHeaderField: "User-Agent")
+            request.setValue("ideType=IDE_UNSPECIFIED,platform=PLATFORM_UNSPECIFIED,pluginType=GEMINI", forHTTPHeaderField: "Client-Metadata")
+            request.httpBody = try? JSONSerialization.data(
+                withJSONObject: [
+                    "cloudaicompanionProject": credentials.projectId as Any,
+                    "metadata": [
+                        "ideType": "IDE_UNSPECIFIED",
+                        "platform": "PLATFORM_UNSPECIFIED",
+                        "pluginType": "GEMINI"
+                    ]
                 ]
-            ]
-        )
-        request.timeoutInterval = 15
+            )
+            request.timeoutInterval = 15
 
-        let (data, response) = try await session.data(for: request)
-        let status = (response as? HTTPURLResponse)?.statusCode ?? 0
+            if let (data, response) = try? await session.data(for: request),
+               let httpResp = response as? HTTPURLResponse, httpResp.statusCode == 200 {
+                var companionProject = credentials.projectId
+                if let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
+                    if let p = obj["cloudaicompanionProject"] as? String {
+                        companionProject = p
+                    } else if let pObj = obj["cloudaicompanionProject"] as? [String: Any],
+                              let p = pObj["id"] as? String {
+                        companionProject = p
+                    }
+                }
 
-        if status == 401 {
-            // Same reasoning as Claude's: rejected but unexpired means the
-            // account underneath has changed.
-            AntigravityCredentials.forgetCached()
-            UserDefaults.standard.removeObject(forKey: "AntigravityEverBridged")
-            throw UsageProviderError.needsAuth
-        }
-        if status == 403 {
-            UserDefaults.standard.removeObject(forKey: "AntigravityEverBridged")
-            throw UsageProviderError.needsAuth
-        }
-        if status == 429 {
-            let retry = (response as? HTTPURLResponse)?
-                .value(forHTTPHeaderField: "Retry-After").flatMap(TimeInterval.init)
-            throw UsageProviderError.rateLimited(retryAfter: retry ?? 0)
-        }
-        guard status == 200 else { throw UsageProviderError.badResponse(status: status) }
-
-        var companionProject = credentials.projectId
-        if let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
-            if let p = obj["cloudaicompanionProject"] as? String {
-                companionProject = p
-            } else if let pObj = obj["cloudaicompanionProject"] as? [String: Any],
-                      let p = pObj["id"] as? String {
-                companionProject = p
+                if let windows = try? await quota(token: credentials.accessToken, project: companionProject), !windows.isEmpty {
+                    let hourlies = windows.filter { $0.id.lowercased().contains("hour") || $0.label.lowercased().contains("hour") }
+                    let mostConstrained = hourlies.max(by: { ($0.usedFraction ?? 0) < ($1.usedFraction ?? 0) }) ?? windows.max(by: { ($0.usedFraction ?? 0) < ($1.usedFraction ?? 0) })
+                    return ProviderSnapshot(id: id, displayName: displayName, glyph: glyph,
+                                            fidelity: .official, status: .ok, windows: windows,
+                                            headlineID: mostConstrained?.id ?? "gemini-hourly")
+                }
             }
-        }
-
-        // Then Google directly, which answers for both licensed accounts and
-        // consumer accounts when addressed with proper client metadata.
-        if let windows = try await quota(token: credentials.accessToken, project: companionProject), !windows.isEmpty {
-            let hourlies = windows.filter { $0.id.lowercased().contains("hour") || $0.label.lowercased().contains("hour") || $0.id.lowercased().contains("flash") }
-            let mostConstrained = hourlies.max(by: { ($0.usedFraction ?? 0) < ($1.usedFraction ?? 0) }) ?? windows.max(by: { ($0.usedFraction ?? 0) < ($1.usedFraction ?? 0) })
-            return ProviderSnapshot(id: id, displayName: displayName, glyph: glyph,
-                                    fidelity: .official, status: .ok, windows: windows,
-                                    headlineID: mostConstrained?.id ?? "gemini-quota")
         }
 
         // Check if OMP has recorded recent usage history in its SQLite store
         let ompWindows = Self.ompUsageWindows()
         if !ompWindows.isEmpty {
-            let mostConstrained = ompWindows.max(by: { ($0.usedFraction ?? 0) < ($1.usedFraction ?? 0) })
+            let hourlies = ompWindows.filter { $0.id.lowercased().contains("hour") || $0.label.lowercased().contains("hour") }
+            let mostConstrained = hourlies.max(by: { ($0.usedFraction ?? 0) < ($1.usedFraction ?? 0) }) ?? ompWindows.max(by: { ($0.usedFraction ?? 0) < ($1.usedFraction ?? 0) })
             return ProviderSnapshot(id: id, displayName: displayName, glyph: glyph,
                                     fidelity: .official, status: .ok, windows: ompWindows,
-                                    headlineID: mostConstrained?.id ?? "gemini-quota")
+                                    headlineID: mostConstrained?.id ?? "gemini-hourly")
         }
-        // Not licensed, so Google will not say how much of what. Our own count
+
+        if everBridged { throw UsageProviderError.credentialExpired }
         // is the only number left — reported as a *count*, with no
         // `usedFraction`, which is a case the model already knows: the cell
         // prints the number and the ring draws its track with no arc, because

--- a/Sources/Providers/AntigravityProvider.swift
+++ b/Sources/Providers/AntigravityProvider.swift
@@ -1,6 +1,6 @@
 import Foundation
+import SQLite3
 import os
-
 /// Gemini, as Antigravity sees it.
 ///
 /// **What this can and cannot report, and why.** Antigravity talks to Google's
@@ -26,7 +26,7 @@ actor AntigravityProvider: UsageProvider {
     /// different audience.
     private let endpoint = URL(string: "https://cloudcode-pa.googleapis.com/v1internal:loadCodeAssist")!
     /// The real usage figure — when the account is allowed to ask for it.
-    private let quotaEndpoint = URL(string: "https://cloudcode-pa.googleapis.com/v1internal:retrieveUserQuotaSummary")!
+    private let quotaEndpoint = URL(string: "https://cloudcode-pa.googleapis.com/v1internal:retrieveUserQuota")!
     private let session: URLSession
     /// A second session, trusting loopback only, for the local language server.
     private let localSession: URLSession
@@ -131,19 +131,21 @@ actor AntigravityProvider: UsageProvider {
         request.httpMethod = "POST"
         request.setValue("Bearer \(credentials.accessToken)", forHTTPHeaderField: "Authorization")
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        // `GEMINI` and not `ANTIGRAVITY`: the latter is rejected outright with
-        // "Invalid value at 'metadata.plugin_type'". The wire name lags the
-        // product name.
+        request.setValue("antigravity/hub/2.8.0 (aidev_client; os_type=darwin; arch=arm64; cl=963137146)", forHTTPHeaderField: "User-Agent")
+        request.setValue("ideType=IDE_UNSPECIFIED,platform=PLATFORM_UNSPECIFIED,pluginType=GEMINI", forHTTPHeaderField: "Client-Metadata")
         request.httpBody = try JSONSerialization.data(
-            withJSONObject: ["metadata": ["pluginType": "GEMINI"]]
+            withJSONObject: [
+                "cloudaicompanionProject": credentials.projectId as Any,
+                "metadata": [
+                    "ideType": "IDE_UNSPECIFIED",
+                    "platform": "PLATFORM_UNSPECIFIED",
+                    "pluginType": "GEMINI"
+                ]
+            ]
         )
         request.timeoutInterval = 15
 
-        // The body is not read. `:loadCodeAssist` answers with tiers and no
-        // numbers — no used, no limit, no reset — so the only thing this call
-        // still contributes is its status code, which separates "signed out"
-        // from "something else went wrong" before the quota endpoint is tried.
-        let (_, response) = try await session.data(for: request)
+        let (data, response) = try await session.data(for: request)
         let status = (response as? HTTPURLResponse)?.statusCode ?? 0
 
         if status == 401 {
@@ -164,12 +166,34 @@ actor AntigravityProvider: UsageProvider {
         }
         guard status == 200 else { throw UsageProviderError.badResponse(status: status) }
 
-        // Then Google directly, which answers for a licensed account.
-        if let windows = try await quota(token: credentials.accessToken), !windows.isEmpty {
-            return ProviderSnapshot(id: id, displayName: displayName, glyph: glyph,
-                                    fidelity: .official, status: .ok, windows: windows)
+        var companionProject = credentials.projectId
+        if let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
+            if let p = obj["cloudaicompanionProject"] as? String {
+                companionProject = p
+            } else if let pObj = obj["cloudaicompanionProject"] as? [String: Any],
+                      let p = pObj["id"] as? String {
+                companionProject = p
+            }
         }
 
+        // Then Google directly, which answers for both licensed accounts and
+        // consumer accounts when addressed with proper client metadata.
+        if let windows = try await quota(token: credentials.accessToken, project: companionProject), !windows.isEmpty {
+            let hourlies = windows.filter { $0.id.lowercased().contains("hour") || $0.label.lowercased().contains("hour") || $0.id.lowercased().contains("flash") }
+            let mostConstrained = hourlies.max(by: { ($0.usedFraction ?? 0) < ($1.usedFraction ?? 0) }) ?? windows.max(by: { ($0.usedFraction ?? 0) < ($1.usedFraction ?? 0) })
+            return ProviderSnapshot(id: id, displayName: displayName, glyph: glyph,
+                                    fidelity: .official, status: .ok, windows: windows,
+                                    headlineID: mostConstrained?.id ?? "gemini-quota")
+        }
+
+        // Check if OMP has recorded recent usage history in its SQLite store
+        let ompWindows = Self.ompUsageWindows()
+        if !ompWindows.isEmpty {
+            let mostConstrained = ompWindows.max(by: { ($0.usedFraction ?? 0) < ($1.usedFraction ?? 0) })
+            return ProviderSnapshot(id: id, displayName: displayName, glyph: glyph,
+                                    fidelity: .official, status: .ok, windows: ompWindows,
+                                    headlineID: mostConstrained?.id ?? "gemini-quota")
+        }
         // Not licensed, so Google will not say how much of what. Our own count
         // is the only number left — reported as a *count*, with no
         // `usedFraction`, which is a case the model already knows: the cell
@@ -232,14 +256,15 @@ actor AntigravityProvider: UsageProvider {
     /// license of this product" — the endpoint exists and the request is well
     /// formed, the entitlement is what is missing. That is not an error worth
     /// alarming anyone about, so it returns nil and the caller falls back.
-    private func quota(token: String) async throws -> [LimitWindow]? {
+    private func quota(token: String, project: String? = nil) async throws -> [LimitWindow]? {
         var request = URLRequest(url: quotaEndpoint)
         request.httpMethod = "POST"
         request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        // Empty on purpose. The request message carries no fields — sending
-        // `metadata` or `quotaId` is rejected outright with "Unknown name".
-        request.httpBody = Data("{}".utf8)
+        request.setValue("antigravity/hub/2.8.0 (aidev_client; os_type=darwin; arch=arm64; cl=963137146)", forHTTPHeaderField: "User-Agent")
+        request.setValue("ideType=IDE_UNSPECIFIED,platform=PLATFORM_UNSPECIFIED,pluginType=GEMINI", forHTTPHeaderField: "Client-Metadata")
+        let bodyObj: [String: Any] = (project != nil && !project!.isEmpty) ? ["project": project!] : ["project": "aicode-consumers"]
+        request.httpBody = try? JSONSerialization.data(withJSONObject: bodyObj)
         request.timeoutInterval = 15
 
         let (data, response) = try await session.data(for: request)
@@ -247,45 +272,206 @@ actor AntigravityProvider: UsageProvider {
         return Self.windows(in: data)
     }
 
-    /// Turns a quota summary into limit windows.
+    /// Turns a quota summary into standard limit windows.
     ///
-    /// Written from the message names in Antigravity's own binary
-    /// (`QuotaSummaryGroup`, `QuotaSummaryBucket`, `QuotaLimit`) because no
-    /// licensed account was available to answer with a real body. So it is
-    /// deliberately suspicious of itself: anything without a positive limit, or
-    /// claiming more used than the limit allows, is dropped rather than shown.
-    /// An empty result sends the caller to the honest fallback, which is the
-    /// right outcome for a shape that turns out to differ.
-    static func windows(in data: Data) -> [LimitWindow] {
-        struct Response: Decodable {
+    /// Standard Antigravity exposes two groups with two windows each:
+    /// 1. "Gemini Models" -> 5-hour Limit & Weekly Limit
+    /// 2. "Claude and GPT models" -> 5-hour Limit & Weekly Limit
+    ///
+    /// Both the local language server (which already provides grouped buckets)
+    /// and direct Google Cloud Code PA `retrieveUserQuota` responses (which list
+    /// individual model buckets) are normalized into this standard 4-window structure.
+    static func windows(in data: Data, now: Date = Date()) -> [LimitWindow] {
+        struct DirectResponse: Decodable {
             struct Bucket: Decodable {
+                let modelId: String?
+                let bucketId: String?
                 let name: String?
                 let displayName: String?
+                let remainingFraction: Double?
                 let used: Double?
                 let limit: Double?
                 let resetTime: String?
+                let window: String?
             }
             struct Group: Decodable {
                 let displayName: String?
                 let buckets: [Bucket]?
             }
-            let quotaGroups: [Group]?
             let buckets: [Bucket]?
+            let groups: [Group]?
+            let quotaGroups: [Group]?
+            let response: GroupBody?
+            struct GroupBody: Decodable {
+                let groups: [Group]?
+            }
         }
 
-        guard let decoded = try? JSONDecoder().decode(Response.self, from: data) else { return [] }
-        let buckets = (decoded.quotaGroups?.flatMap { $0.buckets ?? [] } ?? []) + (decoded.buckets ?? [])
+        guard let decoded = try? JSONDecoder().decode(DirectResponse.self, from: data) else { return [] }
 
-        return buckets.compactMap { bucket in
-            guard let limit = bucket.limit, limit > 0,
-                  let used = bucket.used, used >= 0, used <= limit * 1.5
-            else { return nil }
-            let label = bucket.displayName ?? bucket.name ?? "Usage"
-            return LimitWindow(id: bucket.name ?? label,
-                               label: label,
-                               usedFraction: used / limit,
-                               resetsAt: bucket.resetTime.flatMap(AntigravityCredentials.parse))
+        // Pre-grouped response from local server or legacy wrapper
+        let groups = (decoded.response?.groups ?? []) + (decoded.groups ?? []) + (decoded.quotaGroups ?? [])
+        if !groups.isEmpty {
+            return groups.flatMap { group -> [LimitWindow] in
+                (group.buckets ?? []).compactMap { bucket in
+                    let rawID = bucket.bucketId ?? bucket.modelId ?? bucket.name ?? group.displayName ?? "quota"
+                    if let remaining = bucket.remainingFraction, remaining >= 0, remaining <= 1 {
+                        var bucketLabel = bucket.displayName ?? "Usage"
+                        if bucketLabel.hasSuffix(" Remaining") {
+                            bucketLabel = String(bucketLabel.dropLast(" Remaining".count))
+                        }
+                        let groupLabel = group.displayName ?? ""
+                        return LimitWindow(
+                            id: rawID,
+                            group: groupLabel.isEmpty ? nil : groupLabel,
+                            label: bucketLabel,
+                            usedFraction: 1 - remaining,
+                            resetsAt: bucket.resetTime.flatMap(AntigravityCredentials.parse),
+                            duration: bucket.window == "weekly" ? 7 * 86400 : nil
+                        )
+                    }
+                    if let limit = bucket.limit, limit > 0, let used = bucket.used, used >= 0, used <= limit * 1.5 {
+                        let label = bucket.displayName ?? rawID
+                        return LimitWindow(
+                            id: rawID,
+                            group: group.displayName,
+                            label: label,
+                            usedFraction: used / limit,
+                            resetsAt: bucket.resetTime.flatMap(AntigravityCredentials.parse)
+                        )
+                    }
+                    return nil
+                }
+            }
         }
+
+        // Direct model-level buckets from Google Cloud Code PA `retrieveUserQuota`
+        guard let buckets = decoded.buckets, !buckets.isEmpty else { return [] }
+
+        // If buckets are in legacy/explicit used and limit format
+        if buckets.contains(where: { $0.limit != nil }) {
+            return buckets.compactMap { bucket in
+                guard let limit = bucket.limit, limit > 0,
+                      let used = bucket.used, used >= 0, used <= limit * 1.5
+                else { return nil }
+                let rawID = bucket.name ?? bucket.modelId ?? bucket.bucketId ?? "quota"
+                let label = bucket.displayName ?? rawID
+                return LimitWindow(
+                    id: rawID,
+                    label: label,
+                    usedFraction: used / limit,
+                    resetsAt: bucket.resetTime.flatMap(AntigravityCredentials.parse)
+                )
+            }
+        }
+
+        struct Candidate {
+            let remaining: Double
+            let resetDate: Date?
+            let isWeekly: Bool
+        }
+
+        var geminiHourly: [Candidate] = []
+        var geminiWeekly: [Candidate] = []
+        var thirdPartyHourly: [Candidate] = []
+        var thirdPartyWeekly: [Candidate] = []
+
+        for bucket in buckets {
+            guard let rem = bucket.remainingFraction, rem >= 0, rem <= 1 else { continue }
+            let model = (bucket.modelId ?? bucket.bucketId ?? "").lowercased()
+            guard !model.isEmpty && !model.starts(with: "chat_") else { continue }
+
+            let resetDate = bucket.resetTime.flatMap(AntigravityCredentials.parse)
+            let isWeekly = (bucket.window == "weekly") || (resetDate.map { $0.timeIntervalSince(now) > 24 * 3600 } ?? false)
+            let cand = Candidate(remaining: rem, resetDate: resetDate, isWeekly: isWeekly)
+
+            if model.contains("gemini") {
+                if isWeekly { geminiWeekly.append(cand) } else { geminiHourly.append(cand) }
+            } else if model.contains("claude") || model.contains("gpt") || model.contains("openai") {
+                if isWeekly { thirdPartyWeekly.append(cand) } else { thirdPartyHourly.append(cand) }
+            }
+        }
+
+        func aggregate(candidates: [Candidate], id: String, group: String, label: String, isWeekly: Bool) -> LimitWindow? {
+            guard !candidates.isEmpty else { return nil }
+            let best = candidates.min(by: { $0.remaining < $1.remaining })!
+            return LimitWindow(
+                id: id,
+                group: group,
+                label: label,
+                usedFraction: 1 - best.remaining,
+                resetsAt: best.resetDate,
+                duration: isWeekly ? 7 * 86400 : nil
+            )
+        }
+
+        var windows: [LimitWindow] = []
+        if let w = aggregate(candidates: geminiHourly, id: "gemini-hourly", group: "Gemini Models", label: "5-hour Limit", isWeekly: false) {
+            windows.append(w)
+        }
+        if let w = aggregate(candidates: geminiWeekly, id: "gemini-weekly", group: "Gemini Models", label: "Weekly Limit", isWeekly: true) {
+            windows.append(w)
+        }
+        if let w = aggregate(candidates: thirdPartyHourly, id: "3p-hourly", group: "Claude and GPT models", label: "5-hour Limit", isWeekly: false) {
+            windows.append(w)
+        }
+        if let w = aggregate(candidates: thirdPartyWeekly, id: "3p-weekly", group: "Claude and GPT models", label: "Weekly Limit", isWeekly: true) {
+            windows.append(w)
+        }
+        return windows
+    }
+
+    static func ompUsageWindows() -> [LimitWindow] {
+        let dbURL = URL(fileURLWithPath: ("~/.omp/agent/agent.db" as NSString).expandingTildeInPath)
+        guard let db = SQLiteStore.open(dbURL) else { return [] }
+        defer { sqlite3_close(db) }
+
+        let sql = """
+        SELECT limit_id, label, window_label, used_fraction, resets_at
+        FROM usage_history
+        WHERE provider = 'google-antigravity'
+        ORDER BY recorded_at DESC, id DESC
+        LIMIT 30;
+        """
+        let rows = SQLiteStore.rows(in: db, sql: sql, columns: 5)
+        var latestByID: [String: (group: String, label: String, used: Double, resets: Date?)] = [:]
+
+        for row in rows where row.count >= 5 {
+            let limitId = row[0]
+            guard latestByID[limitId] == nil else { continue }
+
+            let rawLabel = row[1]
+            let windowLabel = row[2].lowercased()
+            guard let usedFraction = Double(row[3]) else { continue }
+            let resetsAtMs = Double(row[4])
+            let resetsAt = (resetsAtMs != nil && resetsAtMs! > 0) ? Date(timeIntervalSince1970: resetsAtMs! / 1000.0) : nil
+
+            let isGemini = limitId.contains(":google:") || rawLabel.contains("Google")
+            let groupName = isGemini ? "Gemini Models" : "Claude and GPT models"
+            let isWeekly = windowLabel.contains("weekly")
+            let labelName = isWeekly ? "Weekly Limit" : "5-hour Limit"
+            let standardID = isGemini ? (isWeekly ? "gemini-weekly" : "gemini-hourly") : (isWeekly ? "3p-weekly" : "3p-hourly")
+
+            if latestByID[standardID] == nil {
+                latestByID[standardID] = (groupName, labelName, usedFraction, resetsAt)
+            }
+        }
+
+        var windows: [LimitWindow] = []
+        let order = ["gemini-hourly", "gemini-weekly", "3p-hourly", "3p-weekly"]
+        for key in order {
+            if let item = latestByID[key] {
+                windows.append(LimitWindow(
+                    id: key,
+                    group: item.group,
+                    label: item.label,
+                    usedFraction: item.used,
+                    resetsAt: item.resets,
+                    duration: key.contains("weekly") ? 7 * 86400 : nil
+                ))
+            }
+        }
+        return windows
     }
 
     /// The plan's display name, for the message the cell shows.

--- a/Sources/Sessions/AntigravityActivityMonitor.swift
+++ b/Sources/Sessions/AntigravityActivityMonitor.swift
@@ -15,17 +15,17 @@ final class AntigravityActivityMonitor: AgentActivityMonitor {
     @Published private(set) var sessions: [AgentSession] = []
     var sessionsPublisher: AnyPublisher<[AgentSession], Never> { $sessions.eraseToAnyPublisher() }
 
-    private let root: URL
+    private let roots: [URL]
     private let interval: TimeInterval
     /// How recently a transcript must have been written to count as live.
     /// Generous, because a model can think for a while between two lines.
     private let staleAfter: TimeInterval
     private var timer: Timer?
 
-    init(root: URL = AntigravityActivity.transcriptRoot,
+    init(roots: [URL] = AntigravityActivity.transcriptRoots,
          interval: TimeInterval = 2,
          staleAfter: TimeInterval = 45) {
-        self.root = root
+        self.roots = roots
         self.interval = interval
         self.staleAfter = staleAfter
     }
@@ -46,9 +46,19 @@ final class AntigravityActivityMonitor: AgentActivityMonitor {
     }
 
     private func poll() {
-        let found = Self.read(root: root, staleAfter: staleAfter)
+        let found = Self.read(roots: roots, staleAfter: staleAfter)
         guard found != sessions else { return }
         sessions = found
+    }
+
+    /// The most recent turn across every install — the same reasoning as
+    /// `AntigravityActivity.transcriptRoots`. Watching one directory meant the
+    /// ring never span for anyone whose Antigravity wrote to another.
+    static func read(roots: [URL], staleAfter: TimeInterval, now: Date = Date()) -> [AgentSession] {
+        roots
+            .flatMap { read(root: $0, staleAfter: staleAfter, now: now) }
+            .max { $0.since < $1.since }
+            .map { [$0] } ?? []
     }
 
     static func read(root: URL, staleAfter: TimeInterval, now: Date = Date()) -> [AgentSession] {

--- a/Tests/AntigravityTests.swift
+++ b/Tests/AntigravityTests.swift
@@ -123,6 +123,102 @@ final class AntigravityActivityTests: XCTestCase {
 
     private let noon = ISO8601DateFormatter().date(from: "2026-08-31T12:00:00Z")!
 
+    /// A second install, so the roots can be tested the way they actually
+    /// occur: several directories, only one of them in use.
+    private func makeRoot() throws -> URL {
+        let url = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("antigravity-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        addTeardownBlock { try? FileManager.default.removeItem(at: url) }
+        return url
+    }
+
+    private func write(_ lines: [String], to root: URL, trajectory: String) throws {
+        let dir = root.appendingPathComponent("\(trajectory)/.system_generated/logs")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        try lines.joined(separator: "\n")
+            .write(to: dir.appendingPathComponent("transcript.jsonl"),
+                   atomically: true, encoding: .utf8)
+    }
+
+    // MARK: - More than one install
+
+    /// The bug this fixes. Leaving a flavour of Antigravity behind leaves its
+    /// directory behind, so a machine that has run the IDE and moved to the CLI
+    /// has both — and reading only the first one found reported nothing while
+    /// the transcripts sat one directory over.
+    func testAnEmptyInstallBesideAUsedOneDoesNotHideIt() throws {
+        let empty = try makeRoot()
+        let used = try makeRoot()
+        try write([step("2026-08-31T09:00:00Z", source: "MODEL")], to: used, trajectory: "a")
+
+        XCTAssertEqual(AntigravityActivity.read(roots: [empty, used], now: noon).requestsToday, 1)
+    }
+
+    /// One person, one account, one number for the day.
+    func testTwoInstallsAddUp() throws {
+        let ide = try makeRoot()
+        let cli = try makeRoot()
+        try write([step("2026-08-31T09:00:00Z", source: "MODEL")], to: ide, trajectory: "a")
+        try write([step("2026-08-31T10:00:00Z", source: "MODEL"),
+                   step("2026-08-31T11:00:00Z", source: "MODEL")], to: cli, trajectory: "b")
+
+        XCTAssertEqual(AntigravityActivity.read(roots: [ide, cli], now: noon).requestsToday, 3)
+    }
+
+    func testTheNewestRequestWinsAcrossInstalls() throws {
+        let older = try makeRoot()
+        let newer = try makeRoot()
+        try write([step("2026-08-31T09:00:00Z", source: "MODEL")], to: older, trajectory: "a")
+        try write([step("2026-08-31T11:00:00Z", source: "MODEL")], to: newer, trajectory: "b")
+
+        XCTAssertEqual(AntigravityActivity.read(roots: [older, newer], now: noon).lastRequest,
+                       ISO8601DateFormatter().date(from: "2026-08-31T11:00:00Z"))
+    }
+
+    func testNoInstallsAtAllIsNotAnError() {
+        XCTAssertEqual(AntigravityActivity.read(roots: [], now: noon).requestsToday, 0)
+    }
+
+    /// The bug itself, at the point it was made: choosing between the
+    /// directories rather than reading all of them.
+    ///
+    /// All four exist on a machine that has run more than one flavour — nothing
+    /// removes the old one — so "the first that exists" is not a choice between
+    /// a real install and a missing one. It picked an empty directory while the
+    /// transcripts sat in the next.
+    func testEveryInstallsBrainIsFoundNotJustTheFirst() throws {
+        let home = try makeRoot()
+        let gemini = home.appendingPathComponent(".gemini")
+        for name in ["antigravity", "antigravity-backup", "antigravity-cli", "antigravity-ide"] {
+            try FileManager.default.createDirectory(
+                at: gemini.appendingPathComponent("\(name)/brain"),
+                withIntermediateDirectories: true
+            )
+        }
+        // Something else living under `.gemini` is not an Antigravity install.
+        try FileManager.default.createDirectory(
+            at: gemini.appendingPathComponent("history"), withIntermediateDirectories: true
+        )
+
+        let roots = AntigravityActivity.transcriptRoots(home: home)
+
+        XCTAssertEqual(roots.count, 4, "found \(roots.map(\.path))")
+        XCTAssertTrue(roots.allSatisfy { $0.lastPathComponent == "brain" })
+        XCTAssertTrue(roots.contains { $0.path.contains("antigravity-cli") })
+    }
+
+    /// A directory without a `brain` is not one to read from.
+    func testAnInstallWithNoBrainIsSkipped() throws {
+        let home = try makeRoot()
+        try FileManager.default.createDirectory(
+            at: home.appendingPathComponent(".gemini/antigravity-cli"),
+            withIntermediateDirectories: true
+        )
+
+        XCTAssertTrue(AntigravityActivity.transcriptRoots(home: home).isEmpty)
+    }
+
     /// The real transcript interleaves user input and system checkpoints with
     /// model answers. Counting those would inflate the figure with work the
     /// model never did.

--- a/Tests/AntigravityTests.swift
+++ b/Tests/AntigravityTests.swift
@@ -507,6 +507,63 @@ final class AntigravityBridgeTests: XCTestCase {
         XCTAssertNil(AntigravityBridge.discover(processTable: table, listeningPorts: { _ in [] }))
     }
 
+    // MARK: - The CLI is an install too
+
+    /// Antigravity ships a CLI as well as an IDE, and it serves the same RPC.
+    /// Looking only for `language_server --csrf_token` meant someone who uses
+    /// `agy` and never installs the IDE got the counted-requests fallback while
+    /// a real quota was being served on loopback the whole time.
+    func testTheCLIIsFoundAndAsksForNoToken() throws {
+        let table = """
+        1 /sbin/launchd
+        34221 agy
+        """
+        let endpoint = try XCTUnwrap(
+            AntigravityBridge.discover(processTable: table, listeningPorts: { pid in
+                XCTAssertEqual(pid, 34221)
+                return [54166, 54167]
+            })
+        )
+
+        XCTAssertNil(endpoint.csrfToken, "the CLI serves this without one")
+        XCTAssertEqual(endpoint.ports, [54166, 54167])
+    }
+
+    func testTheCLIIsFoundByItsFullPathToo() throws {
+        let table = "700 /Users/someone/.local/bin/agy"
+        let endpoint = try XCTUnwrap(
+            AntigravityBridge.discover(processTable: table, listeningPorts: { _ in [9000] })
+        )
+
+        XCTAssertNil(endpoint.csrfToken)
+    }
+
+    /// The IDE keeps its place: it is the one that needs the token, and sending
+    /// none to it is the one way to be refused.
+    func testTheIDEWinsWhenBothAreRunning() throws {
+        let table = """
+        29283 /Applications/Antigravity.app/Contents/Resources/bin/language_server --csrf_token abc
+        34221 agy
+        """
+        let endpoint = try XCTUnwrap(
+            AntigravityBridge.discover(processTable: table, listeningPorts: { _ in [1] })
+        )
+
+        XCTAssertEqual(endpoint.csrfToken, "abc")
+    }
+
+    /// "agy" is three letters and turns up inside real words and real paths, so
+    /// the executable's own name is what is matched — not the line.
+    func testSomethingElseWithAgyInItIsNotTheCLI() {
+        for command in ["/opt/legacy/bin/server", "/usr/bin/agyllomerate", "500 imagy-daemon"] {
+            XCTAssertNil(
+                AntigravityBridge.discover(processTable: "500 \(command)",
+                                           listeningPorts: { _ in [1] }),
+                "\(command) was taken for the Antigravity CLI"
+            )
+        }
+    }
+
     func testItParsesPortsFromLSOF() {
         let output = """
         language_server 29283 vinz 12u IPv4 0x1 0t0 TCP 127.0.0.1:63881 (LISTEN)

--- a/Tests/AntigravityTests.swift
+++ b/Tests/AntigravityTests.swift
@@ -219,6 +219,62 @@ final class AntigravityActivityTests: XCTestCase {
         XCTAssertTrue(AntigravityActivity.transcriptRoots(home: home).isEmpty)
     }
 
+    // MARK: - What the row is called
+
+    /// A bare `0` reads as the app having found nothing, which is also what the
+    /// wrong directory looked like. Saying when it was last used tells them
+    /// apart.
+    func testAQuietDayNamesTheLastTimeItWasUsed() throws {
+        try write([step("2026-08-28T09:00:00Z", source: "MODEL")], to: root, trajectory: "a")
+
+        XCTAssertEqual(AntigravityActivity.read(roots: [root], now: noon).label(now: noon),
+                       "Requests today · last used 3 days ago")
+    }
+
+    func testYesterdayIsNamedAsYesterday() throws {
+        try write([step("2026-08-30T09:00:00Z", source: "MODEL")], to: root, trajectory: "a")
+
+        XCTAssertEqual(AntigravityActivity.read(roots: [root], now: noon).label(now: noon),
+                       "Requests today · last used yesterday")
+    }
+
+    /// Counted in calendar days, like `requestsToday` itself. Measured in
+    /// elapsed hours instead, a late evening reads as "3 hr ago" rather than
+    /// yesterday, and the row's two halves disagree about what a day is.
+    ///
+    /// Built from the local calendar rather than from fixed UTC strings: which
+    /// calendar day an instant falls on is exactly what is under test, so a
+    /// literal `Z` timestamp would pass or fail on the machine's own timezone.
+    func testTheEveningBeforeIsStillYesterday() throws {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = .current
+        let earlyMorning = calendar.date(
+            from: DateComponents(year: 2026, month: 8, day: 31, hour: 1)
+        )!
+        let previousEvening = calendar.date(byAdding: .hour, value: -3, to: earlyMorning)!
+
+        let stamp = ISO8601DateFormatter().string(from: previousEvening)
+        try write([step(stamp, source: "MODEL")], to: root, trajectory: "a")
+
+        XCTAssertEqual(AntigravityActivity.read(roots: [root], now: earlyMorning)
+                           .label(now: earlyMorning),
+                       "Requests today · last used yesterday")
+    }
+
+    /// A day with work on it says nothing about recency — the count is the
+    /// answer, and the old wording is still the right one.
+    func testABusyDayKeepsThePlainLabel() throws {
+        try write([step("2026-08-31T09:00:00Z", source: "MODEL")], to: root, trajectory: "a")
+
+        XCTAssertEqual(AntigravityActivity.read(roots: [root], now: noon).label(now: noon),
+                       "Requests today · no limit published")
+    }
+
+    func testNothingEverRecordedKeepsThePlainLabel() {
+        XCTAssertEqual(AntigravityActivity.read(roots: [], now: noon).label(now: noon),
+                       "Requests today · no limit published")
+    }
+
     /// The real transcript interleaves user input and system checkpoints with
     /// model answers. Counting those would inflate the figure with work the
     /// model never did.

--- a/Tests/AntigravityTests.swift
+++ b/Tests/AntigravityTests.swift
@@ -56,6 +56,20 @@ final class AntigravityCredentialsTests: XCTestCase {
     func testGarbageIsRejectedRatherThanCrashing() {
         XCTAssertNil(AntigravityCredentials.decode(Data("not base64 at all".utf8)))
     }
+
+    func testCredentialsCarriesProjectAndEmail() {
+        let creds = AntigravityCredentials(
+            accessToken: "token-123",
+            expiresAt: Date().addingTimeInterval(3600),
+            authMethod: "consumer",
+            projectId: "aicode-consumers",
+            email: "user@example.com"
+        )
+        XCTAssertEqual(creds.accessToken, "token-123")
+        XCTAssertEqual(creds.projectId, "aicode-consumers")
+        XCTAssertEqual(creds.email, "user@example.com")
+        XCTAssertFalse(creds.isExpired)
+    }
 }
 
 final class AntigravityTierTests: XCTestCase {
@@ -355,6 +369,78 @@ final class AntigravityQuotaTests: XCTestCase {
         XCTAssertEqual(windows.count, 1)
         XCTAssertEqual(windows.first?.usedFraction ?? 0, 0.25, accuracy: 0.0001)
         XCTAssertEqual(windows.first?.label, "Daily")
+    }
+
+    func testItParsesDirectCloudCodeRetrieveUserQuotaBuckets() throws {
+        let now = Date(timeIntervalSince1970: 1788900000)
+        let body = Data("""
+        {
+          "buckets": [
+            {
+              "tokenType": "WTUS",
+              "modelId": "claude-sonnet-4-6",
+              "remainingFraction": 0.75,
+              "resetTime": "2026-09-09T10:39:57Z"
+            },
+            {
+              "tokenType": "WTUS",
+              "modelId": "claude-opus-4-6-thinking",
+              "remainingFraction": 0.85,
+              "resetTime": "2026-09-16T18:00:12Z"
+            },
+            {
+              "tokenType": "WTUS",
+              "modelId": "gemini-3.7-flash-tiered",
+              "remainingFraction": 0.90,
+              "resetTime": "2026-09-09T10:39:57Z"
+            },
+            {
+              "tokenType": "WTUS",
+              "modelId": "gemini-2.5-pro",
+              "remainingFraction": 0.80,
+              "resetTime": "2026-09-16T10:39:57Z"
+            }
+          ]
+        }
+        """.utf8)
+        let windows = AntigravityProvider.windows(in: body, now: now)
+        XCTAssertEqual(windows.count, 4)
+
+        let geminiHourly = try XCTUnwrap(windows.first(where: { $0.id == "gemini-hourly" }))
+        XCTAssertEqual(geminiHourly.group, "Gemini Models")
+        XCTAssertEqual(geminiHourly.label, "5-hour Limit")
+        XCTAssertEqual(geminiHourly.usedFraction ?? 0, 0.10, accuracy: 0.0001)
+
+        let geminiWeekly = try XCTUnwrap(windows.first(where: { $0.id == "gemini-weekly" }))
+        XCTAssertEqual(geminiWeekly.group, "Gemini Models")
+        XCTAssertEqual(geminiWeekly.label, "Weekly Limit")
+        XCTAssertEqual(geminiWeekly.usedFraction ?? 0, 0.20, accuracy: 0.0001)
+
+        let thirdPartyHourly = try XCTUnwrap(windows.first(where: { $0.id == "3p-hourly" }))
+        XCTAssertEqual(thirdPartyHourly.group, "Claude and GPT models")
+        XCTAssertEqual(thirdPartyHourly.label, "5-hour Limit")
+        XCTAssertEqual(thirdPartyHourly.usedFraction ?? 0, 0.25, accuracy: 0.0001)
+
+        let thirdPartyWeekly = try XCTUnwrap(windows.first(where: { $0.id == "3p-weekly" }))
+        XCTAssertEqual(thirdPartyWeekly.group, "Claude and GPT models")
+        XCTAssertEqual(thirdPartyWeekly.label, "Weekly Limit")
+        XCTAssertEqual(thirdPartyWeekly.usedFraction ?? 0, 0.15, accuracy: 0.0001)
+    }
+
+    func testDirectCloudCodeIgnoresInvalidFractions() {
+        let body = Data("""
+        {
+          "buckets": [
+            {"modelId": "gemini-bad-over", "remainingFraction": 1.5},
+            {"modelId": "gemini-bad-under", "remainingFraction": -0.1},
+            {"modelId": "gemini-3.7-flash", "remainingFraction": 0.4}
+          ]
+        }
+        """.utf8)
+        let windows = AntigravityProvider.windows(in: body)
+        XCTAssertEqual(windows.count, 1)
+        XCTAssertEqual(windows.first?.id, "gemini-hourly")
+        XCTAssertEqual(windows.first?.usedFraction ?? 0, 0.6, accuracy: 0.0001)
     }
 
     /// Cursor's free plan reports an included limit of zero, and dividing by it


### PR DESCRIPTION
Closes #82.

## Summary

Antigravity ships a CLI as well as an IDE, and Codenotch only ever looked for the IDE. On a CLI-only machine that costs three things: the request count is always 0, the ring never spins while an agent is working, and — the one I did not expect — a **real quota is being served on loopback the whole time and never asked for**.

## One correction to #82 before the rest

The fix I suggested in the issue was a probe chain, `antigravity-ide` → `antigravity-cli` → `antigravity`, first one that exists wins. **It would not have fixed my own machine.** Moving between flavours does not remove the old directory, so all four exist:

| directory | `brain` exists | trajectories |
|---|---|---|
| `~/.gemini/antigravity` | yes | 0 |
| `~/.gemini/antigravity-ide` | yes | **0** ← the chain stops here |
| `~/.gemini/antigravity-cli` | yes | **37** |
| `~/.gemini/antigravity-backup` | yes | 0 |

"The first that exists" is not a choice between a real install and a missing one. It picks an empty directory while the transcripts sit in the next. So this reads **all** of them and adds them up — trajectories are UUID-named per install, so nothing is double counted, and somebody who uses the IDE and the CLI in one day gets one number for the day rather than whichever half was looked at first.

## Changes

**The activity count and the session monitor** — `AntigravityActivity.transcriptRoots` returns every `~/.gemini/antigravity*/brain` that exists, and `read` sums across them. `AntigravityActivityMonitor` watches all of them and reports the most recent turn, so the working state is no longer blind on a CLI-only install.

**The real quota** — `agy` serves the same `RetrieveUserQuotaSummary` on loopback that the IDE's language server does: two ports, the same response, the same shape `AntigravityBridge.windows(in:)` already parses without a change. Discovery only matched `language_server --csrf_token`, so the CLI was never found. It is now, and the provider reports `.official` percentages instead of a derived count.

The CLI asks for no token — on loopback it answers anyone — so the header is sent only where there is one to send: an empty header is not the same request as no header, and the IDE still refuses without it. The IDE therefore keeps first place when both are running. `agy` is matched on the executable's own name rather than anywhere in the process line, because three letters turn up inside real words and real paths and `/opt/legacy/bin/server` is not an Antigravity install.

**Recency** — the issue's closing note, included here rather than split off: `lastRequest` was already computed and thrown away. A bare `0` on a quiet day reads as the app having failed to find anything, which is exactly what the wrong directory looked like — part of why this went unnoticed. The row now says when it was last used. Counted in calendar days, because the number beside it is: `requestsToday` asks whether a timestamp falls on today's date, and measuring elapsed hours instead calls a Saturday evening "2 days ago" on a Tuesday morning.

## Test plan

- [x] `make test` passes; no new warnings.
- [x] The count, against real data: 213, 187 and 177 on the three busiest days, matching an independent count over the same files. Every one of them read 0 before.
- [x] Live, with `agy` running: the count moved 0 → 4 as requests were made, which is the only evidence that actually settles the directory question.
- [x] The quota, live through `AntigravityBridge` on a running `agy`: four windows — a weekly and a five-hour limit for the Gemini models, another pair for the Claude and GPT ones — with groups and reset times, and the provider reporting them as `.official`.
- [x] Both fixes fail their tests when reverted: the discovery test finds 1 root instead of 4, and the CLI endpoint comes back nil.
- [ ] **Not tried with the IDE installed**, so the "IDE wins when both are running" ordering is covered by a test over a fake process table and not by a real one. I do not have the IDE on this machine.
- [ ] Not tried on a machine where only `~/.gemini/antigravity` exists — the legacy layout — beyond the tests.

One thing worth flagging rather than leaving to be discovered: the quota is only there while `agy` is running. When it exits the bridge goes with it and the provider falls back to the counted requests, which is the existing `everBridged` behaviour and reads as a dimmed, dated last figure rather than a sudden change of units.

## Evidance
<img width="662" height="963" alt="WhatsApp Image 2026-09-09 at 11 47 28" src="https://github.com/user-attachments/assets/f3c5bb61-1d17-4fb5-a822-6d62df446545" />
