### PR TITLE
Build a downloadable app bundle in CI, so trying Codenotch needs no Xcode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     # deployment target or the Liquid Glass APIs the settings panel uses.
     runs-on: macos-26
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       # Printed rather than assumed: when this job fails on a runner image
       # change, the toolchain is the first thing worth seeing.

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -73,6 +73,8 @@ jobs:
             echo "xattr -dr com.apple.quarantine /Applications/Codenotch.app"
             echo '```'
             echo
+            echo "If macOS says the app is *damaged*, that is the quarantine flag rather than a bad download — run the command above."
+            echo
             echo "Universal binary — Apple Silicon and Intel. Requires macOS 15 or later."
           } >> "$GITHUB_STEP_SUMMARY"
 
@@ -109,6 +111,8 @@ jobs:
           Applications, clear the flag once:
 
               xattr -dr com.apple.quarantine /Applications/Codenotch.app
+
+          If macOS says the app is *damaged*, that is the quarantine flag rather than a bad download — run the command above.
 
           For a signed and notarized build, take the latest release instead.
 

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -14,6 +14,10 @@ on:
 jobs:
   package:
     name: Unsigned app bundle
+    # Only the preview release step writes anything; the token is read-only by
+    # default on this repository, and `gh release create` fails without this.
+    permissions:
+      contents: write
     # Same reason as the test job: an older image ships an Xcode that cannot
     # read the project at all — `objectVersion 77` is a format it does not
     # know — whatever the deployment target happens to be.
@@ -72,3 +76,59 @@ jobs:
             echo "Universal binary — Apple Silicon and Intel. Requires macOS 15 or later."
           } >> "$GITHUB_STEP_SUMMARY"
 
+      # --- Preview release ---------------------------------------------------
+      # An artifact is only reachable by someone signed in to GitHub, from a
+      # run page, for 90 days. A release is a plain URL that anyone can click
+      # and that the repository's own sidebar advertises, which is what the
+      # README can honestly point at.
+      #
+      # A single rolling `preview` tag, never `v*`: those belong to `make
+      # publish` and carry the notarized dmg. An unsigned file sitting on the
+      # same release as a signed one is how somebody ends up running the wrong
+      # download and clearing quarantine flags they never needed to.
+      #
+      # Marked a prerelease so GitHub keeps the "Latest" badge on the real
+      # release, and refreshed in place rather than deleted and recreated, so
+      # watchers are notified once rather than on every merge.
+      - name: Publish the preview release
+        if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.version.outputs.value }}
+        run: |
+          set -euo pipefail
+          TAG=preview
+          DMG=$(ls build/ci/*.dmg)
+
+          cat > notes.md <<EOF
+          Built from \`main\` at ${GITHUB_SHA}.
+
+          A build of unreleased \`main\`, so the app can be tried without
+          installing Xcode and compiling it. It is ad-hoc signed rather than
+          notarized, so macOS quarantines the download. After dragging it to
+          Applications, clear the flag once:
+
+              xattr -dr com.apple.quarantine /Applications/Codenotch.app
+
+          For a signed and notarized build, take the latest release instead.
+
+          Universal binary. Requires macOS 15 or later.
+          EOF
+
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            # The tag has to follow, or the release keeps advertising the
+            # commit it was first cut from while serving a newer build.
+            gh api -X PATCH "repos/${GITHUB_REPOSITORY}/git/refs/tags/${TAG}" \
+              -f sha="${GITHUB_SHA}" -F force=true >/dev/null
+            # By name, not --clobber: the filename carries the version, so the
+            # release would otherwise accumulate one stale dmg per release.
+            gh release view "$TAG" --json assets -q '.assets[].name' \
+              | while read -r asset; do gh release delete-asset "$TAG" "$asset" --yes; done
+            gh release edit "$TAG" --prerelease \
+              --title "Preview — ${VERSION} (${GITHUB_SHA:0:7})" --notes-file notes.md >/dev/null
+            gh release upload "$TAG" "$DMG"
+          else
+            gh release create "$TAG" "$DMG" --prerelease --target "${GITHUB_SHA}" \
+              --title "Preview — ${VERSION} (${GITHUB_SHA:0:7})" --notes-file notes.md
+          fi
+          rm -f notes.md

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1,0 +1,74 @@
+name: Package
+
+# Separate from CI on purpose: that job answers "do the tests pass", this one
+# answers "can somebody run this without a Mac dev setup". Tying them together
+# would mean a failing unit test also removes the only way to try the build.
+on:
+  push:
+    branches: [main]
+  pull_request:
+  # So a build can be produced from any branch on demand, without pushing to
+  # main first — this is the button to press when you just want to try it.
+  workflow_dispatch:
+
+jobs:
+  package:
+    name: Unsigned app bundle
+    # Same reason as the test job: an older image ships an Xcode that cannot
+    # read the project at all — `objectVersion 77` is a format it does not
+    # know — whatever the deployment target happens to be.
+    runs-on: macos-26
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Show toolchain
+        run: |
+          xcodebuild -version
+          xcrun --show-sdk-version
+
+      - name: Install XcodeGen
+        run: brew install xcodegen
+
+      # Ad-hoc signed and not notarized — see the `build-ci` comment in the
+      # Makefile for what that costs the person who runs it.
+      - name: Build the disk image
+        run: make dmg-ci
+
+      # Read back rather than assumed: the version comes from project.yml and
+      # is in the filename, so the artifact is identifiable months later when
+      # several of these are sitting in a downloads folder.
+      - name: Read the version
+        id: version
+        run: |
+          echo "value=$(awk -F'"' '/MARKETING_VERSION:/ {print $2}' project.yml)" >> "$GITHUB_OUTPUT"
+
+      # The commit, not just the version, because every push to a branch
+      # produces one of these and the version only changes at a release.
+      - uses: actions/upload-artifact@v7
+        with:
+          name: Codenotch-${{ steps.version.outputs.value }}-${{ github.sha }}
+          path: build/ci/*.dmg
+          # Silence here would mean a green run with nothing to download, which
+          # is the one failure this workflow exists to prevent.
+          if-no-files-found: error
+
+      # Gatekeeper will refuse an ad-hoc signed download, and the instructions
+      # for getting past it are not obvious. Putting them on the run's own page
+      # keeps them next to the file they apply to.
+      - name: Explain how to open it
+        run: |
+          {
+            echo "### Codenotch ${{ steps.version.outputs.value }} — unsigned build"
+            echo
+            echo "Download the artifact below, unzip it, and open the \`.dmg\`."
+            echo
+            echo "This build is ad-hoc signed rather than notarized, so macOS quarantines it."
+            echo "After dragging the app to /Applications, clear the quarantine flag once:"
+            echo
+            echo '```'
+            echo "xattr -dr com.apple.quarantine /Applications/Codenotch.app"
+            echo '```'
+            echo
+            echo "Universal binary — Apple Silicon and Intel. Requires macOS 15 or later."
+          } >> "$GITHUB_STEP_SUMMARY"
+

--- a/Makefile
+++ b/Makefile
@@ -227,3 +227,101 @@ verify-release:
 	codesign --verify --deep --strict --verbose=2 $(RELEASE_DIR)/mnt/$(APP_NAME).app
 	spctl --assess --type execute --verbose=4 $(RELEASE_DIR)/mnt/$(APP_NAME).app
 	hdiutil detach $(RELEASE_DIR)/mnt
+# --- Unsigned builds -----------------------------------------------------------
+# Everything above needs the maintainer's Developer ID certificate and the
+# stored notarization credentials, so it can only ever run on one machine. This
+# produces the same Release-configuration app from a GitHub runner or a fork,
+# ad-hoc signed, so that trying a build no longer means installing Xcode and
+# compiling it — `make dmg-ci`, or the Package workflow's artifact.
+#
+# Ad-hoc rather than unsigned: an arm64 binary carrying no signature at all will
+# not execute, and the bundle needs one coherent signature across the app and
+# the Sparkle framework inside it or Gatekeeper rejects the whole thing before
+# it ever offers an "Open Anyway".
+#
+# Why this is not how releases ship, and what someone running one gives up: the
+# ad-hoc identity is regenerated on every build, so the download is not
+# notarized (macOS quarantines it until the user clears it by hand) and the
+# login keychain's ACL cannot recognise the same app twice — the Claude Code
+# token prompt comes back after every single update, which is exactly what
+# project.yml's stable identity exists to prevent.
+CI_DIR     := build/ci
+CI_DERIVED := $(CI_DIR)/DerivedData
+CI_APP     := $(CI_DERIVED)/Build/Products/Release/$(APP_NAME).app
+CI_DMG     := $(CI_DIR)/$(APP_NAME)-$(VERSION)-unsigned.dmg
+# Absolute: xcodebuild resolves CODE_SIGN_ENTITLEMENTS against the project
+# directory, not the working directory.
+CI_ENTITLEMENTS := $(CURDIR)/$(CI_DIR)/adhoc.entitlements
+
+.PHONY: build-ci dmg-ci
+
+# `build`, not `archive` + `-exportArchive`: exporting reads ExportOptions.plist
+# and re-signs for distribution, which needs the Developer ID identity that is
+# the one thing a runner does not have.
+build-ci: gen
+	rm -rf $(CI_DIR)
+	mkdir -p $(CI_DIR)
+	@# Same reason as `archive`: without this, every build leaves spare
+	@# "Codenotch" entries in Spotlight next to the installed app.
+	@touch build/.metadata_never_index
+	@# The one entitlement an ad-hoc build cannot do without. The hardened
+	@# runtime turns on library validation, which will only load a library
+	@# whose Team ID matches the process's — and an ad-hoc signature carries
+	@# no Team ID at all, so the app and the Sparkle framework beside it can
+	@# never be shown to match. The build looks fine and `codesign --verify
+	@# --deep --strict` passes, because each signature *is* valid; it is dyld
+	@# that refuses, and only at launch:
+	@#
+	@#   Library not loaded: @rpath/Sparkle.framework/Versions/B/Sparkle
+	@#   ... not valid for use in process: mapping process and mapped file
+	@#   (non-platform) have different Team IDs
+	@#
+	@# which macOS reports to the user as "Codenotch cannot be opened because
+	@# of a problem". A Developer ID build has no such trouble: one identity
+	@# signs the app and re-signs the framework, so the Team IDs do match, and
+	@# this is the single difference that has to be relaxed to make up for not
+	@# holding that identity. The hardened runtime otherwise stays on, so a
+	@# preview behaves like the release it previews.
+	printf '%s\n' \
+		'<?xml version="1.0" encoding="UTF-8"?>' \
+		'<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">' \
+		'<plist version="1.0"><dict>' \
+		'<key>com.apple.security.cs.disable-library-validation</key><true/>' \
+		'</dict></plist>' > $(CI_ENTITLEMENTS)
+	xcodebuild -project $(PROJECT) -scheme $(SCHEME) -destination '$(DEST)' \
+		-configuration Release -derivedDataPath $(CI_DERIVED) \
+		CODE_SIGN_IDENTITY="-" CODE_SIGN_STYLE=Automatic DEVELOPMENT_TEAM="" \
+		CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=YES \
+		CODE_SIGN_ENTITLEMENTS="$(CI_ENTITLEMENTS)" \
+		build
+	@# Xcode adds `com.apple.security.get-task-allow` to any non-distribution
+	@# signature. It lets another process attach to and read the memory of an
+	@# app whose whole job is holding other tools' OAuth tokens — unremarkable
+	@# on the machine that built it, not something to hand to a stranger who
+	@# downloaded a build. `-exportArchive` drops it, but that is precisely the
+	@# step needing the Developer ID identity, so the signature is replaced
+	@# here instead, carrying the one entitlement above and nothing else.
+	@#
+	@# The outer bundle only: the framework beside it keeps the signature it
+	@# was built with, and re-sealing the app recomputes its hashes anyway.
+	codesign --force --options runtime --entitlements $(CI_ENTITLEMENTS) \
+		--sign - $(CI_APP)
+	@# Proof rather than assumption, because this is invisible until someone
+	@# thinks to look: fail the build if the entitlement came back.
+	@codesign -d --entitlements - --xml $(CI_APP) 2>/dev/null \
+		| grep -q 'get-task-allow' \
+		&& { echo "get-task-allow survived the re-sign"; exit 1; } || true
+
+# A disk image for the same reason releases ship one, plus one specific to CI:
+# GitHub's artifact upload zips whatever it is given and drops symlinks and the
+# executable bit on the way, which takes an .app bundle apart — the framework
+# inside it is symlinks. A dmg arrives as a single opaque file instead.
+dmg-ci: build-ci
+	rm -rf $(CI_DIR)/stage
+	mkdir -p $(CI_DIR)/stage
+	cp -R $(CI_APP) $(CI_DIR)/stage/
+	ln -s /Applications $(CI_DIR)/stage/Applications
+	hdiutil create -volname "$(APP_NAME)" -srcfolder $(CI_DIR)/stage \
+		-ov -format UDZO $(CI_DMG)
+	rm -rf $(CI_DIR)/stage
+	@echo "Unsigned disk image: $(CI_DMG)"

--- a/README.md
+++ b/README.md
@@ -19,6 +19,26 @@ Hover a ring for its limit windows and when they reset. Claude's ring shows the
 same **current session** window Claude Code's own `/usage` leads with, so the
 two never disagree.
 
+## Download
+
+[**Latest release**](../../releases/latest) — signed, notarized, and updating
+itself from then on. Take this one unless you have a reason not to.
+
+To try unreleased `main` without an Xcode install, the [preview
+build](../../releases/tag/preview) is rebuilt from every commit, and the
+Package workflow keeps a per-commit disk image on each of its
+[runs](../../actions/workflows/package.yml). Neither is notarized — they are
+ad-hoc signed, because the Developer ID certificate exists on one machine — so
+macOS quarantines the download. Clear the flag once, after dragging the app to
+Applications:
+
+```sh
+xattr -dr com.apple.quarantine /Applications/Codenotch.app
+```
+
+Universal binary. macOS 15 or later. To build and install a copy from source
+instead, see [Building](#building).
+
 ## Windows
 
 A Windows port — Rust/Tauri 2, same design and providers — lives in [`windows/`](windows/README.md).

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ Applications:
 xattr -dr com.apple.quarantine /Applications/Codenotch.app
 ```
 
+If macOS says the app is *damaged*, that is the quarantine flag rather than a bad download — run the command above.
+
 Universal binary. macOS 15 or later. To build and install a copy from source
 instead, see [Building](#building).
 


### PR DESCRIPTION
## Why

Trying Codenotch means compiling it. `make release` needs the Developer ID
certificate and the stored notarization credentials, so it only ever runs on
your machine, and `make install` needs Xcode and a checkout. Between a shipped
release and a contributor there is nobody — someone merely curious has to
install a multi-gigabyte toolchain before they can see a single ring.

This adds a compiled build anyone can download and drag to Applications. No
Xcode, no checkout, no Apple account, no `make`. That matters more than usual
for this app: its whole pitch is that it reads tools you already have, so the
distance between "sounds useful" and "I can see my own numbers" ought to be one
download — and it currently is not.

It also gives contributors and you something to hand a bug reporter: a build of
`main` from before and after a change, without asking them to compile anything.

## What is here

Three commits, separable if you only want part of it:

1. **`make dmg-ci` and the Package workflow** — the same Release configuration,
   ad-hoc signed, packaged as a drag-to-Applications dmg and uploaded as an
   artifact on every push, every pull request, and on demand from any branch.
2. **`actions/checkout@v4` → `v7`** — every run was annotated for Node 20,
   which the runners already force onto Node 24 and will stop carrying.
3. **A rolling `preview` prerelease, and a README `## Download` section.**

## This changes what the repository publishes — worth your attention

Commit 3 means that once merged, a push to `main` publishes a `preview`
prerelease carrying that unsigned build. Constraints I worked to:

- **Its own tag, never `v*`.** Those belong to `make publish`, and an unsigned
  dmg attached beside a notarized one is how somebody ends up running the wrong
  download and clearing quarantine flags they never needed to.
- **Marked a prerelease**, so the "Latest" badge stays on the real release.
- **Refreshed in place**, not deleted and recreated, so watchers are notified
  once rather than on every merge. The tag is moved to the built commit so the
  release never advertises one commit while serving another.

Drop that commit and the first two still stand on their own — you would just
have artifacts rather than a link the README can point a stranger at.

## The non-obvious part

An ad-hoc build cannot load Sparkle without help, for the reason `make
install`'s comment already records. The hardened runtime turns on library
validation, which loads a library only when its Team ID matches the process's,
and an ad-hoc signature has no Team ID at all — so the app and the framework
beside it can never be shown to match. Both being ad-hoc is the problem, not
the escape from it.

Nothing catches this before launch. Each signature is individually valid, so
the build succeeds and `codesign --verify --deep --strict` reports the bundle
valid and satisfying its Designated Requirement. It is dyld that refuses:

```
Library not loaded: @rpath/Sparkle.framework/Versions/B/Sparkle
... not valid for use in process: mapping process and mapped file
(non-platform) have different Team IDs
```

which macOS shows the user as "Codenotch cannot be opened because of a
problem". `com.apple.security.cs.disable-library-validation` relaxes that one
check and nothing else, so a CI build still runs under the hardened runtime.

Separately, Xcode adds `com.apple.security.get-task-allow` to any
non-distribution signature, which lets another process attach to and read the
memory of an app holding other tools' OAuth tokens. `-exportArchive` would drop
it, but that is the step needing the Developer ID identity, so the signature is
replaced after the build instead, and the target fails if the entitlement comes
back.

## Verified, not assumed

I got this wrong once before catching it, so: every claim below was checked
against a build published by this workflow, not by reading the diff.

- Downloaded the artifact, mounted it, and **launched the app** — it runs, and
  `vmmap` confirms the framework dyld previously refused is mapped into the
  process.
- `codesign -d --entitlements` on the shipped bundle shows
  `disable-library-validation` alone; `get-task-allow` is gone.
- Signature flags still `adhoc,runtime` — the hardened runtime is intact.
- Both branches of the release step exercised: creating it, and refreshing it
  (tag moved, stale asset removed, `publishedAt` unchanged, so no second
  notification).
- The release step is correctly skipped on non-`main` refs.

## Left for you

- The README badge reads `macOS 26+` while `project.yml` now says `15.0`. My
  section says macOS 15 to match `LSMinimumSystemVersion`, which puts two
  different numbers in one README. One line to fix, but it is your call which
  is right — say the word and I will add it.
- Preview builds keep the shipped `SUFeedURL`, so like any build they check the
  appcast daily and a later release will replace them. Sensible for someone
  just trying the app, surprising for someone testing their own branch. Happy
  to disable automatic checks for CI builds if you would rather.
