### PR TITLE
Fix contributor build with ad-hoc signing fallback

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,23 +27,13 @@ DEST    ?= platform=macOS,arch=$(ARCH)
 # "Signing for Codenotch requires a development team", on every target.
 HAS_DEVELOPER_ID := $(shell security find-identity -v -p codesigning 2>/dev/null | grep "Developer ID Application")
 
-# A personal "Apple Development" certificate, where there is one, is preferred
-# over ad-hoc for exactly the reason the maintainer's identity is: it is
-# stable, so a keychain "Always Allow" grant survives the next rebuild, and
-# working on the credential-reading paths does not mean re-granting after every
-# build. Read its team from a valid signing identity: a certificate can remain
-# in the keychain without its private key, and choosing it would fail the
-# build. With nothing parsed, ad-hoc is the fallback and needs no Apple account.
-DEV_TEAM := $(shell security find-identity -v -p codesigning 2>/dev/null \
-	| sed -n 's/.*"Apple Development: .* (\([A-Z0-9]*\))".*/\1/p' | head -1)
-
+# For contributors, always fall back to ad-hoc signing. Using an "Apple Development"
+# certificate with manual signing on newer Xcode versions often expects a provisioning
+# profile or legacy "Mac Development" certificate, which breaks local `make run`.
+# Ad-hoc signing ensures the build works out of the box for anyone without an Apple
+# Developer account or provisioning profile.
 ifeq (,$(HAS_DEVELOPER_ID))
-ifeq (,$(DEV_TEAM))
 DEV_SIGN := CODE_SIGN_IDENTITY="-" DEVELOPMENT_TEAM="" CODE_SIGN_STYLE=Automatic
-else
-DEV_SIGN := CODE_SIGN_IDENTITY="Apple Development" CODE_SIGN_STYLE=Manual \
-	DEVELOPMENT_TEAM="$(DEV_TEAM)" PROVISIONING_PROFILE_SPECIFIER=""
-endif
 endif
 
 .PHONY: gen build test test-ci run install clean

--- a/Scripts/test-signing.sh
+++ b/Scripts/test-signing.sh
@@ -40,14 +40,14 @@ check_signing 'certificate without a valid identity uses ad-hoc' \
 
 SIGNING_IDENTITIES='  1) AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA "Apple Development: Contributor (TEAM123456)"
      1 valid identities found'
-check_signing 'valid development identity supplies its team' \
-    'Debug CODE_SIGN_IDENTITY="Apple Development" CODE_SIGN_STYLE=Manual DEVELOPMENT_TEAM="TEAM123456"'
+check_signing 'valid development identity falls back to ad-hoc' \
+    'Debug CODE_SIGN_IDENTITY="-" DEVELOPMENT_TEAM="" CODE_SIGN_STYLE=Automatic'
 
 SIGNING_IDENTITIES='  1) AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA "Apple Development: Contributor (TEAM123456)"
   2) BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB "Apple Development: Another Contributor (TEAM654321)"
      2 valid identities found'
-check_signing 'multiple development identities select one team' \
-    'Debug CODE_SIGN_IDENTITY="Apple Development" CODE_SIGN_STYLE=Manual DEVELOPMENT_TEAM="TEAM123456" PROVISIONING_PROFILE_SPECIFIER=""'
+check_signing 'multiple development identities fall back to ad-hoc' \
+    'Debug CODE_SIGN_IDENTITY="-" DEVELOPMENT_TEAM="" CODE_SIGN_STYLE=Automatic'
 
 SIGNING_IDENTITIES='  1) AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA "Developer ID Application: Maintainer (6WFPL8B9FB)"
   2) BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB "Apple Development: Contributor (TEAM123456)"


### PR DESCRIPTION
### Summary
This PR fixes local build failures (`make run`) that contributors encounter when they have an "Apple Development" certificate but lack a corresponding provisioning profile or legacy "Mac Development" certificate.

### Details
Previously, the `Makefile` detected if an "Apple Development" certificate was present in the keychain and aggressively attempted to use it for manual signing. On newer versions of Xcode, trying to manually sign a Mac app (especially with Hardened Runtime enabled) using an "Apple Development" certificate without explicitly providing a provisioning profile causes the build to fail with a `No signing certificate "Mac Development" found` error.

This PR updates the build logic so that if the maintainer's "Developer ID Application" certificate is absent, we always fall back to ad-hoc signing (`CODE_SIGN_IDENTITY="-"`).

### Impact
- **Contributors:** `make run` works out of the box again without failing in the code signing phase.
- **Maintainer:** The maintainer's stable signing flow (which requires the Developer ID cert) remains completely unaffected.
