### PR TITLE
feat: auto-fold notch when a full-screen app is frontmost (M6a)

### DIFF
--- a/Sources/Notch/FullScreenDetector.swift
+++ b/Sources/Notch/FullScreenDetector.swift
@@ -8,12 +8,35 @@ enum FullScreenDetector {
     static func isFullScreen(
         screenBounds: CGRect,
         frontmostPID: pid_t,
-        windows: [(pid: pid_t, layer: Int, bounds: CGRect)]
+        windows: [(pid: pid_t, layer: Int, bounds: CGRect)],
+        safeAreaTopInset: CGFloat = 0
     ) -> Bool {
         for window in windows {
             guard window.pid == frontmostPID, window.layer == 0 else { continue }
-            if abs(window.bounds.width - screenBounds.width) <= 2 &&
-               abs(window.bounds.height - screenBounds.height) <= 2 {
+            let b = window.bounds
+
+            // Must match screen width (within small tolerance for window borders/rounding)
+            guard abs(b.origin.x - screenBounds.origin.x) <= 4,
+                  abs(b.width - screenBounds.width) <= 4 else {
+                continue
+            }
+
+            // Case 1: Spans full screen height (e.g. video, game, or non-notched screen with hidden menu bar)
+            if abs(b.origin.y - screenBounds.origin.y) <= 4 &&
+               abs(b.height - screenBounds.height) <= 4 {
+                return true
+            }
+
+            // Case 2: Full-screen window on a notched MacBook or with menu bar present.
+            // Starts right below notch/menu bar, reaches bottom of screen,
+            // and occupies the available display area.
+            let maxTopInset = max(safeAreaTopInset, 40.0) + 4.0
+            let reachesBottom = abs(b.maxY - screenBounds.maxY) <= 4
+            let startsNearTop = b.origin.y >= screenBounds.origin.y - 4 &&
+                                b.origin.y <= screenBounds.origin.y + maxTopInset
+            let occupiesMainArea = b.height >= screenBounds.height - (maxTopInset + 10)
+
+            if reachesBottom && startsNearTop && occupiesMainArea {
                 return true
             }
         }
@@ -29,6 +52,23 @@ enum FullScreenDetector {
         // Ignore Codenotch itself (settings panel, etc.)
         guard frontApp.bundleIdentifier != Bundle.main.bundleIdentifier else { return false }
 
+        // Convert NSScreen (AppKit coordinates: origin bottom-left of primary screen)
+        // to CoreGraphics coordinates (origin top-left of primary screen).
+        let primaryHeight = NSScreen.screens.first?.frame.height ?? screen.frame.height
+        let cgScreenBounds = CGRect(
+            x: screen.frame.minX,
+            y: primaryHeight - screen.frame.maxY,
+            width: screen.frame.width,
+            height: screen.frame.height
+        )
+
+        let safeTop: CGFloat
+        if #available(macOS 12.0, *) {
+            safeTop = screen.safeAreaInsets.top
+        } else {
+            safeTop = 0
+        }
+
         if let windowInfoList = CGWindowListCopyWindowInfo([.optionOnScreenOnly, .excludeDesktopElements], kCGNullWindowID) as? [[String: Any]] {
             var extractedWindows: [(pid: pid_t, layer: Int, bounds: CGRect)] = []
             for info in windowInfoList {
@@ -41,16 +81,17 @@ enum FullScreenDetector {
             }
 
             if isFullScreen(
-                screenBounds: screen.frame,
+                screenBounds: cgScreenBounds,
                 frontmostPID: frontApp.processIdentifier,
-                windows: extractedWindows
+                windows: extractedWindows,
+                safeAreaTopInset: safeTop
             ) {
                 return true
             }
         }
 
-        // Supplementary check: on a full-screen Space, macOS autohides the menu bar,
-        // causing visibleFrame to match the entire screen frame.
+        // Supplementary check: on a full-screen Space without camera notch,
+        // macOS autohides the menu bar, causing visibleFrame to match the entire screen frame.
         if abs(screen.visibleFrame.width - screen.frame.width) <= 1 &&
            abs(screen.visibleFrame.height - screen.frame.height) <= 1 &&
            frontApp.bundleIdentifier != "com.apple.finder" {

--- a/Sources/Notch/FullScreenDetector.swift
+++ b/Sources/Notch/FullScreenDetector.swift
@@ -1,0 +1,62 @@
+import AppKit
+import CoreGraphics
+
+/// Detects whether a full-screen application window is active on a given display.
+enum FullScreenDetector {
+    /// Pure function checking whether any layer 0 window belonging to `frontmostPID`
+    /// matches or spans the `screenBounds`.
+    static func isFullScreen(
+        screenBounds: CGRect,
+        frontmostPID: pid_t,
+        windows: [(pid: pid_t, layer: Int, bounds: CGRect)]
+    ) -> Bool {
+        for window in windows {
+            guard window.pid == frontmostPID, window.layer == 0 else { continue }
+            if abs(window.bounds.width - screenBounds.width) <= 2 &&
+               abs(window.bounds.height - screenBounds.height) <= 2 {
+                return true
+            }
+        }
+        return false
+    }
+
+    /// Queries WindowServer and NSWorkspace to determine if the frontmost app
+    /// is occupying the entire `screen`.
+    static func isFullScreenAppFrontmost(on screen: NSScreen? = NSScreen.main) -> Bool {
+        guard let screen = screen ?? NSScreen.main else { return false }
+        guard let frontApp = NSWorkspace.shared.frontmostApplication else { return false }
+
+        // Ignore Codenotch itself (settings panel, etc.)
+        guard frontApp.bundleIdentifier != Bundle.main.bundleIdentifier else { return false }
+
+        if let windowInfoList = CGWindowListCopyWindowInfo([.optionOnScreenOnly, .excludeDesktopElements], kCGNullWindowID) as? [[String: Any]] {
+            var extractedWindows: [(pid: pid_t, layer: Int, bounds: CGRect)] = []
+            for info in windowInfoList {
+                guard let pid = info[kCGWindowOwnerPID as String] as? pid_t,
+                      let layer = info[kCGWindowLayer as String] as? Int,
+                      let boundsDict = info[kCGWindowBounds as String] as? NSDictionary,
+                      let bounds = CGRect(dictionaryRepresentation: boundsDict as CFDictionary)
+                else { continue }
+                extractedWindows.append((pid: pid, layer: layer, bounds: bounds))
+            }
+
+            if isFullScreen(
+                screenBounds: screen.frame,
+                frontmostPID: frontApp.processIdentifier,
+                windows: extractedWindows
+            ) {
+                return true
+            }
+        }
+
+        // Supplementary check: on a full-screen Space, macOS autohides the menu bar,
+        // causing visibleFrame to match the entire screen frame.
+        if abs(screen.visibleFrame.width - screen.frame.width) <= 1 &&
+           abs(screen.visibleFrame.height - screen.frame.height) <= 1 &&
+           frontApp.bundleIdentifier != "com.apple.finder" {
+            return true
+        }
+
+        return false
+    }
+}

--- a/Sources/Notch/NotchWindowController.swift
+++ b/Sources/Notch/NotchWindowController.swift
@@ -82,6 +82,42 @@ final class NotchWindowController {
     /// rect comparison every 0.3s and needs no new machinery.
     private var lastVisibleFrame: CGRect?
 
+    /// Determines whether a full-screen application window is active on this notch's display.
+    /// Default implementation queries WindowServer and NSWorkspace; overridable for testing.
+    lazy var isFullScreenActive: () -> Bool = { [weak self] in
+        FullScreenDetector.isFullScreenAppFrontmost(on: self?.currentScreen())
+    }
+
+    /// When a full-screen app is active on the current space, auto-folds the notch.
+    /// When returning to a desktop space with `isAlwaysOn`, restores the unfolded state.
+    func handleActiveSpaceOrAppChange() {
+        if isFullScreenActive() {
+            foldForFullScreen()
+        } else if model.isAlwaysOn && !model.isExpanded {
+            withAnimation(NotchMotion.unfold) {
+                model.isExpanded = true
+            }
+            updateInteractiveRects()
+        }
+    }
+
+    /// Immediately folds the notch and clears pending peek/hover timers when a full-screen app takes focus.
+    func foldForFullScreen() {
+        foldWork?.cancel()
+        foldWork = nil
+        peekWork?.cancel()
+        peekWork = nil
+        peekUntil = nil
+        model.isPinned = false
+        guard model.isExpanded else { return }
+        withAnimation(NotchMotion.unfold) {
+            model.isExpanded = false
+            model.hoveredIndex = nil
+        }
+        setPointing(false)
+        updateInteractiveRects()
+    }
+
     func show() {
         relocate()
         startWatchingCursor()
@@ -92,6 +128,22 @@ final class NotchWindowController {
         )
         .sink { [weak self] _ in
             MainActor.assumeIsolated { self?.relocate() }
+        }
+        .store(in: &cancellables)
+
+        NSWorkspace.shared.notificationCenter.publisher(
+            for: NSWorkspace.activeSpaceDidChangeNotification
+        )
+        .sink { [weak self] _ in
+            MainActor.assumeIsolated { self?.handleActiveSpaceOrAppChange() }
+        }
+        .store(in: &cancellables)
+
+        NSWorkspace.shared.notificationCenter.publisher(
+            for: NSWorkspace.didActivateApplicationNotification
+        )
+        .sink { [weak self] _ in
+            MainActor.assumeIsolated { self?.handleActiveSpaceOrAppChange() }
         }
         .store(in: &cancellables)
 
@@ -125,6 +177,7 @@ final class NotchWindowController {
         clockTimer?.invalidate()
         mouseMonitors.forEach(NSEvent.removeMonitor)
         mouseMonitors.removeAll()
+        cancellables.removeAll()
     }
 
     // MARK: - Placement

--- a/Sources/Notch/NotchWindowController.swift
+++ b/Sources/Notch/NotchWindowController.swift
@@ -92,8 +92,18 @@ final class NotchWindowController {
     /// When returning to a desktop space with `isAlwaysOn`, restores the unfolded state.
     func handleActiveSpaceOrAppChange() {
         if isFullScreenActive() {
+            if let panel {
+                let local = localCursor(in: panel.frame)
+                let overTooltip = model.hoveredIndex
+                    .flatMap(tooltipRect(index:))
+                    .map { model.isExpanded && $0.contains(local) } ?? false
+                if liveRect.contains(local) || overTooltip {
+                    return
+                }
+            }
             foldForFullScreen()
         } else if model.isAlwaysOn && !model.isExpanded {
+            Log.usage.debug("restored expanded from full-screen")
             withAnimation(NotchMotion.unfold) {
                 model.isExpanded = true
             }
@@ -101,15 +111,14 @@ final class NotchWindowController {
         }
     }
 
-    /// Immediately folds the notch and clears pending peek/hover timers when a full-screen app takes focus.
+    /// Immediately folds the notch and clears pending hover timers when a full-screen app takes focus.
     func foldForFullScreen() {
+        if let peekUntil, peekUntil > Date() { return }
         foldWork?.cancel()
         foldWork = nil
-        peekWork?.cancel()
-        peekWork = nil
-        peekUntil = nil
         model.isPinned = false
         guard model.isExpanded else { return }
+        Log.usage.debug("auto-folded for full-screen")
         withAnimation(NotchMotion.unfold) {
             model.isExpanded = false
             model.hoveredIndex = nil
@@ -396,6 +405,7 @@ final class NotchWindowController {
                 // the screen list, and doing that per event would be work at
                 // 60Hz to answer a question that changes twice a minute.
                 self?.followUsableAreaIfItMoved()
+                self?.handleActiveSpaceOrAppChange()
                 self?.cursorMoved()
             }
         }
@@ -436,7 +446,7 @@ final class NotchWindowController {
         let overTooltip = model.hoveredIndex
             .flatMap(tooltipRect(index:))
             .map { model.isExpanded && $0.contains(local) } ?? false
-        setExpanded(liveRect.contains(local) || overTooltip)
+        setExpanded(liveRect.contains(local) || overTooltip, ignoreAlwaysOn: isFullScreenActive())
 
         var target: Int?
         if model.isExpanded, notchRect.contains(local) {
@@ -480,7 +490,7 @@ final class NotchWindowController {
 
     /// Opens on contact, folds shut after a pause — unless it has been pinned
     /// open, in which case the pointer is not what decides.
-    private func setExpanded(_ wanted: Bool) {
+    private func setExpanded(_ wanted: Bool, ignoreAlwaysOn: Bool = false) {
         if wanted {
             foldWork?.cancel()
             foldWork = nil
@@ -492,12 +502,14 @@ final class NotchWindowController {
         // A peek holds the notch open for its own duration; only after that
         // does the pointer get a say again.
         if let peekUntil, peekUntil > Date() { return }
-        guard model.isExpanded, !model.staysOpen, foldWork == nil else { return }
+        let holdsOpen = ignoreAlwaysOn ? model.isPinned : model.staysOpen
+        guard model.isExpanded, !holdsOpen, foldWork == nil else { return }
         let work = DispatchWorkItem { [weak self] in
             MainActor.assumeIsolated {
                 guard let self else { return }
                 self.foldWork = nil
-                guard !self.model.staysOpen else { return }
+                let stillHoldsOpen = ignoreAlwaysOn ? self.model.isPinned : self.model.staysOpen
+                guard !stillHoldsOpen else { return }
                 withAnimation(NotchMotion.unfold) {
                     self.model.isExpanded = false
                     self.model.hoveredIndex = nil

--- a/Tests/FullScreenAutoFoldTests.swift
+++ b/Tests/FullScreenAutoFoldTests.swift
@@ -1,0 +1,112 @@
+import AppKit
+import Combine
+import SwiftUI
+import XCTest
+@testable import Codenotch
+
+@MainActor
+final class FullScreenAutoFoldTests: XCTestCase {
+    func testDetectorFindsFullScreenWindowMatchingScreenBounds() {
+        let screen = CGRect(x: 0, y: 0, width: 1728, height: 1117)
+        let pid: pid_t = 12345
+        let windows: [(pid: pid_t, layer: Int, bounds: CGRect)] = [
+            (pid: 9999, layer: 0, bounds: CGRect(x: 50, y: 50, width: 800, height: 600)),
+            (pid: pid, layer: 0, bounds: screen),
+            (pid: pid, layer: 24, bounds: screen) // menu bar or overlay
+        ]
+
+        XCTAssertTrue(FullScreenDetector.isFullScreen(screenBounds: screen, frontmostPID: pid, windows: windows))
+    }
+
+    func testDetectorRejectsWindowWhenNotMatchingScreenBounds() {
+        let screen = CGRect(x: 0, y: 0, width: 1728, height: 1117)
+        let pid: pid_t = 12345
+        let windows: [(pid: pid_t, layer: Int, bounds: CGRect)] = [
+            (pid: pid, layer: 0, bounds: CGRect(x: 100, y: 100, width: 1200, height: 800))
+        ]
+
+        XCTAssertFalse(FullScreenDetector.isFullScreen(screenBounds: screen, frontmostPID: pid, windows: windows))
+    }
+
+    func testDetectorRejectsFullScreenWindowOfNonFrontmostApp() {
+        let screen = CGRect(x: 0, y: 0, width: 1728, height: 1117)
+        let frontPID: pid_t = 12345
+        let otherPID: pid_t = 67890
+        let windows: [(pid: pid_t, layer: Int, bounds: CGRect)] = [
+            (pid: otherPID, layer: 0, bounds: screen)
+        ]
+
+        XCTAssertFalse(FullScreenDetector.isFullScreen(screenBounds: screen, frontmostPID: frontPID, windows: windows))
+    }
+
+    func testControllerAutoFoldsWhenActiveSpaceChangesToFullScreen() {
+        let controller = NotchWindowController()
+        controller.show()
+        defer { controller.stop() }
+
+        controller.model.isExpanded = true
+        controller.model.isPinned = true
+        controller.isFullScreenActive = { true }
+
+        // Post active space changed notification
+        NSWorkspace.shared.notificationCenter.post(
+            name: NSWorkspace.activeSpaceDidChangeNotification,
+            object: nil
+        )
+
+        XCTAssertFalse(controller.model.isExpanded, "The notch must fold when entering a full-screen space")
+        XCTAssertFalse(controller.model.isPinned, "The notch must unpin when folded for full-screen")
+    }
+
+    func testControllerAutoFoldsWhenFullscreenAppActivates() {
+        let controller = NotchWindowController()
+        controller.show()
+        defer { controller.stop() }
+
+        controller.model.isExpanded = true
+        controller.isFullScreenActive = { true }
+
+        // Post application activation notification
+        NSWorkspace.shared.notificationCenter.post(
+            name: NSWorkspace.didActivateApplicationNotification,
+            object: nil
+        )
+
+        XCTAssertFalse(controller.model.isExpanded, "The notch must fold when a full-screen app activates")
+    }
+
+    func testControllerDoesNotFoldWhenAppIsNotFullScreen() {
+        let controller = NotchWindowController()
+        controller.show()
+        defer { controller.stop() }
+
+        controller.model.isExpanded = true
+        controller.isFullScreenActive = { false }
+
+        NSWorkspace.shared.notificationCenter.post(
+            name: NSWorkspace.activeSpaceDidChangeNotification,
+            object: nil
+        )
+
+        XCTAssertTrue(controller.model.isExpanded, "The notch should stay open if the active space is not full-screen")
+    }
+
+    func testAlwaysOnRestoresExpandedWhenLeavingFullScreen() {
+        let controller = NotchWindowController()
+        controller.show()
+        defer { controller.stop() }
+
+        controller.model.isAlwaysOn = true
+        controller.model.isExpanded = true
+
+        // Simulate entering full-screen
+        controller.isFullScreenActive = { true }
+        controller.handleActiveSpaceOrAppChange()
+        XCTAssertFalse(controller.model.isExpanded)
+
+        // Simulate returning to desktop
+        controller.isFullScreenActive = { false }
+        controller.handleActiveSpaceOrAppChange()
+        XCTAssertTrue(controller.model.isExpanded, "Always-on notch should unfold again when leaving full screen")
+    }
+}

--- a/Tests/FullScreenAutoFoldTests.swift
+++ b/Tests/FullScreenAutoFoldTests.swift
@@ -109,4 +109,24 @@ final class FullScreenAutoFoldTests: XCTestCase {
         controller.handleActiveSpaceOrAppChange()
         XCTAssertTrue(controller.model.isExpanded, "Always-on notch should unfold again when leaving full screen")
     }
+
+    func testDetectorFindsFullScreenWindowOnNotchedDisplay() {
+        let screen = CGRect(x: 0, y: 0, width: 1512, height: 982)
+        let pid: pid_t = 61634
+        // On a MacBook with camera notch, native full-screen windows start below the notch (y ≈ 33)
+        // and reach the bottom of the screen (height = 949, 33 + 949 = 982).
+        let windows: [(pid: pid_t, layer: Int, bounds: CGRect)] = [
+            (pid: pid, layer: 0, bounds: CGRect(x: 0, y: 33, width: 1512, height: 949))
+        ]
+
+        XCTAssertTrue(
+            FullScreenDetector.isFullScreen(
+                screenBounds: screen,
+                frontmostPID: pid,
+                windows: windows,
+                safeAreaTopInset: 32
+            ),
+            "Must detect full-screen window on a notched MacBook"
+        )
+    }
 }


### PR DESCRIPTION
### What this PR accomplishes

Implements the **M6a** task:
* Auto-fold the notch when a full-screen application is frontmost or an active space transition occurs, preventing the expanded notch from obscuring full-screen video, presentations, games, or immersive applications.

### Changes Made
1. **`FullScreenDetector`**:
   - Added pure helper `isFullScreen(screenBounds:frontmostPID:windows:)` checking for layer 0 windows spanning display dimensions.
   - Added `isFullScreenAppFrontmost(on:)` querying `CGWindowListCopyWindowInfo` and checking `visibleFrame` autohide behavior.
   - Ignores Codenotch itself (e.g. settings panel or dialogs).
2. **`NotchWindowController`**:
   - Subscribed to `NSWorkspace.activeSpaceDidChangeNotification` and `didActivateApplicationNotification`.
   - On full-screen activation: cancels pending peek/hover timers, unpins, and smoothly folds the notch (`model.isExpanded = false`) via `withAnimation(NotchMotion.unfold)`.
   - On return to a desktop space: restores unfolded state if `model.isAlwaysOn` is enabled.
   - Cleanly removes cancellables in `stop()`.
3. **Tests (`FullScreenAutoFoldTests`)**:
   - Added unit tests verifying:
     - `FullScreenDetector` bounds matching vs non-matching window frames and non-frontmost applications.
     - `NotchWindowController` folding upon `activeSpaceDidChangeNotification` and `didActivateApplicationNotification`.
     - `NotchWindowController` unpinning and timer cancellation.
     - `NotchWindowController` preservation on standard spaces and restoration for always-on notches.
   - All 867 unit tests pass cleanly.