### PR TITLE
Anchor notch to physical screen edges and keep corner tooltips visible

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,8 +130,9 @@ is asked on the first real alert rather than at launch.
 
 The notch lives on any of the four screen edges. Right and left keep a
 vertical column; top and bottom lay the readings out side by side. It pins
-itself to the *usable* edge, so a bottom notch rests on the Dock and follows
-when the Dock hides or moves. On a Mac with a hardware notch, the top
+itself to the physical screen edge, so showing or hiding the Dock does not
+move it. Hold Option and drag to move along the selected edge; each edge
+remembers its position. On a Mac with a hardware notch, the top
 placement takes its exact shape, so the two read as one rather than as a bar
 parked underneath it.
 

--- a/Sources/Features/TooltipCard.swift
+++ b/Sources/Features/TooltipCard.swift
@@ -77,6 +77,7 @@ private struct TooltipShell<Content: View>: View {
     let height: CGFloat
     /// Which side of the notch the card is on, so the tail goes on the other one.
     let direction: NotchEdge.TooltipDirection
+    var tailOffset: CGFloat = 0
     @ViewBuilder let content: Content
 
     @Environment(\.codenotchReduceTransparency) private var reduceTransparency
@@ -119,6 +120,8 @@ private struct TooltipShell<Content: View>: View {
         return TooltipTail(direction: direction)
             .fill(Palette.card)
             .frame(width: size.width, height: size.height)
+            .offset(x: direction == .up || direction == .down ? tailOffset : 0,
+                    y: direction == .leading || direction == .trailing ? tailOffset : 0)
     }
 
     var body: some View {
@@ -385,7 +388,7 @@ private struct ProviderTooltip: View {
                                     .fontWeight(.semibold)
                                     .foregroundStyle(Palette.textPrimary)
                                     .padding(.leading, Design.px(4))
-                                
+
                                 VStack(alignment: .leading, spacing: NotchLayout.blockSpacing) {
                                     ForEach(Array(group.windows.enumerated()), id: \.element.id) { windowIndex, window in
                                         LimitWindowRow(window: window, inset: 2 * Design.px(16), fidelity: snapshot.fidelity, now: now, resetTimeFormat: resetTimeFormat, showsUsagePace: showUsagePace)
@@ -695,26 +698,15 @@ struct TooltipCard: View {
     /// rather than fixed, so a big screen hides nothing.
     var sessionCap: Int = NotchLayout.defaultSessionCap
     var resetTimeFormat: ResetTimeFormat = .automatic
+    var tailOffset: CGFloat = 0
     @AppStorage(Preferences.showUsagePaceKey) private var showUsagePace = false
-
-    private var groupCount: Int {
-        var groups = Set<String>()
-        var count = 0
-        for window in snapshot.windows {
-            if let group = window.group, !groups.contains(group) {
-                groups.insert(group)
-                count += 1
-            }
-        }
-        return count
-    }
 
     /// The same figure the hover region uses, so what is drawn and what is
     /// reachable can never drift apart.
     private var height: CGFloat {
         NotchLayout.cardHeight(
             windowCount: snapshot.windows.count,
-            groupCount: groupCount,
+            groupCount: snapshot.windowGroupCount,
             sessionCount: activity?.sessions.count ?? 0,
             sessionCap: sessionCap,
             statusMessage: snapshot.statusMessage,
@@ -725,7 +717,7 @@ struct TooltipCard: View {
     }
 
     var body: some View {
-        TooltipShell(height: height, direction: direction) {
+        TooltipShell(height: height, direction: direction, tailOffset: tailOffset) {
             // Stacked, not replaced in place: during a swap both sets of rows
             // exist for a moment, and in a ZStack they overlap and dissolve
             // instead of shoving each other around. Top-aligned so neither

--- a/Sources/Model/UsageModel.swift
+++ b/Sources/Model/UsageModel.swift
@@ -212,6 +212,9 @@ struct ProviderSnapshot: Identifiable, Equatable {
     /// a dash rather than an authoritative-looking 0%.
     var hasReading: Bool { !windows.isEmpty }
 
+    /// Group headings occupy space in both the card and its hover region.
+    var windowGroupCount: Int { Set(windows.compactMap(\.group)).count }
+
     /// How many windows are count-only (no fraction, no bar) — they render as
     /// single-line rows and take less vertical space than full bar rows.
     var compactRowCount: Int {

--- a/Sources/Notch/NotchEdge.swift
+++ b/Sources/Notch/NotchEdge.swift
@@ -66,15 +66,15 @@ enum NotchEdge: String, CaseIterable, Identifiable {
     var explanation: String {
         switch self {
         case .right:
-            return "Down the right-hand edge, clear of a Dock on that side."
+            return "Attached to the right-hand screen edge. Option-drag to move up or down."
         case .left:
-            return "Down the left-hand edge, clear of a Dock on that side."
+            return "Attached to the left-hand screen edge. Option-drag to move up or down."
         case .top:
             return "A wide bar across the top, readings side by side. On a Mac "
                  + "with a notch of its own it runs up to meet it, so the two "
                  + "read as one shape."
         case .bottom:
-            return "A wide bar resting on top of the Dock, readings side by side."
+            return "Attached to the bottom screen edge. Option-drag to move left or right."
         }
     }
 }

--- a/Sources/Notch/NotchGeometry.swift
+++ b/Sources/Notch/NotchGeometry.swift
@@ -53,17 +53,9 @@ extension NSScreen: ScreenDescribing {
 }
 
 enum NotchGeometry {
-    /// The panel hugs the chosen edge and is centred along it.
-    ///
-    /// **Which edge it hugs is `visibleFrame`'s, not `frame`'s.** That is what
-    /// keeps a bottom notch resting on top of the Dock and a top one below the
-    /// menu bar rather than behind them, and it is why the notch moves when the
-    /// Dock hides — `visibleFrame` gives the space back and the notch takes it.
-    ///
-    /// **Centring, though, stays on `frame`.** A Dock at the bottom is nowhere
-    /// near a right-edge notch, and centring on the visible area would shift
-    /// that notch up and down the screen every time the Dock hid itself, for no
-    /// reason anyone could see.
+    /// Anchor to the physical display edge, even when the Dock or menu bar
+    /// reserves part of the desktop. Showing or hiding either must not move
+    /// a position the user chose.
     ///
     /// The rect is rounded out to whole points on purpose. AppKit rounds window
     /// frames anyway, and if it does the rounding the panel ends up a fraction
@@ -96,7 +88,6 @@ enum NotchGeometry {
         trailingExtent: CGFloat = 0
     ) -> CGRect {
         let full = screen.frameValue
-        let usable = screen.visibleFrameValue
         let width = panelSize.width.rounded(.up)
         let height = panelSize.height.rounded(.up)
 
@@ -105,27 +96,19 @@ enum NotchGeometry {
         case .right:
             let y = clamp(full.midY - height / 2 - alongOffset,
                           min: full.minY - slack + trailingExtent, max: full.maxY - height + slack)
-            origin = CGPoint(x: usable.maxX - width, y: y)
+            origin = CGPoint(x: full.maxX - width, y: y)
         case .left:
             let y = clamp(full.midY - height / 2 - alongOffset,
                           min: full.minY - slack + trailingExtent, max: full.maxY - height + slack)
-            origin = CGPoint(x: usable.minX, y: y)
+            origin = CGPoint(x: full.minX, y: y)
         case .top:
-            // AppKit's y grows upward, so the top edge is `maxY`.
-            //
-            // On a Mac with a notch of its own, this one goes all the way up to
-            // meet it — past the menu bar — so the two read as a single shape
-            // rather than as a bar parked underneath the hardware. Where there
-            // is nothing to merge with, covering the menu bar buys nothing, so
-            // it stays below it.
-            let top = screen.hardwareNotch == nil ? usable.maxY : full.maxY
             let x = clamp(full.midX - width / 2 + alongOffset,
                           min: full.minX - slack, max: full.maxX - width + slack - trailingExtent)
-            origin = CGPoint(x: x, y: top - height)
+            origin = CGPoint(x: x, y: full.maxY - height)
         case .bottom:
             let x = clamp(full.midX - width / 2 + alongOffset,
                           min: full.minX - slack, max: full.maxX - width + slack - trailingExtent)
-            origin = CGPoint(x: x, y: usable.minY)
+            origin = CGPoint(x: x, y: full.minY)
         }
 
         return CGRect(

--- a/Sources/Notch/NotchRootView.swift
+++ b/Sources/Notch/NotchRootView.swift
@@ -63,7 +63,8 @@ struct NotchRootView: View {
                         now: model.now,
                         direction: model.edge.tooltipDirection,
                         sessionCap: model.sessionCap,
-                        resetTimeFormat: model.resetTimeFormat
+                        resetTimeFormat: model.resetTimeFormat,
+                        tailOffset: tooltipTailOffset(index: index, snapshot: snapshot)
                     )
                         // Deliberately *no* `.id` here: the card is one object
                         // that travels and resizes between cells, which reads
@@ -214,6 +215,26 @@ struct NotchRootView: View {
         )
     }
 
+    private func tooltipLength(_ snapshot: ProviderSnapshot) -> CGFloat {
+        model.edge.isVertical
+            ? NotchLayout.cardHeight(
+                windowCount: snapshot.windows.count,
+                groupCount: snapshot.windowGroupCount,
+                sessionCount: model.activity(for: snapshot.id)?.sessions.count ?? 0,
+                sessionCap: model.sessionCap,
+                statusMessage: snapshot.statusMessage,
+                blockMessage: snapshot.block?.summary(now: model.now),
+                hasTokenUsage: snapshot.tokenUsage != nil,
+                compactRowCount: snapshot.compactRowCount
+            )
+            : NotchLayout.cardWidth
+    }
+
+    private func tooltipTailOffset(index: Int, snapshot: ProviderSnapshot) -> CGFloat {
+        model.slack + model.ringCenter(index: index) * model.sizeScale
+            - model.tooltipAlong(index: index, length: tooltipLength(snapshot))
+    }
+
     /// The tooltip is the card plus its tail; `position` centres that pair, so
     /// the tail lands on the hovered cell and the card sits beyond it.
     private func tooltipCentre(
@@ -223,17 +244,19 @@ struct NotchRootView: View {
             ? NotchLayout.cardWidth
             : NotchLayout.cardHeight(
                 windowCount: snapshot.windows.count,
+                groupCount: snapshot.windowGroupCount,
                 sessionCount: model.activity(for: snapshot.id)?.sessions.count ?? 0,
                 sessionCap: model.sessionCap,
                 statusMessage: snapshot.statusMessage,
                 blockMessage: snapshot.block?.summary(now: model.now),
+                hasTokenUsage: snapshot.tokenUsage != nil,
                 compactRowCount: snapshot.compactRowCount
             )
         // The ring it points at has moved with the notch, so the tail follows
         // it — but the card beyond the tail is drawn at its own size, and
         // `tooltipInset` already ends where the drawn notch does.
         return place.point(
-            along: model.slack + model.ringCenter(index: index) * model.sizeScale,
+            along: model.tooltipAlong(index: index, length: tooltipLength(snapshot)),
             across: model.tooltipInset + (NotchLayout.tailLength + card) / 2
         )
     }

--- a/Sources/Notch/NotchViewModel.swift
+++ b/Sources/Notch/NotchViewModel.swift
@@ -81,12 +81,17 @@ final class NotchViewModel: ObservableObject {
     /// the controller says otherwise, which reads as "no screen known yet".
     @Published var screenSize: CGSize = .zero
 
-    /// The same screen minus the menu bar and the Dock.
-    ///
-    /// A horizontal notch starts at the *usable* edge and grows inward from
-    /// there, so those two are room it never had. A side notch is centred on
-    /// the whole screen and floats over both, so for that one they are not.
-    @Published var screenUsableSize: CGSize = .zero
+    /// Visible slice of the panel along its edge, in local stack coordinates.
+    @Published var visibleAlongRange: ClosedRange<CGFloat>?
+
+    func tooltipAlong(index: Int, length: CGFloat) -> CGFloat {
+        let centre = slack + ringCenter(index: index) * sizeScale
+        guard let range = visibleAlongRange else { return centre }
+        let lower = range.lowerBound + length / 2
+        let upper = range.upperBound - length / 2
+        guard lower <= upper else { return (range.lowerBound + range.upperBound) / 2 }
+        return min(max(centre, lower), upper)
+    }
 
     /// Take the notch geometry of whichever screen the panel is on.
     func adopt(screen: ScreenDescribing) {
@@ -96,8 +101,6 @@ final class NotchViewModel: ObservableObject {
         // and may sit under the menu bar, so the menu bar is not room lost.
         let size = screen.frameValue.size
         if screenSize != size { screenSize = size }
-        let usable = screen.visibleFrameValue.size
-        if screenUsableSize != usable { screenUsableSize = usable }
     }
 
     /// How far in from the bezel the notch's contents start.
@@ -358,7 +361,7 @@ final class NotchViewModel: ObservableObject {
                 - shapeLength(cellCount: cellCount)
                 - 2 * NotchLayout.cardCorner
         }
-        return screenUsableSize.height / sizeScale
+        return screenSize.height / sizeScale
             - contentInset
             - NotchLayout.bodyDepth(for: edge)
             - NotchLayout.tailLength

--- a/Sources/Notch/NotchWindowController.swift
+++ b/Sources/Notch/NotchWindowController.swift
@@ -73,14 +73,6 @@ final class NotchWindowController {
     private var visibility: NotchVisibility = .onHover
     /// Whether we have pushed the pointing hand onto the cursor stack.
     private var isPointing = false
-    /// The usable area the panel was last placed against.
-    ///
-    /// The notch is pinned to `visibleFrame` so it rests on the Dock rather than
-    /// under it — but an auto-hiding Dock revealing or concealing itself fires
-    /// no screen-parameter notification, so nothing would tell us the space had
-    /// come back. The cursor poll is already running; noticing there costs one
-    /// rect comparison every 0.3s and needs no new machinery.
-    private var lastVisibleFrame: CGRect?
 
     func show() {
         relocate()
@@ -154,7 +146,6 @@ final class NotchWindowController {
             alongOffset: model.alongOffset, slack: model.slack,
             trailingExtent: model.trailingExtent
         )
-        lastVisibleFrame = screen.visibleFrame
 
         if let panel {
             panel.setFrame(frame, display: true)
@@ -194,6 +185,16 @@ final class NotchWindowController {
             self.panel = panel
             self.hostingView = hosting
         }
+        // Use the actual panel origin: near a corner its transparent padding
+        // can extend offscreen, while the tooltip itself must stay visible.
+        if let panel {
+            let visible = panel.frame.intersection(screen.frame)
+            let range: ClosedRange<CGFloat> = model.edge.isVertical
+                ? (panel.frame.maxY - visible.maxY)...(panel.frame.maxY - visible.minY)
+                : (visible.minX - panel.frame.minX)...(visible.maxX - panel.frame.minX)
+            if model.visibleAlongRange != range { model.visibleAlongRange = range }
+        }
+
         // The frame AppKit actually gave us, which is what the flush right-hand
         // edge depends on.
         if let panel {
@@ -294,6 +295,7 @@ final class NotchWindowController {
         let snapshot = model.snapshots[index]
         let cardHeight = NotchLayout.cardHeight(
             windowCount: snapshot.windows.count,
+            groupCount: snapshot.windowGroupCount,
             sessionCount: model.activity(for: snapshot.id)?.sessions.count ?? 0,
             sessionCap: model.sessionCap,
             statusMessage: snapshot.statusMessage,
@@ -305,7 +307,7 @@ final class NotchWindowController {
         // pointer has to cross. Along it, the card's own extent.
         let cardAcross = model.edge.isVertical ? NotchLayout.cardWidth : cardHeight
         let cardAlong = model.edge.isVertical ? cardHeight : NotchLayout.cardWidth
-        let centre = model.slack + model.ringCenter(index: index) * model.sizeScale
+        let centre = model.tooltipAlong(index: index, length: cardAlong)
         return placement.rect(
             along: centre - cardAlong / 2,
             // The card's own extent does not scale, and it begins where the
@@ -339,10 +341,6 @@ final class NotchWindowController {
     private func startWatchingCursor() {
         let poll = Timer(timeInterval: 0.3, repeats: true) { [weak self] _ in
             MainActor.assumeIsolated {
-                // Only on the poll, not on every mouse-moved event: this reads
-                // the screen list, and doing that per event would be work at
-                // 60Hz to answer a question that changes twice a minute.
-                self?.followUsableAreaIfItMoved()
                 self?.cursorMoved()
             }
         }
@@ -367,14 +365,6 @@ final class NotchWindowController {
     private func localCursor(in frame: CGRect) -> CGPoint {
         let mouse = NSEvent.mouseLocation
         return CGPoint(x: mouse.x - frame.minX, y: frame.maxY - mouse.y)
-    }
-
-    /// Has the Dock appeared, gone away, moved or resized since we last placed
-    /// the panel? Nothing notifies us, so this is asked rather than told.
-    private func followUsableAreaIfItMoved() {
-        guard let screen = currentScreen() else { return }
-        guard screen.visibleFrame != lastVisibleFrame else { return }
-        relocate()
     }
 
     private func cursorMoved() {

--- a/Tests/HardwareNotchTests.swift
+++ b/Tests/HardwareNotchTests.swift
@@ -34,22 +34,20 @@ final class HardwareNotchGeometryTests: XCTestCase {
                        "it stopped below the menu bar instead of meeting the notch")
     }
 
-    /// With nothing to merge with, covering the menu bar is pure cost.
-    func testWithoutOneItStillSitsBelowTheMenuBar() {
+    func testWithoutOneItStillReachesThePhysicalTopEdge() {
         let frame = NotchGeometry.panelFrame(for: plain, panelSize: size, edge: .top)
-        XCTAssertEqual(frame.maxY, plain.visibleFrameValue.maxY, accuracy: 0.001)
+        XCTAssertEqual(frame.maxY, plain.frameValue.maxY, accuracy: 0.001)
     }
 
-    /// Only the top edge merges. The others have nothing to merge with, and a
-    /// bottom notch still has a Dock to keep clear of.
+    /// Hardware merging only affects the top edge.
     func testTheOtherEdgesAreUnaffectedByIt() {
         XCTAssertEqual(
             NotchGeometry.panelFrame(for: notched, panelSize: size, edge: .bottom).minY,
-            notched.visibleFrameValue.minY, accuracy: 0.001
+            notched.frameValue.minY, accuracy: 0.001
         )
         XCTAssertEqual(
             NotchGeometry.panelFrame(for: notched, panelSize: CGSize(width: 300, height: 700), edge: .right).maxX,
-            notched.visibleFrameValue.maxX, accuracy: 0.001
+            notched.frameValue.maxX, accuracy: 0.001
         )
     }
 

--- a/Tests/NotchEdgeTests.swift
+++ b/Tests/NotchEdgeTests.swift
@@ -126,9 +126,8 @@ final class NotchPlacementTests: XCTestCase {
     }
 }
 
-/// The notch is pinned to the *usable* edge, so it rests on the Dock rather
-/// than under it, and below the menu bar rather than behind it.
-final class DockAvoidanceTests: XCTestCase {
+/// Desktop reservations must not displace a user-selected screen position.
+final class PhysicalScreenEdgeTests: XCTestCase {
     /// A 70pt Dock at the bottom, and the menu bar above it.
     private let docked = FakeScreen(
         frameValue: CGRect(x: 0, y: 0, width: 1800, height: 1169),
@@ -136,17 +135,17 @@ final class DockAvoidanceTests: XCTestCase {
     )
     private let wide = CGSize(width: 600, height: 200)
 
-    func testTheBottomEdgeRestsOnTopOfTheDock() {
+    func testTheBottomEdgeReachesTheScreenBelowTheDock() {
         let frame = NotchGeometry.panelFrame(for: docked, panelSize: wide, edge: .bottom)
-        XCTAssertEqual(frame.minY, 70, accuracy: 0.001)
+        XCTAssertEqual(frame.minY, 0, accuracy: 0.001)
     }
 
-    func testTheTopEdgeHangsBelowTheMenuBar() {
+    func testTheTopEdgeReachesThePhysicalScreenEdge() {
         let frame = NotchGeometry.panelFrame(for: docked, panelSize: wide, edge: .top)
-        XCTAssertEqual(frame.maxY, docked.visibleFrameValue.maxY, accuracy: 0.001)
+        XCTAssertEqual(frame.maxY, docked.frameValue.maxY, accuracy: 0.001)
     }
 
-    func testASideDockPushesTheNotchIn() {
+    func testASideDockDoesNotPushTheNotchIn() {
         let leftDock = FakeScreen(
             frameValue: CGRect(x: 0, y: 0, width: 1800, height: 1169),
             visibleFrameValue: CGRect(x: 90, y: 0, width: 1710, height: 1132)
@@ -154,19 +153,17 @@ final class DockAvoidanceTests: XCTestCase {
         let frame = NotchGeometry.panelFrame(
             for: leftDock, panelSize: CGSize(width: 334, height: 484), edge: .left
         )
-        XCTAssertEqual(frame.minX, 90, accuracy: 0.001)
+        XCTAssertEqual(frame.minX, 0, accuracy: 0.001)
     }
 
-    /// A Dock that hides gives the space back, and the notch takes it — this is
-    /// what makes the placement follow rather than guess once at launch.
-    func testItFollowsTheDockWhenItHides() {
+    func testItStaysAtTheSameEdgeWhenTheDockHides() {
         let hidden = FakeScreen(
             frameValue: docked.frameValue,
             visibleFrameValue: CGRect(x: 0, y: 0, width: 1800, height: 1132)
         )
         XCTAssertEqual(
             NotchGeometry.panelFrame(for: docked, panelSize: wide, edge: .bottom).minY,
-            70, accuracy: 0.001
+            0, accuracy: 0.001
         )
         XCTAssertEqual(
             NotchGeometry.panelFrame(for: hidden, panelSize: wide, edge: .bottom).minY,

--- a/Tests/NotchGeometryTests.swift
+++ b/Tests/NotchGeometryTests.swift
@@ -220,6 +220,57 @@ final class PanelEdgeTests: XCTestCase {
     }
 }
 
+/// Use an offset monitor and reserve desktop space on every side so accidental
+/// dependencies on the primary display or visibleFrame are caught together.
+final class ScreenAnchorRegressionTests: XCTestCase {
+    func testEveryEdgeIgnoresDesktopReservationsAtEveryDragPosition() {
+        let full = CGRect(x: -1920, y: -300, width: 1920, height: 1080)
+        let shown = FakeScreen(frameValue: full,
+                               visibleFrameValue: full.insetBy(dx: 90, dy: 70))
+        let hidden = FakeScreen(frameValue: full, visibleFrameValue: full)
+        for edge in NotchEdge.allCases {
+            let size = NotchPlacement.panelSize(edge: edge, length: 800, depth: 300)
+            for offset: CGFloat in [-10000, -230, 0, 310, 10000] {
+                let frame = NotchGeometry.panelFrame(for: shown, panelSize: size,
+                                                     edge: edge, alongOffset: offset, slack: 200)
+                XCTAssertEqual(frame, NotchGeometry.panelFrame(for: hidden, panelSize: size,
+                                                                edge: edge, alongOffset: offset, slack: 200))
+                switch edge {
+                case .left: XCTAssertEqual(frame.minX, full.minX)
+                case .right: XCTAssertEqual(frame.maxX, full.maxX)
+                case .top: XCTAssertEqual(frame.maxY, full.maxY)
+                case .bottom: XCTAssertEqual(frame.minY, full.minY)
+                }
+            }
+        }
+    }
+
+    @MainActor func testCornerTooltipsStayInsideTheVisiblePartOfThePanel() {
+        for size in NotchSize.allCases {
+            for edge in NotchEdge.allCases {
+                let model = NotchViewModel()
+                model.edge = edge
+                model.sizeScale = size.scale
+                let length: CGFloat = edge.isVertical ? 300 : NotchLayout.cardWidth
+                let ring = model.slack + model.ringCenter(index: 0) * size.scale
+                XCTAssertEqual(model.tooltipAlong(index: 0, length: length), ring)
+                // Both ends of the screen: the ring remains on screen, while a
+                // card centred on it would lose its heading or its right edge.
+                for range in [(ring - 45)...(ring + 900), (ring - 900)...(ring + 45)] {
+                    model.visibleAlongRange = range
+                    let centre = model.tooltipAlong(index: 0, length: length)
+                    XCTAssertGreaterThanOrEqual(centre - length / 2, range.lowerBound - 0.0001)
+                    XCTAssertLessThanOrEqual(centre + length / 2, range.upperBound + 0.0001)
+                    XCTAssertNotEqual(centre, ring)
+                    XCTAssertLessThanOrEqual(abs(ring - centre), length / 2 - NotchLayout.tailHeight / 2)
+                }
+                model.visibleAlongRange = (ring - 900)...(ring + 900)
+                XCTAssertEqual(model.tooltipAlong(index: 0, length: length), ring)
+            }
+        }
+    }
+}
+
 /// The size choice reaches the screen in the notch's own measurements, never
 /// in the tooltip's. These pin the seam between the two.
 final class ScaledMeasurementTests: XCTestCase {

--- a/Tests/NotchLayoutTests.swift
+++ b/Tests/NotchLayoutTests.swift
@@ -1076,7 +1076,6 @@ final class SessionCapTests: XCTestCase {
             let model = NotchViewModel()
             model.edge = .right
             model.screenSize = CGSize(width: 1512, height: height)
-            model.screenUsableSize = CGSize(width: 1512, height: height - 37)
             XCTAssertLessThanOrEqual(
                 model.panelSize(cellCount: 4).height, height,
                 "the panel runs off a \(height)pt screen"
@@ -1085,17 +1084,15 @@ final class SessionCapTests: XCTestCase {
     }
 
     /// A top or bottom notch spends the card's height reaching inward instead,
-    /// against the usable screen — it starts below the menu bar, so the menu
-    /// bar is room it never had.
-    @MainActor func testAHorizontalNotchStaysWithinTheUsableScreen() {
+    /// against the full screen, starting at the physical bezel.
+    @MainActor func testAHorizontalNotchStaysWithinThePhysicalScreen() {
         for height in stride(from: CGFloat(900), through: 2000, by: 23) {
             for edge in [NotchEdge.top, .bottom] {
                 let model = NotchViewModel()
                 model.edge = edge
                 model.screenSize = CGSize(width: 1512, height: height)
-                model.screenUsableSize = CGSize(width: 1512, height: height - 37)
                 XCTAssertLessThanOrEqual(
-                    model.panelSize(cellCount: 4).height, height - 37,
+                    model.panelSize(cellCount: 4).height, height,
                     "\(edge): the panel runs off a \(height)pt screen"
                 )
             }

--- a/Tests/NotchRenderTests.swift
+++ b/Tests/NotchRenderTests.swift
@@ -263,7 +263,7 @@ final class EdgeCrossfadeTests: XCTestCase {
                        "the notch never came back")
         guard let screen = NotchGeometry.preferredScreen(from: NSScreen.screens) else { return }
         XCTAssertEqual(controller.panelFrameForTesting?.minY ?? -1,
-                       screen.visibleFrame.minY, accuracy: 1,
+                       screen.frame.minY, accuracy: 1,
                        "it did not end up on the edge it was sent to")
     }
 
@@ -555,5 +555,41 @@ final class StaleAfterMarginTests: XCTestCase {
     func testTheShippedDefaultsKeepTheSameMargin() {
         let store = UsageStore(providers: [])
         XCTAssertGreaterThan(store.staleAfterForTesting, store.idleRefreshIntervalForTesting)
+    }
+}
+
+@MainActor
+final class PhysicalPanelIntegrationTests: XCTestCase {
+    func testActualPanelsStayOnTheBezelAndKeepCornerCardsVisible() throws {
+        let screen = try XCTUnwrap(NSScreen.main)
+        for size in NotchSize.allCases {
+            for edge in NotchEdge.allCases {
+                let controller = NotchWindowController()
+                controller.assignedScreen = screen
+                controller.model.edge = edge
+                controller.model.sizeScale = size.scale
+                controller.model.snapshots = Array(Fixtures.snapshots().prefix(2))
+                controller.show()
+                defer { controller.stop() }
+                for offset: CGFloat in [-10000, 0, 10000] {
+                    controller.model.alongOffset = offset
+                    controller.relocate()
+                    let frame = try XCTUnwrap(controller.panelFrameForTesting)
+                    switch edge {
+                    case .left: XCTAssertEqual(frame.minX, screen.frame.minX, accuracy: 1)
+                    case .right: XCTAssertEqual(frame.maxX, screen.frame.maxX, accuracy: 1)
+                    case .top: XCTAssertEqual(frame.maxY, screen.frame.maxY, accuracy: 1)
+                    case .bottom: XCTAssertEqual(frame.minY, screen.frame.minY, accuracy: 1)
+                    }
+                    let range = try XCTUnwrap(controller.model.visibleAlongRange)
+                    let length: CGFloat = edge.isVertical ? 260 : NotchLayout.cardWidth
+                    for index in 0..<2 {
+                        let centre = controller.model.tooltipAlong(index: index, length: length)
+                        XCTAssertGreaterThanOrEqual(centre - length / 2, range.lowerBound)
+                        XCTAssertLessThanOrEqual(centre + length / 2, range.upperBound)
+                    }
+                }
+            }
+        }
     }
 }

--- a/Tests/PreferencesTests.swift
+++ b/Tests/PreferencesTests.swift
@@ -85,3 +85,20 @@ final class PreferencesMigrationTests: XCTestCase {
         XCTAssertEqual(NotchSize.medium.scale, 1)
     }
 }
+
+@MainActor
+final class NotchPositionPersistenceTests: XCTestCase {
+    func testEachEdgesPositionSurvivesReopeningPreferences() throws {
+        let name = "NotchPositionTests.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: name))
+        defer { defaults.removePersistentDomain(forName: name) }
+        let preferences = Preferences(defaults: defaults)
+        for (index, edge) in NotchEdge.allCases.enumerated() {
+            preferences.setOffset(CGFloat(index * 150 - 225), for: edge)
+        }
+        let reopened = Preferences(defaults: defaults)
+        for (index, edge) in NotchEdge.allCases.enumerated() {
+            XCTAssertEqual(reopened.offset(for: edge), CGFloat(index * 150 - 225))
+        }
+    }
+}


### PR DESCRIPTION
The notch currently anchors to the desktop area left by the Dock and menu bar. For example, a bottom Dock reserving 70 points places the notch 70 points above the physical display edge, and showing or hiding the Dock can move it away from the user's chosen position.

Anchor all four placements to the physical screen frame and preserve the existing per-edge Option-drag offsets and settings-handle bounds. This intentionally allows the notch to occupy the area reserved for the Dock or menu bar. Keep hardware-notch joining and all three notch sizes working.

Near a corner, clamp the tooltip card to the visible portion of the panel and offset its tail toward the hovered ring. Use matching geometry for drawing and mouse interaction, including grouped limits and Codex token statistics. Remove the Dock-area polling that would otherwise reposition the panel.

Validation:
- `make test`: 864 tests passed, including physical-edge, offset-display, Dock reservation, position persistence and corner-tooltip tests at all three sizes.
- `bash Scripts/test-signing.sh`: all four checks passed.
- `git diff --cached --check`: passed.
