### PR TITLE
Ignore leftover Cursor subagents and stale waiting flags

### DIFF
--- a/Sources/Sessions/CursorActivityMonitor.swift
+++ b/Sources/Sessions/CursorActivityMonitor.swift
@@ -11,6 +11,12 @@ import SQLite3
 /// - `unfinishedRunAt` — set while a run is in flight, cleared when it finishes.
 /// - `hasBlockingPendingActions` / `hasPendingPlan` — set when it wants you.
 ///
+/// Nested `isSubagent` composers are skipped: the parent chat already carries
+/// the busy/waiting state, and finished subagents are what left the blocking
+/// flag set for months. Waiting rows are gated on this editor launch (or a
+/// write still inside the staleness window), so a leftover approval from a
+/// previous process does not keep the notch amber.
+///
 /// The database is in **WAL mode**, so it must be opened without `immutable`:
 /// that flag tells SQLite to ignore the write-ahead log, which means reading
 /// whatever was true at the last checkpoint. It is the difference between a
@@ -102,13 +108,24 @@ final class CursorActivityMonitor: ObservableObject, AgentActivityMonitor {
         guard let db = SQLiteStore.open(store) else { return [] }
         defer { sqlite3_close(db) }
 
-        let values = SQLiteStore.rows(
+        // `isSubagent` lives on the row, not always in the JSON value. Nested
+        // composers (continual-learning, explore, …) are not their own notch
+        // rows: the parent chat already carries the busy/waiting state, and
+        // finished subagents are what left `hasBlockingPendingActions` set for
+        // months after the run ended.
+        let rows = SQLiteStore.rows(
             in: db,
-            sql: "SELECT value FROM composerHeaders WHERE isArchived = 0 ORDER BY recency DESC LIMIT 40"
+            sql: """
+            SELECT value, isSubagent FROM composerHeaders
+            WHERE isArchived = 0 ORDER BY recency DESC LIMIT 40
+            """,
+            columns: 2
         )
-        return values
-            .compactMap {
-                session(fromHeader: $0, cursorLaunchedAt: cursorLaunchedAt,
+        return rows
+            .compactMap { row in
+                session(fromHeader: row[0],
+                        isSubagent: flag(row.count > 1 ? row[1] : nil),
+                        cursorLaunchedAt: cursorLaunchedAt,
                         staleAfter: staleAfter, now: now)
             }
             .sorted { $0.since > $1.since }
@@ -137,7 +154,15 @@ final class CursorActivityMonitor: ObservableObject, AgentActivityMonitor {
     ///   at all and `cursorLaunchedAt` is nil.
     /// - Written longer than `staleAfter` ago, the conversation has stopped
     ///   being written to, which is the only evidence an abandoned run leaves.
+    ///
+    /// Waiting is different from busy on one point: checkpoints do not move
+    /// until you answer, so a plan from this morning must keep its amber.
+    /// The launch gate still applies — a blocking flag from a previous
+    /// process is not a question — and a wait that has gone silent longer
+    /// than `staleAfter` with the editor shut or restarted is retired the
+    /// same way a dead run is.
     static func session(fromHeader json: String,
+                        isSubagent: Bool = false,
                         cursorLaunchedAt: Date?,
                         staleAfter: TimeInterval,
                         now: Date = Date()) -> AgentSession? {
@@ -146,12 +171,16 @@ final class CursorActivityMonitor: ObservableObject, AgentActivityMonitor {
               let id = head["composerId"] as? String
         else { return nil }
 
+        if isSubagent || flag(head["isSubagent"]) { return nil }
+
         let blocked = (head["hasBlockingPendingActions"] as? Bool) == true
             || (head["hasPendingPlan"] as? Bool) == true
         let runStart = date(head["unfinishedRunAt"])
         // A quarter of rows carry `lastUpdatedAt` and no checkpoint at all.
         let lastWrite = date(head["conversationCheckpointLastUpdatedAt"])
             ?? date(head["lastUpdatedAt"])
+        let created = date(head["createdAt"])
+        let touched = lastWrite ?? runStart ?? created
 
         let isRunning: Bool = {
             guard let runStart, let cursorLaunchedAt else { return false }
@@ -159,21 +188,28 @@ final class CursorActivityMonitor: ObservableObject, AgentActivityMonitor {
             // since `unfinishedRunAt` *is* its creation time that is the most
             // recent thing to have happened to it. The same value on a chat
             // opened last week is correctly stale.
-            let touched = lastWrite ?? runStart
-            guard touched >= cursorLaunchedAt else { return false }
-            return now.timeIntervalSince(touched) <= staleAfter
+            let stamp = lastWrite ?? runStart
+            guard stamp >= cursorLaunchedAt else { return false }
+            return now.timeIntervalSince(stamp) <= staleAfter
         }()
 
         let isRecentlyFinished: Bool = {
             guard let runStart, let cursorLaunchedAt else { return false }
-            let touched = lastWrite ?? runStart
-            guard touched >= cursorLaunchedAt else { return false }
-            let age = now.timeIntervalSince(touched)
+            let stamp = lastWrite ?? runStart
+            guard stamp >= cursorLaunchedAt else { return false }
+            let age = now.timeIntervalSince(stamp)
             return age > staleAfter && age <= staleAfter + 15
         }()
 
+        let isWaiting = blocked && isCurrentWait(
+            touched: touched,
+            cursorLaunchedAt: cursorLaunchedAt,
+            staleAfter: staleAfter,
+            now: now
+        )
+
         let state: AgentSession.State
-        if blocked { state = .waiting }
+        if isWaiting { state = .waiting }
         else if isRunning { state = .busy }
         else if isRecentlyFinished { state = .idle }
         else { return nil }
@@ -192,9 +228,39 @@ final class CursorActivityMonitor: ObservableObject, AgentActivityMonitor {
             name: (head["name"] as? String) ?? "Untitled chat",
             detail: (head["subtitle"] as? String) ?? "Cursor",
             state: state,
-            waitingFor: blocked ? "needs your input" : nil,
+            waitingFor: isWaiting ? "needs your input" : nil,
             since: since
         )
+    }
+
+    /// Waiting is live if it belongs to this editor launch — you may sit on
+    /// a plan for hours — or if the last write is still inside the staleness
+    /// window, which covers a crash-and-restart. An undated row with the
+    /// editor up is trusted: we cannot prove it is old.
+    private static func isCurrentWait(touched: Date?,
+                                      cursorLaunchedAt: Date?,
+                                      staleAfter: TimeInterval,
+                                      now: Date) -> Bool {
+        let recentlyTouched = touched.map { now.timeIntervalSince($0) <= staleAfter } ?? false
+        guard let cursorLaunchedAt else { return recentlyTouched }
+        guard let touched else { return true }
+        return touched >= cursorLaunchedAt || recentlyTouched
+    }
+
+    /// Cursor stores booleans as 0/1 in SQLite, and JSONSerialization often
+    /// hands them back as `NSNumber`. Empty and unknown values are false.
+    private static func flag(_ value: Any?) -> Bool {
+        switch value {
+        case let flag as Bool:
+            return flag
+        case let number as NSNumber:
+            return number.boolValue
+        case let text as String:
+            let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+            return trimmed == "1" || trimmed == "true" || trimmed == "yes"
+        default:
+            return false
+        }
     }
 
     /// Cursor writes its timestamps as milliseconds since the epoch.

--- a/Tests/ActivitySummaryTests.swift
+++ b/Tests/ActivitySummaryTests.swift
@@ -60,7 +60,8 @@ final class CursorActivityTests: XCTestCase {
                         name: String? = nil,
                         subtitle: String? = nil,
                         blocking: Bool? = nil,
-                        plan: Bool? = nil) -> String {
+                        plan: Bool? = nil,
+                        subagent: Bool? = nil) -> String {
         var head: [String: Any] = [:]
         head["composerId"] = id
         head["unfinishedRunAt"] = run.map(millis)
@@ -71,6 +72,7 @@ final class CursorActivityTests: XCTestCase {
         head["subtitle"] = subtitle
         head["hasBlockingPendingActions"] = blocking
         head["hasPendingPlan"] = plan
+        head["isSubagent"] = subagent
         let data = try! JSONSerialization.data(withJSONObject: head)
         return String(data: data, encoding: .utf8)!
     }
@@ -123,14 +125,62 @@ final class CursorActivityTests: XCTestCase {
         XCTAssertEqual(s.state, .busy)
     }
 
-    /// A blocked row still counts with the editor shut — it really is waiting
-    /// on you — but it must not be dated by a run that never finished.
+    /// A blocked row still counts with the editor shut when the write is
+    /// recent — you may have crashed mid-approval — but it must not be dated
+    /// by a run that never finished.
     func testWaitingSurvivesAClosedEditorButNotAStaleRunTime() throws {
         let checkpoint = runAt.addingTimeInterval(18_170)
         let s = try XCTUnwrap(session(header(checkpoint: checkpoint, plan: true),
                                       launchedAt: nil))
         XCTAssertEqual(s.state, .waiting)
         XCTAssertEqual(s.since, checkpoint)
+    }
+
+    /// The June `agents-memory-updater` zombies: Cursor leaves
+    /// `hasBlockingPendingActions` set on finished subagent composers, and
+    /// waiting used to ignore both the launch gate and the staleness window.
+    func testAStaleWaitingRowFromBeforeThisLaunchIsNotListed() {
+        XCTAssertNil(session(header(run: nil, checkpoint: runAt, plan: true),
+                             launchedAt: runAt.addingTimeInterval(8_170),
+                             now: runAt.addingTimeInterval(8_230)))
+    }
+
+    /// Same flag, editor not even open: a wait that went silent hours ago is
+    /// not still asking for something.
+    func testAStaleWaitingRowIsNotListedWhenTheEditorIsClosed() {
+        XCTAssertNil(session(header(run: nil, checkpoint: runAt, plan: true),
+                             launchedAt: nil,
+                             now: runAt.addingTimeInterval(3600)))
+    }
+
+    /// Waiting is allowed to sit for hours while the editor stays up — you
+    /// have not answered yet, and checkpoints will not move until you do.
+    /// Gating it on the busy-run staleness window would hide a plan from this
+    /// morning.
+    func testAWaitingRowFromThisLaunchStillCountsAfterHours() throws {
+        let checkpoint = runAt.addingTimeInterval(60)
+        let s = try XCTUnwrap(session(header(run: nil, checkpoint: checkpoint, plan: true),
+                                      launchedAt: runAt,
+                                      staleAfter: 15 * 60,
+                                      now: checkpoint.addingTimeInterval(4 * 3600)))
+        XCTAssertEqual(s.state, .waiting)
+    }
+
+    /// Restarted the editor thirty seconds after it asked: the write predates
+    /// this launch, but it is still recent, so the wait survived the crash.
+    func testARecentWaitingRowSurvivesARestart() throws {
+        let s = try XCTUnwrap(session(header(run: nil, checkpoint: runAt, plan: true),
+                                      launchedAt: runAt.addingTimeInterval(30),
+                                      now: runAt.addingTimeInterval(40)))
+        XCTAssertEqual(s.state, .waiting)
+    }
+
+    /// Nested composers (continual-learning, explore, …) are not their own
+    /// notch rows. The parent chat already carries the busy/waiting state,
+    /// and finished subagents are what left the blocking flag set for months.
+    func testASubagentRowIsNotListedEvenWhenItLooksLive() {
+        XCTAssertNil(session(header(subagent: true)))
+        XCTAssertNil(session(header(run: nil, plan: true, subagent: true)))
     }
 
     /// `unfinishedRunAt` is the composer's creation time, not the current run's:
@@ -179,9 +229,8 @@ final class CursorActivityTests: XCTestCase {
     /// opened is dated from when it was opened — not from the wall clock, which
     /// would restamp it on every two-second poll and republish for ever.
     func testAWaitingRowWithNoWritesFallsBackToCreatedAt() throws {
-        let created = runAt.addingTimeInterval(-981_829)
-        let s = try XCTUnwrap(session(header(run: nil, created: created, plan: true),
-                                      launchedAt: nil))
+        let created = runAt
+        let s = try XCTUnwrap(session(header(run: nil, created: created, plan: true)))
         XCTAssertEqual(s.since, created)
     }
 
@@ -253,9 +302,9 @@ final class CursorActivityTests: XCTestCase {
         let older = runAt
         let newer = runAt.addingTimeInterval(100)
         let url = try makeStore([
-            (header(id: "older", run: older, checkpoint: older), archived: 0),
-            (header(id: "newer", run: newer, checkpoint: newer), archived: 0),
-            (header(id: "filed", run: newer, checkpoint: newer), archived: 1),
+            (header(id: "older", run: older, checkpoint: older), archived: 0, subagent: 0),
+            (header(id: "newer", run: newer, checkpoint: newer), archived: 0, subagent: 0),
+            (header(id: "filed", run: newer, checkpoint: newer), archived: 1, subagent: 0),
         ])
         defer { try? FileManager.default.removeItem(at: url) }
 
@@ -265,21 +314,38 @@ final class CursorActivityTests: XCTestCase {
         XCTAssertEqual(found.map(\.id), ["cursor.newer", "cursor.older"])
     }
 
+    /// Cursor stores `isSubagent` as a column, not always in the JSON value.
+    /// The June zombies had the column set and the header silent about it.
+    func testReadSkipsSubagentColumnEvenWhenTheHeaderOmitsIt() throws {
+        let url = try makeStore([
+            (header(id: "parent", checkpoint: runAt), archived: 0, subagent: 0),
+            (header(id: "nested", checkpoint: runAt), archived: 0, subagent: 1),
+        ])
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let found = CursorActivityMonitor.read(store: url, cursorLaunchedAt: .distantPast,
+                                               staleAfter: 10 * 60,
+                                               now: runAt.addingTimeInterval(1))
+        XCTAssertEqual(found.map(\.id), ["cursor.parent"])
+    }
+
     /// Mirrors `SQLiteStoreTests.makeDatabase`: closing checkpoints the WAL, so
     /// the file reads back the way it would after the editor has quit.
-    private func makeStore(_ rows: [(String, archived: Int)]) throws -> URL {
+    private func makeStore(_ rows: [(String, archived: Int, subagent: Int)]) throws -> URL {
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent("cursor-\(UUID().uuidString).sqlite")
         var db: OpaquePointer?
         XCTAssertEqual(sqlite3_open(url.path, &db), SQLITE_OK)
         sqlite3_exec(db, "PRAGMA journal_mode=WAL;", nil, nil, nil)
         sqlite3_exec(db, """
-        CREATE TABLE composerHeaders (value TEXT, isArchived INT, recency INT);
+        CREATE TABLE composerHeaders (
+            value TEXT, isArchived INT, recency INT, isSubagent INT
+        );
         """, nil, nil, nil)
         for (index, row) in rows.enumerated() {
             let escaped = row.0.replacingOccurrences(of: "'", with: "''")
             sqlite3_exec(db, """
-            INSERT INTO composerHeaders VALUES ('\(escaped)', \(row.archived), \(index));
+            INSERT INTO composerHeaders VALUES ('\(escaped)', \(row.archived), \(index), \(row.subagent));
             """, nil, nil, nil)
         }
         sqlite3_close(db)


### PR DESCRIPTION
## Summary
- Cursor leaves `hasBlockingPendingActions` set on finished **nested** composers (`isSubagent`, e.g. `agents-memory-updater`). Waiting was not gated on launch or silence, so those rows kept the notch amber for months after the run ended.
- Skip subagent composers: the parent chat already carries busy/waiting. Gate waiting the same way busy already is — this editor launch, or a write still inside the 15-minute window so a crash-and-restart still shows a real approval.
- Observed on a live store: ten June 2026 memory-updater waiters plus one genuinely busy parent chat. After the change, only the parent remains.

This is the waiting/subagent half of the leftover-run problem. #4 covered busy `unfinishedRunAt` leftovers (that gate is already on `main`). No open PR duplicates this; #49 only wraps `"Untitled chat"` for localisation.

Fixes #48.

## Test plan
- [x] `CursorActivityTests` (26) and full suite (866) pass
- [ ] Hover the Cursor ring with no live chat: no amber waiters from old nested agents
- [ ] A parent chat that is actually waiting for approval still shows, including hours later while Cursor stays up
- [ ] Nested live work (explore / memory-updater) shows via the parent, not as its own row