### PR TITLE
fix: find Claude Code when it was installed with npm (discovery + 1.7.0 token renewal)

### DIFF
--- a/Sources/Providers/ClaudeCLI.swift
+++ b/Sources/Providers/ClaudeCLI.swift
@@ -21,9 +21,48 @@ enum ClaudeCLI {
     /// this. Matched on the resolved path, so a symlink into it is caught too.
     static let desktopOwned = "/Library/Application Support/Claude/"
 
+    /// Where a Node version manager puts an `npm install -g` — a directory
+    /// named for the Node version, which no entry in `candidates` can spell.
+    ///
+    /// npm remains the common way to install Claude Code, and under `nvm` the
+    /// binary lands in `~/.nvm/versions/node/<version>/bin`. Without this,
+    /// `standalone` returns nil on those machines, and the renewal that keeps
+    /// a ring from ageing out never runs at all — silently, since finding no
+    /// command is not an error.
+    ///
+    /// Newest version first: upgrading Node leaves every older tree in place
+    /// with whatever was installed against it at the time, and only the
+    /// current one is certainly the install being run. `.numeric` rather than
+    /// a semver parse, because the names are `v20.20.2` and `v22.22.3` and the
+    /// only thing asked of the order is that 22 sorts above 20 — which a plain
+    /// string comparison gets backwards.
+    static func nodeVersionCandidates(home: String = NSHomeDirectory(),
+                                      fileManager: FileManager = .default) -> [String] {
+        let versions = (home as NSString).appendingPathComponent(".nvm/versions/node")
+        guard let names = try? fileManager.contentsOfDirectory(atPath: versions) else { return [] }
+        return names
+            .sorted { $0.compare($1, options: .numeric) == .orderedDescending }
+            .map { (versions as NSString).appendingPathComponent("\($0)/bin/claude") }
+    }
+
+    /// The fixed locations a global npm install lands in, outside the paths
+    /// Claude Code's own installers use.
+    static func nodeToolCandidates(home: String = NSHomeDirectory()) -> [String] {
+        [".volta/bin/claude",      // Volta's shim directory
+         "Library/pnpm/claude",    // pnpm's global bin on macOS
+         ".npm-global/bin/claude"] // npm with a user-level prefix
+            .map { (home as NSString).appendingPathComponent($0) }
+    }
+
+    /// `candidates` first, so a copy Claude Code's own installer maintains is
+    /// preferred over one npm happens to have left in a Node tree.
     static func standalone(candidates: [String] = candidates,
+                           home: String = NSHomeDirectory(),
                            fileManager: FileManager = .default) -> URL? {
-        for path in candidates {
+        let all = candidates
+            + nodeToolCandidates(home: home)
+            + nodeVersionCandidates(home: home, fileManager: fileManager)
+        for path in all {
             let expanded = (path as NSString).expandingTildeInPath
             guard fileManager.isExecutableFile(atPath: expanded) else { continue }
             // `resolvingSymlinksInPath` because the Homebrew entry is a symlink

--- a/Sources/Providers/ClaudeUsageCLI.swift
+++ b/Sources/Providers/ClaudeUsageCLI.swift
@@ -40,8 +40,34 @@ struct ClaudeUsageCLI: Sendable {
     private static let searchPaths = [
         ".local/bin/claude",     // the native installer
         ".claude/local/claude",  // the migrate-from-npm layout
-        ".bun/bin/claude"
+        ".bun/bin/claude",
+        ".volta/bin/claude",     // Volta's shim directory
+        "Library/pnpm/claude",   // pnpm's global bin on macOS
+        ".npm-global/bin/claude" // npm with a user-level prefix
     ]
+
+    /// Where a Node version manager puts an `npm install -g` — a directory
+    /// named for the Node version, which no fixed path can spell.
+    ///
+    /// npm is still how most people install Claude Code, and under `nvm` the
+    /// binary lands in `~/.nvm/versions/node/<version>/bin`. Without this,
+    /// `locate` returns nil on those machines and the app falls back to the
+    /// token path, which is the one that has to keep asking for the keychain.
+    ///
+    /// Newest version first: upgrading Node leaves every older tree in place,
+    /// each with whatever was installed against it at the time, and only the
+    /// current one is certainly the install being run. `.numeric` rather than
+    /// a semver parse, because the names are `v20.20.2` and `v22.22.3` and the
+    /// only thing asked of the order is that 22 sorts above 20 — which a plain
+    /// string comparison gets backwards.
+    private static func nodeVersionCandidates(home: URL, fileManager: FileManager) -> [URL] {
+        let versions = home.appendingPathComponent(".nvm/versions/node")
+        guard let names = try? fileManager.contentsOfDirectory(atPath: versions.path)
+        else { return [] }
+        return names
+            .sorted { $0.compare($1, options: .numeric) == .orderedDescending }
+            .map { versions.appendingPathComponent($0).appendingPathComponent("bin/claude") }
+    }
 
     /// Relative to the filesystem root rather than absolute, so a test can point
     /// the whole search at a temporary directory. Left absolute, `locate` would
@@ -57,7 +83,11 @@ struct ClaudeUsageCLI: Sendable {
     static func locate(home: URL = ClaudeProfile.homeDirectory,
                        root: URL = URL(fileURLWithPath: "/"),
                        fileManager: FileManager = .default) -> ClaudeUsageCLI? {
+        // Version-manager trees come after the fixed paths and before the
+        // system ones, so an installation Claude Code maintains itself still
+        // wins over a copy npm happens to have left in an old Node tree.
         let candidates = searchPaths.map { home.appendingPathComponent($0) }
+            + nodeVersionCandidates(home: home, fileManager: fileManager)
             + systemPaths.map { root.appendingPathComponent($0) }
         guard let found = candidates.first(where: {
             fileManager.isExecutableFile(atPath: $0.path)

--- a/Tests/ClaudeTokenRefresherTests.swift
+++ b/Tests/ClaudeTokenRefresherTests.swift
@@ -14,8 +14,72 @@ final class ClaudeCLITests: XCTestCase {
         XCTAssertFalse(ClaudeCLI.isDesktopOwned(URL(fileURLWithPath: "/opt/homebrew/bin/claude")))
     }
 
-    func testNothingInstalledIsNotAnError() {
-        XCTAssertNil(ClaudeCLI.standalone(candidates: ["/nowhere/claude"]))
+    /// An empty home rather than the developer's own: `standalone` also looks
+    /// in the Node version trees now, and left pointing at the real home this
+    /// passed or failed depending on whether the person running it happened to
+    /// have installed Claude Code with npm.
+    func testNothingInstalledIsNotAnError() throws {
+        let home = try makeHome(executablesAt: [])
+
+        XCTAssertNil(ClaudeCLI.standalone(candidates: ["/nowhere/claude"], home: home.path))
+    }
+
+    /// npm is still how most people install Claude Code, and under a Node
+    /// version manager the binary sits in a directory named for the Node
+    /// version — a path no entry in `candidates` can spell. Without it,
+    /// `standalone` returns nil on those machines and the renewal that keeps
+    /// the ring alive simply never runs.
+    func testItFindsAnNpmInstallUnderNVM() throws {
+        let home = try makeHome(executablesAt: [".nvm/versions/node/v22.22.3/bin/claude"])
+
+        XCTAssertNotNil(ClaudeCLI.standalone(candidates: [], home: home.path))
+    }
+
+    /// Upgrading Node leaves every older tree in place; only the current one is
+    /// certainly the install being run.
+    func testTheNewestNodeVersionWins() throws {
+        let home = try makeHome(executablesAt: [".nvm/versions/node/v20.20.2/bin/claude",
+                                                ".nvm/versions/node/v22.22.3/bin/claude"])
+
+        let found = ClaudeCLI.standalone(candidates: [], home: home.path)?.path
+
+        XCTAssertEqual(found?.contains("v22.22.3"), true, "expected v22.22.3, got \(found ?? "nil")")
+    }
+
+    func testItFindsAVoltaShim() throws {
+        let home = try makeHome(executablesAt: [".volta/bin/claude"])
+
+        XCTAssertNotNil(ClaudeCLI.standalone(candidates: [], home: home.path))
+    }
+
+    /// The fixed locations still come first: a copy Claude Code's own installer
+    /// maintains is the one to renew with.
+    func testAnInstallerCopyOutranksANodeManager() throws {
+        let home = try makeHome(executablesAt: [".nvm/versions/node/v22.22.3/bin/claude",
+                                                "installer/claude"])
+
+        let found = ClaudeCLI.standalone(
+            candidates: [home.appendingPathComponent("installer/claude").path],
+            home: home.path
+        )?.path
+
+        XCTAssertEqual(found?.hasSuffix("installer/claude"), true)
+    }
+
+    private func makeHome(executablesAt paths: [String]) throws -> URL {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ClaudeCLITests.\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        addTeardownBlock { try? FileManager.default.removeItem(at: root) }
+
+        for path in paths {
+            let url = root.appendingPathComponent(path)
+            try FileManager.default.createDirectory(at: url.deletingLastPathComponent(),
+                                                    withIntermediateDirectories: true)
+            FileManager.default.createFile(atPath: url.path, contents: Data(),
+                                           attributes: [.posixPermissions: 0o755])
+        }
+        return root
     }
 }
 

--- a/Tests/ClaudeUsageCLITests.swift
+++ b/Tests/ClaudeUsageCLITests.swift
@@ -188,6 +188,63 @@ final class ClaudeUsageCLITests: XCTestCase {
         XCTAssertNil(ClaudeUsageCLI.locate(home: home, root: home))
     }
 
+    /// npm is how most people install Claude Code, and under a Node version
+    /// manager its bin directory is named for the Node version — a path no
+    /// fixed string can spell.
+    func testItFindsClaudeInstalledUnderNVM() throws {
+        let home = try makeHome(executablesAt: [".nvm/versions/node/v22.22.3/bin/claude"])
+
+        XCTAssertEqual(ClaudeUsageCLI.locate(home: home, root: home)?.binary.lastPathComponent,
+                       "claude")
+    }
+
+    /// A machine that has upgraded Node keeps every old version tree, and only
+    /// the current one is guaranteed to hold the install that is actually run.
+    func testTheNewestNodeVersionWins() throws {
+        let home = try makeHome(executablesAt: [".nvm/versions/node/v20.20.2/bin/claude",
+                                                ".nvm/versions/node/v22.22.3/bin/claude"])
+
+        let found = ClaudeUsageCLI.locate(home: home, root: home)?.binary.path
+
+        XCTAssertEqual(found?.contains("v22.22.3"), true, "expected v22.22.3, got \(found ?? "nil")")
+    }
+
+    /// Volta and pnpm keep a single stable bin directory of their own, outside
+    /// every path the installers use.
+    func testItFindsClaudeInAVoltaShimDirectory() throws {
+        let home = try makeHome(executablesAt: [".volta/bin/claude"])
+
+        XCTAssertNotNil(ClaudeUsageCLI.locate(home: home, root: home))
+    }
+
+    func testItFindsClaudeInPnpmsGlobalBin() throws {
+        let home = try makeHome(executablesAt: ["Library/pnpm/claude"])
+
+        XCTAssertNotNil(ClaudeUsageCLI.locate(home: home, root: home))
+    }
+
+    /// The native installer still wins when both are present: it is the layout
+    /// Claude Code keeps up to date itself.
+    func testTheNativeInstallerOutranksANodeManager() throws {
+        let home = try makeHome(executablesAt: [".nvm/versions/node/v22.22.3/bin/claude",
+                                                ".local/bin/claude"])
+
+        XCTAssertEqual(ClaudeUsageCLI.locate(home: home, root: home)?.binary.path,
+                       home.appendingPathComponent(".local/bin/claude").path)
+    }
+
+    private func makeHome(executablesAt paths: [String]) throws -> URL {
+        let root = try makeHome(executableAt: nil)
+        for path in paths {
+            let url = root.appendingPathComponent(path)
+            try FileManager.default.createDirectory(at: url.deletingLastPathComponent(),
+                                                    withIntermediateDirectories: true)
+            FileManager.default.createFile(atPath: url.path, contents: Data(),
+                                           attributes: [.posixPermissions: 0o755])
+        }
+        return root
+    }
+
     private func makeHome(executableAt path: String?, executable: Bool = true) throws -> URL {
         let root = FileManager.default.temporaryDirectory
             .appendingPathComponent("ClaudeUsageCLITests.\(UUID().uuidString)")


### PR DESCRIPTION
Rebased onto 1.7.0, and extended: the same gap now also disables the token renewal that 1.7.0 introduced.

Two call sites look for the `claude` command by fixed path, and neither covers an `npm install -g @anthropic-ai/claude-code`. Under a Node version manager the binary sits in a directory named for the Node version — `~/.nvm/versions/node/v22.22.3/bin/claude` — which no fixed path can spell.

**1. `ClaudeUsageCLI.locate`** returns nil, so the provider falls to the token path: the one the header comment describes as unable to stop asking for the keychain.

**2. `ClaudeCLI.standalone` (new in 1.7.0)** returns nil, so `ClaudeTokenRefresher` never runs. This is the more serious one, because it is the mechanism that keeps a ring from ageing out, and it fails *silently* — finding no command is deliberately not an error, so there is nothing in the log and nothing in the UI. On the machine this was found on, all four candidates are absent:

```
/opt/homebrew/bin/claude     absent
/usr/local/bin/claude        absent
~/.local/bin/claude          absent
/usr/bin/claude              absent
```

That Mac is exactly the case #67 describes — Claude Code used through the desktop app — so it is precisely the machine 1.7.0's renewal was written for, and precisely the one where it cannot fire.

## What this changes

- Three fixed layouts a global npm install lands in: Volta's shims, pnpm's macOS global bin, an npm user-level prefix.
- Enumeration of the `~/.nvm/versions/node` trees, newest first. `.numeric` ordering rather than a semver parse, since all that is asked is that `v22` sorts above `v20`.
- Both sites keep their existing precedence: fixed installer paths first, Node trees after, so a copy Claude Code maintains itself still wins. In `ClaudeCLI` the new paths go in before the `desktopOwned` check, so a Node tree cannot smuggle in the desktop app's copy. Tests pin both.
- `testNothingInstalledIsNotAnError` now takes an empty home. Pointed at the real one it started passing or failing depending on whether whoever ran it had installed Claude Code with npm — the same hazard `ClaudeUsageCLI.locate`'s `root` parameter exists to avoid. It caught my own machine on the first run.

## Tests

Nine added across `ClaudeUsageCLITests` and `ClaudeCLITests`, using each file's own temp-home harness: nvm discovery, newest-version-wins, Volta, pnpm, and a precedence guard on each side. Written first, and they fail on `main`.

`make test` on macOS 26.6.2 / Xcode 26.6: **1025 tests, 1 skipped, 0 failures.**

## One thing this does not fix

Once found, `claude "/usage"` still returns nothing `ClaudeUsageCLI.parse` can read on Claude Code **2.1.266** installed via npm. Invoked exactly as `run(binary:profile:)` does it (no TTY, stdin at `/dev/null`), and also with `-p`, and from a directory Claude Code already trusts, the only output is the session cost summary — no limit lines, so `parse` throws `badResponse`. Filed separately as #95; I could not test the native-installer build to see whether it differs.

So the CLI reading may stay unavailable on those machines. The renewal fix above does not depend on it: `ClaudeTokenRefresher` runs `claude -p` with an empty stdin, not `/usage`, and that is what keeps the token path alive.

