### PR TITLE
Run `claude /usage` from one fixed directory, in print mode, without a transcript

### DIFF
--- a/Sources/Providers/ClaudeUsageCLI.swift
+++ b/Sources/Providers/ClaudeUsageCLI.swift
@@ -31,6 +31,35 @@ struct ClaudeUsageCLI: Sendable {
     /// wedged process cannot hold a refresh open. A timeout kills the process.
     static let timeout: TimeInterval = 20
 
+    /// Print mode, and no transcript. Started interactively, `/usage` also
+    /// files a session under `<config>/projects/`, one per call, and can put
+    /// up the workspace-trust dialogue for a directory Claude Code has not
+    /// seen. `--print` skips the dialogue, and `--no-session-persistence`,
+    /// which only exists in print mode, skips the transcript. The lines this
+    /// reads are the same either way.
+    static let arguments = ["--print", "--no-session-persistence", "/usage"]
+
+    /// Where `/usage` is run from: one directory, kept for the life of the
+    /// install.
+    ///
+    /// Claude Code keys the transcript folder it writes under
+    /// `<config>/projects/` on the working directory. A fresh temporary
+    /// directory per call, which is what this did before, therefore left a
+    /// new, never-revisited project folder behind on every poll: twelve an
+    /// hour, indefinitely. One fixed directory means at most one folder, and
+    /// with `arguments` above no transcript at all.
+    static func scratchDirectory(
+        applicationSupport: URL = FileManager.default.urls(for: .applicationSupportDirectory,
+                                                           in: .userDomainMask)[0],
+        fileManager: FileManager = .default
+    ) throws -> URL {
+        let directory = applicationSupport
+            .appendingPathComponent("Codenotch", isDirectory: true)
+            .appendingPathComponent("usage-scratch", isDirectory: true)
+        try fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+        return directory
+    }
+
     // MARK: - Finding the binary
 
     /// Every path Claude Code installs itself to, newest installer first.
@@ -82,13 +111,10 @@ struct ClaudeUsageCLI: Sendable {
     }
 
     private static func run(binary: URL, profile: ClaudeProfile) throws -> String {
-        // A directory of its own, so a session artifact written on the way past
-        // lands somewhere disposable rather than in whatever directory the app
-        // happened to be launched from.
-        let scratch = FileManager.default.temporaryDirectory
-            .appendingPathComponent("codenotch-usage-\(UUID().uuidString)", isDirectory: true)
-        try? FileManager.default.createDirectory(at: scratch, withIntermediateDirectories: true)
-        defer { try? FileManager.default.removeItem(at: scratch) }
+        // A directory of its own, so nothing Claude Code writes on the way
+        // past lands in whatever directory the app happened to be launched
+        // from. See `scratchDirectory` for why it is the same one every time.
+        let scratch = try scratchDirectory()
 
         var environment = ProcessInfo.processInfo.environment
         // Only for a named profile. Pointing the variable at `~/.claude`
@@ -103,7 +129,7 @@ struct ClaudeUsageCLI: Sendable {
 
         let process = Process()
         process.executableURL = binary
-        process.arguments = ["/usage"]
+        process.arguments = Self.arguments
         process.currentDirectoryURL = scratch
         process.environment = environment
         // Never a terminal. Left inheriting the app's stdin, `claude` waits for

--- a/Sources/Providers/ClaudeUsageCLI.swift
+++ b/Sources/Providers/ClaudeUsageCLI.swift
@@ -31,13 +31,27 @@ struct ClaudeUsageCLI: Sendable {
     /// wedged process cannot hold a refresh open. A timeout kills the process.
     static let timeout: TimeInterval = 20
 
-    /// Print mode, and no transcript. Started interactively, `/usage` also
-    /// files a session under `<config>/projects/`, one per call, and can put
-    /// up the workspace-trust dialogue for a directory Claude Code has not
-    /// seen. `--print` skips the dialogue, and `--no-session-persistence`,
-    /// which only exists in print mode, skips the transcript. The lines this
-    /// reads are the same either way.
-    static let arguments = ["--print", "--no-session-persistence", "/usage"]
+    /// Print mode, no transcript, no MCP servers. Started interactively,
+    /// `/usage` also files a session under `<config>/projects/`, one per call,
+    /// and can put up the workspace-trust dialogue for a directory Claude Code
+    /// has not seen. `--print` skips the dialogue, and
+    /// `--no-session-persistence`, which only exists in print mode, skips the
+    /// transcript. The lines this reads are the same either way.
+    ///
+    /// `--strict-mcp-config` with no `--mcp-config` means no MCP server at all.
+    /// Without it every poll starts whatever the user has configured in
+    /// `~/.claude.json` and their settings, which on a busy machine is a dozen
+    /// Node processes and their connections to GitHub, Cloudflare and the like,
+    /// none of which `/usage` needs. Measured on Claude Code 2.1.259: with the
+    /// flag the process talks to api.anthropic.com and Claude Code's own
+    /// feature-gate host only. (`--mcp-config '{}'` is not an option: the flag
+    /// is variadic and swallows `/usage` as a second config path.)
+    ///
+    /// Telemetry is deliberately left on. `DISABLE_TELEMETRY` and
+    /// `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC` also stop the feature-gate
+    /// fetch, and the per-model weekly line (`Current week (Fable)`) is behind
+    /// one of those gates: with either set, `/usage` no longer prints it.
+    static let arguments = ["--print", "--no-session-persistence", "--strict-mcp-config", "/usage"]
 
     /// Where `/usage` is run from: one directory, kept for the life of the
     /// install.

--- a/Tests/ClaudeUsageCLITests.swift
+++ b/Tests/ClaudeUsageCLITests.swift
@@ -187,6 +187,44 @@ final class ClaudeUsageCLITests: XCTestCase {
         XCTAssertNil(ClaudeUsageCLI.locate(home: home, root: home))
     }
 
+    // MARK: - Where it runs
+
+    /// One directory, reused. Claude Code files a transcript folder per working
+    /// directory, so a fresh one per call left a folder behind every five
+    /// minutes.
+    func testTheScratchDirectoryIsOneFixedPlace() throws {
+        let support = try makeHome(executableAt: nil)
+
+        let first = try ClaudeUsageCLI.scratchDirectory(applicationSupport: support)
+        let second = try ClaudeUsageCLI.scratchDirectory(applicationSupport: support)
+
+        XCTAssertEqual(first, second)
+        XCTAssertEqual(first.path, support.appendingPathComponent("Codenotch/usage-scratch").path)
+        var isDirectory: ObjCBool = false
+        XCTAssertTrue(FileManager.default.fileExists(atPath: first.path, isDirectory: &isDirectory))
+        XCTAssertTrue(isDirectory.boolValue)
+    }
+
+    /// A place that cannot be made is an error for the caller to fall back
+    /// from, not a silent run in whatever directory the app was launched in.
+    func testAScratchDirectoryThatCannotBeMadeThrows() throws {
+        let support = try makeHome(executableAt: nil)
+        // A file where the parent directory has to go.
+        FileManager.default.createFile(atPath: support.appendingPathComponent("Codenotch").path,
+                                       contents: Data())
+
+        XCTAssertThrowsError(try ClaudeUsageCLI.scratchDirectory(applicationSupport: support))
+    }
+
+    /// Print mode without a transcript: the two flags are what stop Claude Code
+    /// filing a session for every poll, and `/usage` still has to be what is
+    /// asked.
+    func testItAsksInPrintModeWithoutATranscript() {
+        XCTAssertTrue(ClaudeUsageCLI.arguments.contains("--print"))
+        XCTAssertTrue(ClaudeUsageCLI.arguments.contains("--no-session-persistence"))
+        XCTAssertEqual(ClaudeUsageCLI.arguments.last, "/usage")
+    }
+
     private func makeHome(executableAt path: String?, executable: Bool = true) throws -> URL {
         let root = FileManager.default.temporaryDirectory
             .appendingPathComponent("ClaudeUsageCLITests.\(UUID().uuidString)")

--- a/Tests/ClaudeUsageCLITests.swift
+++ b/Tests/ClaudeUsageCLITests.swift
@@ -225,6 +225,14 @@ final class ClaudeUsageCLITests: XCTestCase {
         XCTAssertEqual(ClaudeUsageCLI.arguments.last, "/usage")
     }
 
+    /// No MCP servers for a usage poll. `--strict-mcp-config` on its own is
+    /// the whole switch; a `--mcp-config` beside it would eat `/usage` as a
+    /// second config path, so it must stay absent.
+    func testItStartsNoMCPServers() {
+        XCTAssertTrue(ClaudeUsageCLI.arguments.contains("--strict-mcp-config"))
+        XCTAssertFalse(ClaudeUsageCLI.arguments.contains("--mcp-config"))
+    }
+
     private func makeHome(executableAt path: String?, executable: Bool = true) throws -> URL {
         let root = FileManager.default.temporaryDirectory
             .appendingPathComponent("ClaudeUsageCLITests.\(UUID().uuidString)")


### PR DESCRIPTION
I noticed my `~/.claude/projects` listing growing by one folder every few
minutes while Codenotch was idle. The cause is in `ClaudeUsageCLI.run()`: it
starts `claude /usage` in a fresh temporary directory on every poll and
deletes the directory afterwards. Claude Code names the transcript folder it
writes under `<config>/projects/` after the working directory, so each poll
leaves a project folder behind that nothing reads again. With the default
five minute refresh that is twelve folders an hour for as long as the app
runs. On Claude Code 2.1.259 each one is about 62 KB, and a fresh launch
produced its first `-private-var-folders-...-T-codenotch-usage-<uuid>` folder
within 25 seconds.

Three changes, all inside `run()` and its argument list:

1. The working directory is now `~/Library/Application Support/Codenotch/usage-scratch`,
   created once and kept. At most one project folder can ever exist for it.
2. The call is `claude --print --no-session-persistence /usage`. In print mode
   Claude Code skips the workspace trust dialogue, and with the flag it writes
   no transcript at all. The lines the parser reads are the same. To check:
   two interactive calls in the same directory left two 62 KB `.jsonl` files,
   two calls with these flags left none.

3. `--strict-mcp-config`, with no `--mcp-config` beside it, so the subprocess
   loads no MCP server. Without it every poll started everything configured
   in `~/.claude.json` and the settings, on my machine a dozen Node processes
   and their connections to GitHub and Cloudflare-hosted endpoints, for a
   reading that needs none of them. With the flag, `lsof` on the subprocess
   shows api.anthropic.com and Claude Code's own feature-gate host, nothing
   else. I left telemetry on: `DISABLE_TELEMETRY` also skips the feature-gate
   fetch, and the "Current week (Fable)" line disappears with it. (`--mcp-config
   '{}'` is not usable here, the flag is variadic and eats `/usage` as a second
   config path.)

One caveat. `--no-session-persistence` only exists in print mode, and an older
Claude Code that does not know the flag exits non-zero. The caller already
treats that as "no login" and falls back to the token path, so old installs
keep working as they do today.

Tests cover the fixed directory, the error when it cannot be created, and the
arguments. `make test` is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
