### PR TITLE
docs: say that clicking the notch keeps it open

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,15 @@ At rest it is a small pill on the screen edge that unfolds when the pointer
 reaches it — configurable in Settings to always show, or to hide entirely.
 Settings live in an orb below the notch: an arc at rest, a gear on hover.
 
+Clicking the notch while it is open keeps it open, so it stays put while you
+read it; clicking it again lets it fold away as usual. That click has to land
+on the body itself, since a ring takes its own click to refetch that provider
+and the orb takes one to open Settings. Right-clicking offers the same thing as
+a menu item, **Keep open**, ticked while the notch is being held open, which is
+the surer way to release one that was kept open by accident. The item is
+greyed out when Settings says Always show, because that choice is Settings' to
+change.
+
 In Settings → Appearance → Reset time, choose **Time remaining** for countdowns
 like "Resets in 3 Days 3h". **Reset date** keeps the reset date and time, with
 minutes shown when less than an hour remains.


### PR DESCRIPTION
Two gestures the README does not mention: clicking the open notch pins it (`handleClick` falls through to `togglePinned`), and right-clicking offers the same as a **Keep open** menu item.

Neither is discoverable, and the failure mode is unpleasant. A notch kept open by a stray click reads as one that has stopped folding, and the obvious remedy of clicking it again lands on a ring or the orb about as often as not, which refetches a provider or opens Settings and leaves the notch exactly as open as it was. Someone here reached the point of asking me where the app was broken; nothing was.

The paragraph goes in **Placement**, right after the sentence about the pill unfolding on hover, and says three things: that the click keeps it open, that it has to land on the body rather than a ring or the orb, and that the menu item is the way back that needs no aim. It also notes the item is disabled under Always show, matching the tooltip already in `contextMenu()`.

No code change.
