### PR TITLE
docs: give the README a button that downloads the app

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,13 @@ two never disagree.
 
 ## Download
 
-[**Latest release**](../../releases/latest) — signed, notarized, and updating
-itself from then on. Take this one unless you have a reason not to.
+[![Download for macOS](docs/design/download-macos.svg)](../../releases/latest/download/Codenotch.dmg)
+
+That button is the disk image itself, not the page it sits on — the asset is
+named `Codenotch.dmg` in every release, so `releases/latest/download/` always
+resolves to the newest one and the link never needs updating. Signed,
+notarized, and updating itself from then on. Take this one unless you have a
+reason not to; the [release page](../../releases/latest) has the notes.
 
 To try unreleased `main` without an Xcode install, the [preview
 build](../../releases/tag/preview) is rebuilt from every commit, and the

--- a/docs/design/download-macos.svg
+++ b/docs/design/download-macos.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="244" height="56" viewBox="0 0 244 56" role="img" aria-label="Download for macOS">
+  <title>Download for macOS</title>
+  <!-- The notch's own black, with the ring track as its edge — sampled from
+       Palette rather than picked, so the button reads as part of the app. -->
+  <rect x="0.75" y="0.75" width="242.5" height="54.5" rx="13.25"
+        fill="#000000" stroke="#303030" stroke-width="1.5"/>
+  <!-- A tray with an arrow coming down into it. Deliberately not the Apple
+       logo: that mark is Apple's, and a download button is not a place to
+       spend somebody else's trademark. -->
+  <g stroke="#00FF88" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" fill="none">
+    <path d="M26 17.5v13.5"/>
+    <path d="M20.5 25.5 26 31l5.5-5.5"/>
+    <path d="M19 35.5v2.2a2.3 2.3 0 0 0 2.3 2.3h9.4a2.3 2.3 0 0 0 2.3-2.3v-2.2"/>
+  </g>
+  <text x="48" y="33.5"
+        font-family="-apple-system, BlinkMacSystemFont, 'SF Pro Text', 'Helvetica Neue', Helvetica, Arial, sans-serif"
+        font-size="16" font-weight="600" fill="#FFFFFF">Download for macOS</text>
+</svg>


### PR DESCRIPTION
## Summary

The Download section opened with a link to the releases *page*. The shortest path from landing on the repository to having the app was: read a paragraph, click through, pick the right asset out of the release notes, click again. For a menu-bar app somebody is deciding whether to try in the next ten seconds, that is three steps too many.

This adds a button that links straight at the disk image.

## How the link stays correct

Every release names its asset `Codenotch.dmg`, so `releases/latest/download/Codenotch.dmg` always resolves to the newest one — the link never needs updating at a release. Checked against 1.7.0: it redirects to the asset itself, `Content-Disposition: attachment; filename=Codenotch.dmg`, rather than to a page.

Relative, like the links already in this section, so it works on a fork as well as here.

It points at the **notarized** release and not the rolling `preview`, for the reason `package.yml`'s own comment gives: an unsigned file sitting next to a signed one is how somebody ends up running the wrong download and clearing quarantine flags they never needed to. The link to the release page stays for the notes.

## The button

`docs/design/download-macos.svg`, drawn from `Palette` rather than picked by eye — the notch's own black, the ring track as its edge, the ample green for the mark. SVG so it stays sharp on a Retina display without an `@2x`, and so the wording can be changed without a design tool.

**No Apple logo.** That mark is Apple's to license, and a download button on somebody else's repository is not the place to spend a trademark. If you would rather have it, say so and I will swap the glyph.

## Test plan

- [x] The URL resolves to the asset: `curl -IL` on `releases/latest/download/Codenotch.dmg` returns 200 with `filename=Codenotch.dmg`.
- [x] The SVG renders correctly — checked as an image, not just as valid XML.
- [x] GitHub renders it. The `<img>` survives the README sanitizer with its `src` intact, and the file is served from both `raw.githubusercontent.com` and the `/raw/` path as `content-type: image/svg+xml`, so a browser draws it rather than showing markup. That was the one thing I could not take on faith, since GitHub sanitizes SVGs and the text inside is what usually goes.
- No `make test` run: this changes a Markdown file and adds an image, and touches no Swift.
