### PR TITLE
Follow the locale's hour cycle for reset times instead of forcing 12-hour

### DIFF
--- a/Sources/Model/ResetCopy.swift
+++ b/Sources/Model/ResetCopy.swift
@@ -68,7 +68,14 @@ enum ResetCopy {
             return L10n.t("Resets \(formatter.string(from: resetsAt))", locale: locale)
         }
 
-        formatter.setLocalizedDateFormatFromTemplate("E h:mm a")
+        // `j`, not `h`: a literal hour symbol in a template pins the clock to
+        // twelve hours whatever the region, so everywhere that writes 00:00
+        // rather than 12:00 AM — most of Europe, Asia and Latin America — read
+        // "Resets mer. 12:00 AM" here while every other clock on the Mac said
+        // 00:00. `j` asks the locale, which also carries the "24-Hour Time"
+        // switch in System Settings. Regions that write AM/PM keep it, so
+        // English is still "Thu 12:00 AM".
+        formatter.setLocalizedDateFormatFromTemplate("E j:mm")
         return L10n.t("Resets \(formatter.string(from: resetsAt))", locale: locale)
     }
 

--- a/Sources/Model/UsageModel.swift
+++ b/Sources/Model/UsageModel.swift
@@ -161,15 +161,13 @@ struct UsageBlock: Equatable {
         let formatter = ResetCopy.formatter(for: calendar)
         formatter.locale = locale
         // The same clock the vendor's own banner uses — "4:13 PM" — rather
-        // than a countdown, because that is what you are waiting for.
+        // than a countdown, because that is what you are waiting for. `j`
+        // rather than `h` so the hour cycle is the region's, as in
+        // `ResetCopy`; a 12-hour region still reads "4:13 PM".
         let template = ResetCopy.daysApart(from: now, to: resetsAt,
                                            calendar: calendar) >= 1
-            ? "E h:mm a" : "h:mm a"
-        if locale.language.languageCode?.identifier == "en" {
-            formatter.dateFormat = template
-        } else {
-            formatter.setLocalizedDateFormatFromTemplate(template)
-        }
+            ? "E j:mm" : "j:mm"
+        formatter.setLocalizedDateFormatFromTemplate(template)
         return L10n.t("\(reason) until \(formatter.string(from: resetsAt))", locale: locale)
     }
 }

--- a/Tests/CodexUsageTests.swift
+++ b/Tests/CodexUsageTests.swift
@@ -308,6 +308,24 @@ final class UsageBlockTests: XCTestCase {
         XCTAssertFalse(text.contains("min"), "a countdown, not the time it lifts")
     }
 
+    /// The clock keeps the locale's hour cycle, as the reset line does: a
+    /// 24-hour region reads "Paused until 16:13", not "4:13 PM".
+    func testTheClockFollowsTheLocalesHourCycle() {
+        let now = Date(timeIntervalSince1970: 1_788_000_000)
+        let block = UsageBlock(reason: "Paused", resetsAt: now.addingTimeInterval(90 * 60))
+        for id in ["fr_FR", "de_DE", "ja_JP", "en_GB"] {
+            let locale = Locale(identifier: id)
+            let text = block.summary(now: now, locale: locale)
+            let symbols = DateFormatter()
+            symbols.locale = locale
+            XCTAssertFalse(text.contains(symbols.amSymbol) || text.contains(symbols.pmSymbol),
+                           "\(id) got a 12-hour clock: \(text)")
+        }
+        let american = block.summary(now: now, locale: Locale(identifier: "en_US"))
+        XCTAssertTrue(american.contains("AM") || american.contains("PM"),
+                      "en_US lost its AM/PM: \(american)")
+    }
+
     /// With no reset time there is nothing to promise, so it says only what it
     /// knows.
     func testWithoutAResetItSaysOnlyTheReason() {

--- a/Tests/ResetCopyTests.swift
+++ b/Tests/ResetCopyTests.swift
@@ -57,6 +57,33 @@ final class ResetCopyTests: XCTestCase {
         XCTAssertFalse(hasPeriodBetweenDigits, "expected no full stop between time digits in \(text)")
     }
 
+    /// Most of the world keeps a 24-hour clock, and this line was the one
+    /// place it slipped into "12:00 AM": a literal `h` and `a` in the template
+    /// pin the clock to twelve hours instead of asking the locale. Regions
+    /// that do write AM/PM keep it, so the frame's English copy is unchanged.
+    func testFollowsTheLocalesHourCycle() {
+        let twentyFourHour = ["fr_FR", "de_DE", "es_ES", "it_IT", "pt_BR", "ru_RU",
+                              "tr_TR", "ja_JP", "zh_CN", "en_GB"]
+        let twelveHour = ["en_US", "en_AU", "en_CA", "en_IN", "ko_KR"]
+        for id in twentyFourHour + twelveHour {
+            let locale = Locale(identifier: id)
+            var calendar = Calendar(identifier: .gregorian)
+            calendar.locale = locale
+            let text = ResetCopy.text(for: now.addingTimeInterval(6 * 60 * 60), now: now,
+                                      calendar: calendar, locale: locale)
+            // The locale's own day-period words rather than "AM": Japanese
+            // writes 午前, Korean 오전, Australia am.
+            let symbols = DateFormatter()
+            symbols.locale = locale
+            let hasDayPeriod = text.contains(symbols.amSymbol) || text.contains(symbols.pmSymbol)
+            if twelveHour.contains(id) {
+                XCTAssertTrue(hasDayPeriod, "\(id) lost its AM/PM: \(text)")
+            } else {
+                XCTAssertFalse(hasDayPeriod, "\(id) got a 12-hour clock: \(text)")
+            }
+        }
+    }
+
     func testPastResetsReadAsResetting() {
         XCTAssertEqual(ResetCopy.text(for: now.addingTimeInterval(-5), now: now), "Resetting…")
     }


### PR DESCRIPTION
## What

The reset line ("Resets Thu 12:00 AM") and the blocked line ("Paused until 4:13 PM") built their clock from the template `E h:mm a`. A literal hour symbol in a template pins the hour cycle, so every region that writes 00:00 rather than 12:00 AM — most of Europe, Asia and Latin America — got a 12-hour clock here while every other clock on the Mac said 00:00. It was the one place the app ignored the region's convention and the "24-Hour Time" switch in System Settings.

`j` asks the locale for its hour cycle instead. Regions that write AM/PM keep it, so nothing changes in English:

| Locale | Before | After |
|---|---|---|
| en_US | Resets Wed 5:13 AM | Resets Wed 5:13 AM |
| en_AU | Resets Wed 5:13 am | Resets Wed 5:13 am |
| ko_KR | Resets (수) 오전 5:13 | Resets (수) 오전 5:13 |
| en_GB | Resets Wed 5:13 AM | Resets Wed 05:13 |
| de_DE | Resets Mi. 5:13 AM | Resets Mi. 05:13 |
| fr_FR | Resets mer. 5:13 AM | Resets mer. 05:13 |
| pt_BR | Resets qua., 5:13 AM | Resets qua., 05:13 |
| ja_JP | Resets 水 午前5:13 | Resets 水 5:13 |
| zh_CN | Resets 周三 上午5:13 | Resets 周三 05:13 |

The English-only branch in `UsageBlock.summary` that wrote the pattern directly (added with the Simplified Chinese localization to preserve the previous output) is folded into the same template call, since `j` yields the identical `h:mm a` there.

## Tests

- `ResetCopyTests.testFollowsTheLocalesHourCycle` — ten 24-hour locales (fr, de, es, it, pt-BR, ru, tr, ja, zh-CN, en-GB) show no day period; five 12-hour ones (en-US, en-AU, en-CA, en-IN, ko) keep theirs. The check uses each locale's own AM/PM symbols, so 午前 and 오전 count too.
- `UsageBlockTests.testTheClockFollowsTheLocalesHourCycle` — same for the "paused until" line.

Both fail on `main` ("Resets mer. 5:13 AM", "Paused until 2:10 PM") and pass with the change. `make test`: 1018 tests, 0 failures.

Independent of #99 (French localization): this is about the clock, not the copy, and applies to every 24-hour region.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
