### PR TITLE
feat: draw the weekly limit as a second ring

### DIFF
--- a/Sources/App/AppDelegate.swift
+++ b/Sources/App/AppDelegate.swift
@@ -293,6 +293,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 .sink { [weak fleet] in fleet?.apply(accentColor: $0) }
                 .store(in: &cancellables)
 
+            preferences.$weeklyRing
+                .receive(on: RunLoop.main)
+                .sink { [weak fleet] in fleet?.apply(weeklyRing: $0) }
+                .store(in: &cancellables)
+
             preferences.$disconnectedProviders
                 .receive(on: RunLoop.main)
                 .sink { [weak store] in store?.disconnected = $0 }
@@ -463,6 +468,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         fleet.apply(scale: preferences.notchScale)
         fleet.apply(resetTimeFormat: preferences.resetTimeFormat)
         fleet.apply(accentColor: preferences.accentColor)
+        fleet.apply(weeklyRing: preferences.weeklyRing)
         fleet.show()
     }
 

--- a/Sources/Features/ProviderRing.swift
+++ b/Sources/Features/ProviderRing.swift
@@ -21,6 +21,11 @@ struct ProviderRing: View {
     /// A fetch this cell asked for, in flight.
     var isRefreshing: Bool = false
     var localPerformance: LocalModelPerformance?
+    /// The weekly limit, when the provider has one. Nil is the ordinary case
+    /// for a provider with a single window, and draws nothing.
+    var weeklyFraction: Double?
+    /// Where the user asked for it, if at all.
+    var weeklyRing: WeeklyRing = .off
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @Environment(\.codenotchReduceTransparency) private var reduceTransparency
@@ -31,6 +36,20 @@ struct ProviderRing: View {
         isBlocked ? .exhausted : UsageBand.band(for: usedFraction ?? 0)
     }
     private var sweep: CGFloat { CGFloat(min(max(usedFraction ?? 0, 0), 1)) }
+
+    private var weeklyBand: UsageBand {
+        isBlocked ? .exhausted : UsageBand.band(for: weeklyFraction ?? 0)
+    }
+    private var weeklySweep: CGFloat { CGFloat(min(max(weeklyFraction ?? 0, 0), 1)) }
+
+    /// Inside, the weekly ring and the working indicator want the same band —
+    /// 1.03pt apart, one of them spinning. Rather than shave both until neither
+    /// is legible, the transient one wins: while a provider is working that is
+    /// the more urgent fact, and the week is still a hover away. Outside there
+    /// is no contest, so nothing is given up there.
+    private var isWorking: Bool {
+        weeklyRing == .inside && activity != nil && activity?.state != .idle
+    }
 
     var body: some View {
         ZStack {
@@ -62,6 +81,44 @@ struct ProviderRing: View {
                         // that sweeps reads as a measurement being taken.
                         .animation(NotchMotion.reading, value: sweep)
                         .animation(NotchMotion.reading, value: band)
+                }
+
+                // The weekly limit, when there is one and it has been asked
+                // for. Same start and direction as the headline arc, so the
+                // two are read the same way round; thinner and at its own
+                // radius, so which is which never has to be worked out.
+                //
+                // It carries its own band colour rather than borrowing the
+                // headline's: a session at 12% beside a week at 91% is exactly
+                // the case this exists for, and painting them the same colour
+                // would hide it. Held slightly back in opacity so the headline
+                // stays the one the eye lands on first.
+                if let radius = weeklyRing.radius, weeklyFraction != nil, !isWorking {
+                    let inset = NotchLayout.ringDiameter / 2 - radius
+
+                    // A track of its own, for the same reason the headline has
+                    // one: a week nobody has spent yet draws an arc of zero
+                    // length, and without something behind it that is
+                    // indistinguishable from the feature being broken. Codex
+                    // opened its week at 0% and read as missing.
+                    Circle()
+                        .inset(by: inset)
+                        .stroke(Palette.ringTrack,
+                                style: StrokeStyle(lineWidth: NotchLayout.weeklyRingStroke))
+                        .opacity(reduceTransparency ? 1 : 0.7)
+
+                    Circle()
+                        .inset(by: inset)
+                        .trim(from: 0, to: weeklySweep)
+                        .stroke(
+                            weeklyBand.color(accent: accentColor),
+                            style: StrokeStyle(lineWidth: NotchLayout.weeklyRingStroke,
+                                               lineCap: .round)
+                        )
+                        .opacity(reduceTransparency ? 1 : 0.8)
+                        .rotationEffect(.degrees(-90))
+                        .animation(NotchMotion.reading, value: weeklySweep)
+                        .animation(NotchMotion.reading, value: weeklyBand)
                 }
 
                 ProviderGlyphView(glyph: glyph)
@@ -167,6 +224,7 @@ struct ProviderCell: View {
     let snapshot: ProviderSnapshot
     var activity: ActivitySummary?
     var isRefreshing: Bool = false
+    var weeklyRing: WeeklyRing = .off
 
     /// A dash, not "0%": nothing read is not the same as nothing used.
     private var readingText: String {
@@ -182,7 +240,9 @@ struct ProviderCell: View {
                 isBlocked: snapshot.block != nil,
                 activity: activity,
                 isRefreshing: isRefreshing,
-                localPerformance: snapshot.localPerformance
+                localPerformance: snapshot.localPerformance,
+                weeklyFraction: snapshot.hasReading ? snapshot.weeklyFraction : nil,
+                weeklyRing: weeklyRing
             )
             Text(readingText)
                 .font(Typography.percent)

--- a/Sources/Model/UsageArchive.swift
+++ b/Sources/Model/UsageArchive.swift
@@ -16,6 +16,9 @@ struct UsageArchive {
         let fetchedAt: Date
         /// Optional so archives written before this field still decode.
         let headlineID: String?
+        /// Optional for the same reason: an archive written before the weekly
+        /// ring existed has no second window to name, and must still open.
+        let weeklyID: String?
         /// Optional so archives written before Codex token activity existed
         /// continue to open and show their last quota reading.
         let tokenUsage: CodexTokenUsage?
@@ -84,6 +87,7 @@ struct UsageArchive {
                 status: .stale(since: entry.fetchedAt),
                 windows: entry.windows,
                 headlineID: entry.headlineID,
+                weeklyID: entry.weeklyID,
                 tokenUsage: entry.tokenUsage
             )
             result[entry.id] = (snapshot, entry.fetchedAt)
@@ -101,6 +105,7 @@ struct UsageArchive {
                 windows: $0.snapshot.windows,
                 fetchedAt: $0.fetchedAt,
                 headlineID: $0.snapshot.headlineID,
+                weeklyID: $0.snapshot.weeklyID,
                 tokenUsage: $0.snapshot.tokenUsage
             )
         }

--- a/Sources/Model/UsageModel.swift
+++ b/Sources/Model/UsageModel.swift
@@ -186,6 +186,9 @@ struct ProviderSnapshot: Identifiable, Equatable {
     /// first", and a window dropping out of the response silently promotes
     /// another one — the ring keeps its shape and quietly changes its subject.
     var headlineID: String?
+    /// Which window the weekly ring draws, when it is switched on. Declared
+    /// rather than derived — see `weeklyWindow`.
+    var weeklyID: String?
     /// Set when something is blocked right now. Deliberately separate from the
     /// windows: it is not a measurement, it is a door being shut.
     var block: UsageBlock?
@@ -232,6 +235,31 @@ struct ProviderSnapshot: Identifiable, Equatable {
     }
 
     var usedFraction: Double? { headline?.usedFraction }
+
+    /// The window the second ring draws, when one is switched on.
+    ///
+    /// Declared by the provider, exactly like `headlineID`, and for the same
+    /// reason: the weekly window is called something different by everyone who
+    /// has one — `weekly_all`, `secondary`, `weekly`, `gemini-weekly` — and a
+    /// rule that guessed from durations would silently skip whichever provider
+    /// had not filled that field in, with nothing on screen to say why.
+    ///
+    /// Nil means this provider has no second window worth a ring, which is a
+    /// real answer rather than a missing one.
+    var weeklyWindow: LimitWindow? {
+        guard let weeklyID else { return nil }
+        // Never the window the headline is already drawing. Providers that pick
+        // their headline by which limit is tightest — Antigravity does — will
+        // sometimes land on the weekly one, and two rings reporting the same
+        // number is worse than one: it reads as a second fact that happens to
+        // agree, rather than as the same fact twice.
+        guard weeklyID != headlineID else { return nil }
+        return windows.first { $0.id == weeklyID }
+    }
+
+    /// Nil when there is no weekly window, or when the provider reports one
+    /// without a denominator — the same rule the headline ring follows.
+    var weeklyFraction: Double? { weeklyWindow?.usedFraction }
 
     /// What the cell prints under the ring.
     var headlineText: String {

--- a/Sources/Notch/NotchFleet.swift
+++ b/Sources/Notch/NotchFleet.swift
@@ -41,6 +41,9 @@ final class NotchFleet {
     private var displayPreference: DisplayPreference = .followActiveWindow
     private var resetTimeFormat: ResetTimeFormat = .automatic
     private var accentColor: AccentColorChoice = .system
+    /// One choice for the whole fleet, like the edge and the size: a weekly
+    /// ring on one display and not another would read as a bug.
+    private var weeklyRing: WeeklyRing = .off
     /// The ⌥-drag nudge along the current edge. One value for the whole
     /// fleet, the same as `edge` itself — displays do not each get their own
     /// edge, so they do not each get their own nudge either.
@@ -136,6 +139,13 @@ final class NotchFleet {
         self.resetTimeFormat = resetTimeFormat
         for controller in controllers.values {
             controller.model.resetTimeFormat = resetTimeFormat
+        }
+    }
+
+    func apply(weeklyRing: WeeklyRing) {
+        self.weeklyRing = weeklyRing
+        for controller in controllers.values {
+            controller.model.weeklyRing = weeklyRing
         }
     }
 
@@ -305,6 +315,7 @@ final class NotchFleet {
         controller.model.sizeScale = scale
         controller.model.resetTimeFormat = resetTimeFormat
         controller.model.accentColor = accentColor
+        controller.model.weeklyRing = weeklyRing
         controller.onRefresh = onRefresh
         controller.onRefreshProvider = onRefreshProvider
         controller.onOpenSettings = onOpenSettings

--- a/Sources/Notch/NotchLayout.swift
+++ b/Sources/Notch/NotchLayout.swift
@@ -61,6 +61,23 @@ enum NotchLayout {
     static let activityDiameter = Design.px(72)
     static let activityStroke   = Design.px(5.5)
 
+    // The weekly ring. Not in the design frame — the frame draws one ring per
+    // provider — so these are placed against what is already there rather than
+    // quoted from it, and the tests state the clearances rather than the
+    // numbers.
+    //
+    // Thinner than the headline arc on purpose: same kind of fact, lesser
+    // claim on the eye. Two arcs of equal weight in a 44pt circle read as one
+    // confused reading rather than as two limits.
+    static let weeklyRingStroke = Design.px(5)
+    /// Inside: centred in the gap between the glyph and the working
+    /// indicator's own arc, which is the only clear band left in there.
+    static let weeklyInsideRadius = Design.px(28)
+    /// Outside: past the track, into the margin the notch keeps between a ring
+    /// and its bezel. Far enough out not to crowd the track, far enough in that
+    /// the bezel is never touched — `NotchLayoutTests` pins both.
+    static let weeklyOutsideRadius = Design.px(65)
+
     // The settings orb: it lives *below* the notch, not inside it. At rest only
     // an arc of its edge is drawn, tucked into the corner the bottom flare
     // makes; on hover the same circle fills in and takes a gear. One circle,

--- a/Sources/Notch/NotchRootView.swift
+++ b/Sources/Notch/NotchRootView.swift
@@ -177,7 +177,8 @@ struct NotchRootView: View {
             ProviderCell(
                 snapshot: snapshot,
                 activity: model.activity(for: snapshot),
-                isRefreshing: model.isRefreshing(snapshot)
+                isRefreshing: model.isRefreshing(snapshot),
+                weeklyRing: model.weeklyRing
             )
                 // Pinned to what the cell claims along the stack, or the drawn
                 // rings stop lining up with the centres `ringCenter` hands to

--- a/Sources/Notch/NotchViewModel.swift
+++ b/Sources/Notch/NotchViewModel.swift
@@ -128,6 +128,10 @@ final class NotchViewModel: ObservableObject {
     /// Mirrors the persisted Appearance choice so the separate notch window
     /// redraws immediately when Settings changes it.
     @Published var accentColor: AccentColorChoice = .system
+    /// Whether a provider's weekly limit gets a ring of its own, and where.
+    /// Mirrored here for the same reason `accentColor` is: the notch is a
+    /// separate window, and it has to redraw the moment Settings changes this.
+    @Published var weeklyRing: WeeklyRing = .off
     /// The display's own notch, when this edge has to share the bezel with one.
     ///
     /// Set by the window controller from the screen the panel is on, because

--- a/Sources/Providers/AntigravityProvider.swift
+++ b/Sources/Providers/AntigravityProvider.swift
@@ -95,7 +95,8 @@ actor AntigravityProvider: UsageProvider {
             let mostConstrained = windows.max(by: { ($0.usedFraction ?? 0) < ($1.usedFraction ?? 0) })
             return ProviderSnapshot(id: id, displayName: displayName, glyph: glyph,
                                     fidelity: .official, status: .ok, windows: windows,
-                                    headlineID: mostConstrained?.id ?? "gemini-5h")
+                                    headlineID: mostConstrained?.id ?? "gemini-5h",
+                                    weeklyID: "gemini-weekly")
         }
 
         if localQuotaOverride != nil && everBridged {
@@ -110,7 +111,8 @@ actor AntigravityProvider: UsageProvider {
             let mostConstrained = windows.max(by: { ($0.usedFraction ?? 0) < ($1.usedFraction ?? 0) })
             return ProviderSnapshot(id: id, displayName: displayName, glyph: glyph,
                                     fidelity: .official, status: .ok, windows: windows,
-                                    headlineID: mostConstrained?.id ?? "gemini-5h")
+                                    headlineID: mostConstrained?.id ?? "gemini-5h",
+                                    weeklyID: "gemini-weekly")
         }
 
         // 2. Fallback to OMP SQLite store if offline or direct call fails
@@ -119,7 +121,8 @@ actor AntigravityProvider: UsageProvider {
             let mostConstrained = ompWindows.max(by: { ($0.usedFraction ?? 0) < ($1.usedFraction ?? 0) })
             return ProviderSnapshot(id: id, displayName: displayName, glyph: glyph,
                                     fidelity: .official, status: .ok, windows: ompWindows,
-                                    headlineID: mostConstrained?.id ?? "gemini-5h")
+                                    headlineID: mostConstrained?.id ?? "gemini-5h",
+                                    weeklyID: "gemini-weekly")
         }
 
         if everBridged { throw UsageProviderError.credentialExpired }

--- a/Sources/Providers/ClaudeOAuthProvider.swift
+++ b/Sources/Providers/ClaudeOAuthProvider.swift
@@ -102,7 +102,8 @@ actor ClaudeOAuthProvider: UsageProvider {
                 fidelity: .official,
                 status: .ok,
                 windows: windows,
-                headlineID: "session"
+                headlineID: "session",
+                weeklyID: "weekly_all"
             )
         }
         if let retryNoEarlierThan, retryNoEarlierThan > Date() {
@@ -218,7 +219,8 @@ actor ClaudeOAuthProvider: UsageProvider {
             fidelity: .official,
             status: .ok,
             windows: payload.limitWindows(),
-            headlineID: "session"
+            headlineID: "session",
+            weeklyID: "weekly_all"
         )
     }
 

--- a/Sources/Providers/CodexLocalProvider.swift
+++ b/Sources/Providers/CodexLocalProvider.swift
@@ -83,6 +83,7 @@ actor CodexLocalProvider: UsageProvider {
             id: id, displayName: displayName, glyph: glyph,
             fidelity: .official, status: .ok, windows: windows,
             headlineID: windows.first?.id,
+            weeklyID: "secondary",
             tokenUsage: profileUsage
         )
     }

--- a/Sources/Providers/CommandCodeProvider.swift
+++ b/Sources/Providers/CommandCodeProvider.swift
@@ -102,7 +102,8 @@ actor CommandCodeProvider: UsageProvider {
                 fidelity: .official,
                 status: .ok,
                 windows: windows,
-                headlineID: "monthly"
+                headlineID: "monthly",
+                weeklyID: "weekly"
             )
         } catch UsageProviderError.rateLimited(let retryAfter) {
             consecutiveRateLimits += 1

--- a/Sources/Providers/GLMProvider.swift
+++ b/Sources/Providers/GLMProvider.swift
@@ -84,7 +84,8 @@ actor GLMProvider: UsageProvider {
                 fidelity: .official,
                 status: .ok,
                 windows: payload.windows,
-                headlineID: "session"
+                headlineID: "session",
+                weeklyID: "weekly"
             )
         } catch UsageProviderError.rateLimited(let retryAfter) {
             // Bookkeeping where the answer was, not down in `fetch`: the wait

--- a/Sources/Providers/OllamaProvider.swift
+++ b/Sources/Providers/OllamaProvider.swift
@@ -62,7 +62,8 @@ actor OllamaProvider: UsageProvider {
             fidelity: .official,
             status: .ok,
             windows: result.windows,
-            headlineID: result.headlineID
+            headlineID: result.headlineID,
+            weeklyID: "weekly"
         )
     }
 

--- a/Sources/Providers/OpenCodeProvider.swift
+++ b/Sources/Providers/OpenCodeProvider.swift
@@ -82,7 +82,8 @@ actor OpenCodeProvider: UsageProvider {
                 fidelity: .official,
                 status: .ok,
                 windows: read,
-                headlineID: "rolling"
+                headlineID: "rolling",
+                weeklyID: "weekly"
             )
         } catch UsageProviderError.rateLimited(let retryAfter) {
             // Bookkeeping where the answer was, not down in `fetch`: the wait

--- a/Sources/Settings/Preferences.swift
+++ b/Sources/Settings/Preferences.swift
@@ -135,6 +135,11 @@ final class Preferences: ObservableObject {
         didSet { defaults.set(showUsagePace, forKey: Self.showUsagePaceKey) }
     }
 
+    /// Whether the weekly limit gets a ring of its own, and where it sits.
+    @Published var weeklyRing: WeeklyRing {
+        didSet { defaults.set(weeklyRing.rawValue, forKey: Keys.weeklyRing) }
+    }
+
     /// The colour used for positive usage and active-work indicators.
     @Published var accentColor: AccentColorChoice {
         didSet { defaults.set(accentColor.rawValue, forKey: Keys.accentColor) }
@@ -250,6 +255,8 @@ final class Preferences: ObservableObject {
         static let resetTimeFormat = "resetTimeFormat"
         static let scope = "notchScope"
         static let accentColor = "accentColor"
+        // A new key, so there is nothing under the old app name to migrate.
+        static let weeklyRing = "weeklyRing"
         static let lastSeenVersion = "lastSeenVersion"
         static let order = "providerOrder"
         static let announceSessionEnd = "announceSessionEnd"
@@ -373,6 +380,10 @@ final class Preferences: ObservableObject {
         self.notchScope = defaults.string(forKey: Keys.scope)
             .flatMap(NotchScreenScope.init(rawValue:)) ?? .mainDisplay
         // Follow the Mac unless the user explicitly chooses a Codenotch colour.
+        // Off by default: an extra arc in a 44pt circle is a change to how
+        // every reading looks, and nobody asked for it on their behalf.
+        self.weeklyRing = defaults.string(forKey: Keys.weeklyRing)
+            .flatMap(WeeklyRing.init(rawValue:)) ?? .off
         self.accentColor = defaults.string(forKey: Keys.accentColor)
             .flatMap(AccentColorChoice.init(rawValue:)) ?? .system
         // Absent means never chosen, which is follow-the-Mac.

--- a/Sources/Settings/SettingsView.swift
+++ b/Sources/Settings/SettingsView.swift
@@ -518,6 +518,16 @@ struct SettingsView: View {
                     .foregroundStyle(.secondary)
                     .fixedSize(horizontal: false, vertical: true)
 
+                Picker(L10n.t("Weekly ring"), selection: $preferences.weeklyRing) {
+                    ForEach(WeeklyRing.allCases) { Text($0.title).tag($0) }
+                }
+                .pickerStyle(.segmented)
+
+                Text(preferences.weeklyRing.explanation)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+
                 Picker(L10n.t("Show"), selection: $preferences.notchVisibility) {
                     ForEach(NotchVisibility.allCases) { Text($0.title).tag($0) }
                 }

--- a/Sources/Settings/WeeklyRing.swift
+++ b/Sources/Settings/WeeklyRing.swift
@@ -1,0 +1,55 @@
+import Foundation
+
+/// Whether the weekly limit gets a ring of its own, and where it sits.
+///
+/// The cell draws one window: the provider's declared headline, which for
+/// Claude is the current session. The weekly allowance is the one that actually
+/// runs out first on a busy week, and until now the only way to see it was to
+/// hover. A second, thinner arc puts it on the same glance.
+///
+/// Inside or outside rather than a single "on", because which one reads better
+/// is not something this can decide for somebody: the notch is small, the two
+/// arcs are close together at any size, and whether the inner gap or the bezel
+/// margin is the clearer place depends on the size the notch is set to and on
+/// the eyes looking at it.
+enum WeeklyRing: String, CaseIterable, Identifiable {
+    /// One ring, as every version before this drew it.
+    case off
+    /// In the gap between the glyph and the track, where the activity arc also
+    /// lives — closer to the reading it belongs to, tighter on space.
+    case inside
+    /// Just beyond the track, in the margin the notch already keeps clear of
+    /// its bezel — more room, and further from the headline it sits beside.
+    case outside
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .off:     return L10n.t("Off")
+        case .inside:  return L10n.t("Inside")
+        case .outside: return L10n.t("Outside")
+        }
+    }
+
+    var explanation: String {
+        switch self {
+        case .off:
+            return L10n.t("One ring per provider, showing the headline limit. The weekly allowance stays in the hover card.")
+        case .inside:
+            return L10n.t("A thinner ring for the weekly limit, drawn inside the main one. It shares the gap with the working indicator.")
+        case .outside:
+            return L10n.t("A thinner ring for the weekly limit, drawn around the main one, in the margin between the ring and the notch edge.")
+        }
+    }
+
+    /// Where the arc's centre-line sits, measured from the ring's centre. Nil
+    /// when there is no second ring to place.
+    var radius: CGFloat? {
+        switch self {
+        case .off:     return nil
+        case .inside:  return NotchLayout.weeklyInsideRadius
+        case .outside: return NotchLayout.weeklyOutsideRadius
+        }
+    }
+}

--- a/Tests/NotchLayoutTests.swift
+++ b/Tests/NotchLayoutTests.swift
@@ -66,6 +66,35 @@ final class NotchLayoutTests: XCTestCase {
         XCTAssertGreaterThan(innerEdge, NotchLayout.glyphSize / 2)
     }
 
+    /// The weekly ring is placed against what is already inside the circle
+    /// rather than quoted from the design frame, which draws one ring — so the
+    /// clearances are what the test states, not the numbers.
+    func testTheInsideWeeklyRingClearsTheGlyphAndTheWorkingIndicator() {
+        let outer = NotchLayout.weeklyInsideRadius + NotchLayout.weeklyRingStroke / 2
+        let inner = NotchLayout.weeklyInsideRadius - NotchLayout.weeklyRingStroke / 2
+        XCTAssertGreaterThan(inner, NotchLayout.glyphSize / 2,
+                             "the weekly ring is drawn over the glyph")
+        XCTAssertLessThan(outer,
+                          NotchLayout.activityDiameter / 2 - NotchLayout.activityStroke / 2,
+                          "the weekly ring collides with the working indicator")
+    }
+
+    /// Outside, the two things it must not touch are the track it sits beyond
+    /// and the bezel the notch keeps clear of.
+    func testTheOutsideWeeklyRingClearsTheTrackAndTheBezel() {
+        let inner = NotchLayout.weeklyOutsideRadius - NotchLayout.weeklyRingStroke / 2
+        let outer = NotchLayout.weeklyOutsideRadius + NotchLayout.weeklyRingStroke / 2
+        XCTAssertGreaterThan(inner, NotchLayout.ringDiameter / 2,
+                             "the weekly ring overlaps the track it is meant to sit outside")
+        XCTAssertLessThan(outer, NotchLayout.ringDiameter / 2 + NotchLayout.ringMargin(for: .right),
+                          "the weekly ring reaches past the bezel")
+    }
+
+    /// Thinner than the headline arc: same kind of fact, lesser claim on the eye.
+    func testTheWeeklyRingIsThinnerThanTheHeadline() {
+        XCTAssertLessThan(NotchLayout.weeklyRingStroke, NotchLayout.progressStroke)
+    }
+
     /// Every cell's tooltip has to fit inside the panel, or the card would be
     /// clipped for the first and last providers.
     func testTooltipFitsThePanelForEveryCell() {

--- a/Tests/NotchRenderTests.swift
+++ b/Tests/NotchRenderTests.swift
@@ -59,6 +59,104 @@ final class NotchRenderTests: XCTestCase {
         }
     }
 
+    /// The weekly ring has to actually appear, and only when asked for.
+    ///
+    /// Counted by colour rather than by ink: the arcs are drawn on top of the
+    /// notch's own black, which is already opaque, so `inkedFraction` cannot
+    /// see them at all — it answers the same number to three decimal places
+    /// whether the ring is there or not. Saturation is what separates an arc
+    /// from the body behind it and the grey track beside it.
+    func testTheWeeklyRingPaintsOnlyWhenSwitchedOn() {
+        func colour(_ ring: WeeklyRing) -> Double {
+            let model = model(edge: .right)
+            model.weeklyRing = ring
+            model.snapshots = model.snapshots.map { snapshot in
+                ProviderSnapshot(
+                    id: snapshot.id, displayName: snapshot.displayName,
+                    glyph: snapshot.glyph, fidelity: snapshot.fidelity,
+                    status: snapshot.status,
+                    windows: snapshot.windows + [
+                        LimitWindow(id: "weekly_all", label: "All models", usedFraction: 0.9)
+                    ],
+                    headlineID: snapshot.headlineID,
+                    weeklyID: "weekly_all"
+                )
+            }
+            guard let rep = render(model) else { return -1 }
+            return colouredFraction(rep)
+        }
+
+        let off = colour(.off)
+        XCTAssertGreaterThan(off, 0, "the headline arc is missing too — this measures nothing")
+        XCTAssertGreaterThan(colour(.inside), off, "inside painted no arc")
+        XCTAssertGreaterThan(colour(.outside), off, "outside painted no arc")
+    }
+
+    /// A week nobody has spent yet still has to be visible.
+    ///
+    /// At 0% the arc has no length, so without a track behind it the ring is
+    /// indistinguishable from the feature being missing — which is exactly how
+    /// Codex read when its week opened empty.
+    func testAnEmptyWeeklyRingStillDrawsItsTrack() {
+        func ink(_ ring: WeeklyRing) -> Double {
+            let model = model(edge: .right)
+            model.weeklyRing = ring
+            model.snapshots = model.snapshots.map { snapshot in
+                ProviderSnapshot(
+                    id: snapshot.id, displayName: snapshot.displayName,
+                    glyph: snapshot.glyph, fidelity: snapshot.fidelity,
+                    status: snapshot.status,
+                    // Nothing used yet: the arc is zero length, the track is all
+                    // there is to see.
+                    windows: snapshot.windows + [
+                        LimitWindow(id: "weekly_all", label: "All models", usedFraction: 0)
+                    ],
+                    headlineID: snapshot.headlineID,
+                    weeklyID: "weekly_all"
+                )
+            }
+            guard let rep = render(model) else { return -1 }
+            return greyFraction(rep)
+        }
+
+        XCTAssertGreaterThan(ink(.outside), ink(.off),
+                             "an empty week drew nothing at all")
+    }
+
+    /// Fraction of sampled pixels that are the ring track's own grey — the way
+    /// to see a track, which carries no hue and so is invisible to
+    /// `colouredFraction`.
+    private func greyFraction(_ rep: NSBitmapImageRep) -> Double {
+        var grey = 0, total = 0
+        for x in stride(from: 0, to: rep.pixelsWide, by: 2) {
+            for y in stride(from: 0, to: rep.pixelsHigh, by: 2) {
+                total += 1
+                guard let colour = rep.colorAt(x: x, y: y), colour.alphaComponent > 0.5,
+                      let rgb = colour.usingColorSpace(.sRGB) else { continue }
+                let channels = [rgb.redComponent, rgb.greenComponent, rgb.blueComponent]
+                let neutral = (channels.max()! - channels.min()!) < 0.06
+                if neutral, channels.max()! > 0.10, channels.max()! < 0.45 { grey += 1 }
+            }
+        }
+        return total == 0 ? 0 : Double(grey) / Double(total)
+    }
+
+    /// Fraction of sampled pixels carrying a hue — an arc rather than the black
+    /// body, the grey track or white type.
+    private func colouredFraction(_ rep: NSBitmapImageRep) -> Double {
+        var coloured = 0, total = 0
+        for x in stride(from: 0, to: rep.pixelsWide, by: 2) {
+            for y in stride(from: 0, to: rep.pixelsHigh, by: 2) {
+                total += 1
+                guard let colour = rep.colorAt(x: x, y: y), colour.alphaComponent > 0.5,
+                      let rgb = colour.usingColorSpace(.sRGB) else { continue }
+                let channels = [rgb.redComponent, rgb.greenComponent, rgb.blueComponent]
+                if (channels.max()! - channels.min()!) > 0.15 { coloured += 1 }
+            }
+        }
+        return total == 0 ? 0 : Double(coloured) / Double(total)
+    }
+
     /// And it paints it against the bezel, not somewhere in the middle of the
     /// transparent panel.
     func testTheNotchPaintsAgainstTheBezelOnEveryEdge() {

--- a/Tests/PreferencesTests.swift
+++ b/Tests/PreferencesTests.swift
@@ -68,6 +68,19 @@ final class PreferencesMigrationTests: XCTestCase {
         XCTAssertEqual(preferences.appPresence, .dock)
         XCTAssertEqual(preferences.notchEdge, .right)
         XCTAssertEqual(preferences.notchSize, .medium)
+        XCTAssertEqual(preferences.weeklyRing, .off)
+    }
+
+    /// Off by default, and it has to stay chosen once it is chosen: an extra
+    /// arc in a 44pt circle changes how every reading looks, so it is not
+    /// something to switch on for somebody, nor to forget they switched on.
+    func testTheWeeklyRingIsOffUntilAskedForAndThenSurvivesARelaunch() {
+        let (fresh, name) = makeDefaults()
+        XCTAssertEqual(Preferences(defaults: fresh).weeklyRing, .off)
+
+        Preferences(defaults: fresh).weeklyRing = .outside
+
+        XCTAssertEqual(Preferences(defaults: UserDefaults(suiteName: name)!).weeklyRing, .outside)
     }
 
     /// The size has to outlive the launch that chose it, or it reads as a

--- a/Tests/UsageResponseTests.swift
+++ b/Tests/UsageResponseTests.swift
@@ -422,6 +422,51 @@ final class ResetWindowTests: XCTestCase {
         XCTAssertEqual(snapshot.windows.count, 1, "the weekly is still listed in the tooltip")
     }
 
+    /// The second ring resolves the same way the headline does: by the id the
+    /// provider declared, not by position.
+    func testTheWeeklyRingResolvesTheDeclaredWindow() {
+        let snapshot = ProviderSnapshot(
+            id: "claude", displayName: "Claude", glyph: .claude,
+            fidelity: .official, status: .ok,
+            windows: [
+                LimitWindow(id: "session", label: "Session", usedFraction: 0.12),
+                LimitWindow(id: "weekly_all", label: "All models", usedFraction: 0.91)
+            ],
+            headlineID: "session", weeklyID: "weekly_all"
+        )
+        XCTAssertEqual(snapshot.weeklyWindow?.id, "weekly_all")
+        XCTAssertEqual(snapshot.weeklyFraction, 0.91)
+        XCTAssertEqual(snapshot.usedFraction, 0.12, "the headline is untouched")
+    }
+
+    /// A provider that picks its headline by whichever limit is tightest —
+    /// Antigravity does — will sometimes land on the weekly one. Two rings
+    /// reporting the same number is worse than one: it reads as a second fact
+    /// that happens to agree rather than as the same fact drawn twice.
+    func testNoSecondRingWhenTheHeadlineIsAlreadyTheWeekly() {
+        let snapshot = ProviderSnapshot(
+            id: "gemini", displayName: "Antigravity", glyph: .antigravity,
+            fidelity: .official, status: .ok,
+            windows: [LimitWindow(id: "gemini-weekly", label: "Weekly", usedFraction: 0.8)],
+            headlineID: "gemini-weekly", weeklyID: "gemini-weekly"
+        )
+        XCTAssertNil(snapshot.weeklyWindow)
+        XCTAssertNil(snapshot.weeklyFraction)
+        XCTAssertEqual(snapshot.headline?.id, "gemini-weekly", "the headline still draws it")
+    }
+
+    /// Declared but absent is not an error — the provider simply did not return
+    /// that window this time, and one ring is the honest answer.
+    func testAMissingWeeklyWindowDrawsNoSecondRing() {
+        let snapshot = ProviderSnapshot(
+            id: "claude", displayName: "Claude", glyph: .claude,
+            fidelity: .official, status: .ok,
+            windows: [LimitWindow(id: "session", label: "Session", usedFraction: 0.2)],
+            headlineID: "session", weeklyID: "weekly_all"
+        )
+        XCTAssertNil(snapshot.weeklyFraction)
+    }
+
     /// A provider that declares no headline keeps the old positional rule.
     func testUndeclaredHeadlineFallsBackToTheFirstWindow() {
         let snapshot = ProviderSnapshot(


### PR DESCRIPTION
## Summary

A cell draws one window — the headline the provider declares, which for Claude is the current session. The weekly allowance is the one that actually runs out first on a busy week, and the only way to see it was to hover. This gives it a ring of its own.

**Off by default**, so an existing install looks exactly as it did.

## Off, inside or outside — not a switch

Which position reads better is not something the code can decide for somebody. The notch is small, the two arcs are close together at any size, and whether the inner gap or the bezel margin is the clearer place depends on the size the notch is set to and on the eyes looking at it. Measured, from the ring's centre:

| | arc | clears |
|---|---|---|
| inside | 9.59 – 11.47pt | 0.94pt from the glyph, 1.03pt from the working indicator |
| outside | 23.50 – 25.38pt | 1.50pt from the track, 9.59pt from the bezel |

**No existing `NotchLayout` constant is touched** — `git diff` on that file deletes zero lines. The new radii are placed against what is already in the circle rather than quoted from the design frame, which draws one ring, so every measurement there still answers to `docs/design/frame-124-hover-tooltip.png`.

## Two things found by looking rather than by testing

**A week at 0% drew nothing.** Codex opened its weekly at 0%, the arc had zero length, and with nothing behind it that is indistinguishable from the feature being broken — which is exactly how it was reported to me. The second ring now has a track of its own, for the same reason the headline has one.

**Inside, it yields to the working indicator.** The two want the same band, 1.03pt apart, one of them spinning. Rather than shave both until neither is legible, the transient fact wins while a provider is working and the week stays a hover away. Outside there is no contest and nothing is given up.

## Which window

Declared by the provider, like `headlineID` and for the same reason: everyone who has a weekly window calls it something different — `weekly_all`, `secondary`, `weekly`, `gemini-weekly` — and a rule that guessed from `duration` would silently skip whichever provider had not filled that field in, with nothing on screen to say why.

Never the window the headline is already drawing. Antigravity picks its headline by whichever limit is tightest and so lands on its own weekly some of the time; two rings reporting the same number reads as a second fact that happens to agree rather than as one fact drawn twice.

Populated for Claude, Codex, GLM, OpenCode, Ollama, Command Code and Antigravity. Not for Grok, whose `credits` window *is* the weekly one and is already the headline.

## Test plan

- [x] `make test` passes with no signing override.
- [x] Clearances are pinned as clearances rather than as numbers: inside clears the glyph and the working indicator, outside clears the track and the bezel, and the weekly arc is thinner than the headline's.
- [x] Rendered, not calculated, where the question is whether something appears — and with two different measures, because each is blind to one case. The arcs are drawn over the notch's own opaque black, so counting ink cannot see them: it answers the same number to seventeen decimal places whether the ring is there or not. A 0% arc carries no hue, so counting colour cannot see its track. Both of those were caught by watching a test pass that should have failed.
- [x] Both regressions fail their tests when reverted — removing the track makes the empty-week test report an identical pixel count, which is the failure it exists to catch.
- [x] Live on this machine, through the running app: Claude `session` → `weekly_all` at 47%, Antigravity `gemini-5h` → `gemini-weekly` at 46% (agreeing with `agy`'s own panel, which reports 53.57% remaining), Codex `primary` → `secondary` at 0% and visible by its track.
- [ ] **Only three providers are connected here**, so GLM, OpenCode, Ollama and Command Code are wired but never drawn by me. Their `weeklyID` is a one-line declaration each and resolves by id, so the risk is naming rather than logic — but I have not seen them.
- [ ] Not tried with a hardware notch or on a second display.

## One hole I would rather name than leave for you to find

When a provider's headline lands on its own weekly window, the second ring correctly disappears — but Antigravity has four windows, so there is always another pair worth showing, and it shows nothing instead. Making the second ring "the principal window that is not the headline" would close that, at the cost of the name: it stops being a weekly ring. I left it as it is rather than widen the idea without asking; say the word if you would rather have it.
