### PR TITLE
Let only the hardware notch wake a notch joined to it

### DIFF
--- a/Sources/Notch/NotchViewModel.swift
+++ b/Sources/Notch/NotchViewModel.swift
@@ -508,6 +508,21 @@ final class NotchViewModel: ObservableObject {
     var restingLength: CGFloat { hardwareNotch?.width ?? NotchLayout.pillHeight }
     var restingDepth: CGFloat { hardwareNotch?.height ?? NotchLayout.pillWidth }
 
+    /// What wakes the folded notch, in panel points: the resting shape and a
+    /// band around it, or the resting shape alone.
+    ///
+    /// The band is for the pill. A 10pt sliver on a screen edge is a fiddly
+    /// target, and the only cost of surrounding it is that it opens a little
+    /// eagerly. Joined to the hardware notch the band is a different matter:
+    /// the notch is already a generous target, and a band around it reached
+    /// 34pt *below* the menu bar — across the title bar of a window tiled
+    /// against the centre of the screen, whose close, minimise and zoom
+    /// buttons then opened the notch on approach and disappeared under it.
+    /// Flush with the hardware, what wakes the notch is the notch.
+    var wakeLength: CGFloat { max(restingLength * sizeScale, wakeBand) }
+    var wakeDepth: CGFloat { restingDepth * sizeScale + wakeBand }
+    private var wakeBand: CGFloat { isFlushWithHardware ? 0 : NotchLayout.pillHotZone }
+
     /// The drawn size of the notch body, in panel axes.
     var notchSize: CGSize {
         NotchPlacement.panelSize(edge: edge, length: notchLength, depth: notchDepth)

--- a/Sources/Notch/NotchWindowController.swift
+++ b/Sources/Notch/NotchWindowController.swift
@@ -285,19 +285,15 @@ final class NotchWindowController {
         )
     }
 
-    /// What wakes the folded notch. Deliberately larger than the pill it
-    /// surrounds — a 10pt target on a screen edge is a fiddly thing to hit, and
-    /// the cost of being generous is only that it opens a little eagerly.
+    /// What wakes the folded notch. Larger than the pill it surrounds, and
+    /// exactly the hardware notch when it is joined to one — see
+    /// `NotchViewModel.wakeLength` for both halves of that.
     private var pillRect: CGRect {
-        // Whatever the resting shape is — the pill, or the display's own notch
-        // when it is joining one — the region that wakes it is that plus a
-        // generous band, because both are small targets on a screen edge.
-        let length = max(model.restingLength * model.sizeScale, NotchLayout.pillHotZone)
-        return placement.rect(
-            along: model.slack + (model.shapeLength * model.sizeScale - length) / 2,
+        placement.rect(
+            along: model.slack + (model.shapeLength * model.sizeScale - model.wakeLength) / 2,
             across: 0,
-            length: length,
-            depth: model.restingDepth * model.sizeScale + NotchLayout.pillHotZone
+            length: model.wakeLength,
+            depth: model.wakeDepth
         )
     }
 

--- a/Tests/HardwareNotchTests.swift
+++ b/Tests/HardwareNotchTests.swift
@@ -135,6 +135,31 @@ final class MergedTopNotchTests: XCTestCase {
         XCTAssertEqual(m.notchDepth, NotchLayout.pillWidth, accuracy: 0.001)
     }
 
+    /// Nothing below the hardware wakes it.
+    ///
+    /// The pill's band exists because a 10pt sliver is hard to hit. The notch
+    /// is 220 by 38 and needs no help — and the band it inherited ran 34pt
+    /// below the menu bar, across the title bar of a window tiled to the
+    /// centre of the screen. Aiming at that window's close button opened the
+    /// notch on top of the button.
+    func testWhatWakesItIsExactlyTheHardwareNotch() {
+        let m = model(cells: 4)
+        m.isExpanded = false
+        XCTAssertEqual(m.wakeLength, realNotch.width, accuracy: 0.001,
+                       "the wake region is wider than the hardware")
+        XCTAssertEqual(m.wakeDepth, realNotch.height, accuracy: 0.001,
+                       "the wake region reaches below the hardware, into the window under it")
+    }
+
+    /// The pill keeps its band: it is the small target the band was made for.
+    func testThePillIsStillWokenByABandAroundIt() {
+        let m = model(cells: 4, screen: plain)
+        m.isExpanded = false
+        XCTAssertGreaterThan(m.wakeDepth, m.restingDepth,
+                             "the pill lost the band that makes it hittable")
+        XCTAssertGreaterThanOrEqual(m.wakeLength, m.restingLength)
+    }
+
     func testAScreenWithoutOneInsetsNothing() {
         XCTAssertEqual(model(cells: 4, screen: plain).contentInset, 0, accuracy: 0.001)
         for edge in [NotchEdge.right, .left, .bottom] {


### PR DESCRIPTION
## What

With **Edge: Top** on a MacBook, the folded notch is woken by the resting shape plus a 34pt band inward (`pillHotZone`). That band exists for the pill — a 10pt sliver on a screen edge is a fiddly target — but joined to the hardware notch it reaches 34pt *below* the menu bar, right across the title bar of any window tiled against the centre of the screen.

On a 14" MacBook Pro in a left/right split:

| | x | y |
|---|---|---|
| Hardware notch | 663 – 848 | 0 – 32 |
| Wake region (before) | 663 – 848 | 0 – 66 |
| Right-hand window's close/minimise/zoom | 771 – 820 | ≈ 49 |

Aiming at those buttons opens the notch on approach, and the open notch (≈ 120pt deep, taking mouse events across its whole shape) then covers them and swallows the click. The user can no longer close the right-hand window with the mouse.

Flush with the hardware, what wakes the notch is now exactly the notch (185 × 32pt here). The pill keeps its band — it is the small target the band was made for.

## How

The wake size moves from a private rect in `NotchWindowController` into `NotchViewModel.wakeLength` / `wakeDepth`, where it can be tested without a panel; the controller's `pillRect` reads them. No behaviour change for the pill, the side edges, or the bottom edge.

## Tests

- `MergedTopNotchTests.testWhatWakesItIsExactlyTheHardwareNotch` — wake region equals the hardware notch's width and height.
- `MergedTopNotchTests.testThePillIsStillWokenByABandAroundIt` — on a screen without a notch the band is still there.

`make test`: 1018 tests, 0 failures.

Verified with a Debug build on the 14" MacBook Pro above, two windows tiled left/right: the right-hand window's close, minimise and zoom buttons take the click again, and moving the pointer up into the menu bar under the hardware notch still opens it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

