### PR TITLE
Paint the open notch, its tooltip and the settings orb with Liquid Glass

### DIFF
--- a/Sources/App/AppDelegate.swift
+++ b/Sources/App/AppDelegate.swift
@@ -293,6 +293,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 .sink { [weak fleet] in fleet?.apply(accentColor: $0) }
                 .store(in: &cancellables)
 
+            preferences.$notchSurfaceStyle
+                .receive(on: RunLoop.main)
+                .sink { [weak fleet] in fleet?.apply(surfaceStyle: $0) }
+                .store(in: &cancellables)
+
             preferences.$disconnectedProviders
                 .receive(on: RunLoop.main)
                 .sink { [weak store] in store?.disconnected = $0 }
@@ -463,6 +468,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         fleet.apply(scale: preferences.notchScale)
         fleet.apply(resetTimeFormat: preferences.resetTimeFormat)
         fleet.apply(accentColor: preferences.accentColor)
+        fleet.apply(surfaceStyle: preferences.notchSurfaceStyle)
         fleet.show()
     }
 

--- a/Sources/DesignSystem/Palette.swift
+++ b/Sources/DesignSystem/Palette.swift
@@ -1,25 +1,42 @@
+import AppKit
 import SwiftUI
 
-/// Sampled from `docs/design/frame-124-hover-tooltip.png`, not invented.
+/// The dark values are sampled from `docs/design/frame-124-hover-tooltip.png`,
+/// not invented, and they differ slightly from the hexes written in the design
+/// spec — the frame is the source of truth, so the sampled values win.
 ///
-/// Note these differ slightly from the hexes written in the design spec — the
-/// frame is the source of truth, so the sampled values win.
+/// The light values are not sampled from anything, because there is no light
+/// frame: they exist only because the glass surface (`NotchSurfaceStyle.glass`)
+/// hands light and dark to the Mac's Appearance settings, and white ink on
+/// light glass is unreadable. They were picked for at least 3:1 against white.
+/// `solid` pins the panel to `darkAqua`, so it keeps the frame's hexes exactly.
+///
+/// The two tracks are translucent white / black rather than a fixed grey so
+/// they darken or lighten whatever is behind them instead of looking painted
+/// on top of the glass. Their dark alphas are the ones that composite to the
+/// frame's `#303030` / `#2D2D2D` over black, so the solid style is unchanged.
+///
+/// `notch` and `card` stay pure black: they paint the resting pill, which has
+/// to read as the bezel, and the whole surface in the solid style.
 enum Palette {
     static let notch         = Color.black                    // #000000
     static let card          = Color.black                    // #000000
-    static let ringTrack     = Color(hex: 0x303030)
-    static let barTrack      = Color(hex: 0x2D2D2D)
+    static let ringTrack     = Color(dark: .white.withAlphaComponent(0.188),
+                                     light: .black.withAlphaComponent(0.16))
+    static let barTrack      = Color(dark: .white.withAlphaComponent(0.176),
+                                     light: .black.withAlphaComponent(0.15))
 
-    static let ample         = Color(hex: 0x00FF88)           // green
-    static let watch         = Color(hex: 0xF2FF00)           // yellow
+    static let ample         = Color(dark: NSColor(hex: 0x00FF88), light: NSColor(hex: 0x00A356))
+    static let watch         = Color(dark: NSColor(hex: 0xF2FF00), light: NSColor(hex: 0xB08800))
+    /// Already 3.5:1 on white, so the warning colour is the same in both.
     static let critical      = Color(hex: 0xFF3F00)           // orange
 
     // Generation-speed bands are independent of cloud quota usage.
     static let generationFast = Color(hex: 0x0A84FF)          // blue
     static let generationSlow = Color(hex: 0xFF453A)          // red
 
-    static let textPrimary   = Color.white
-    static let textSecondary = Color(hex: 0x808080)
+    static let textPrimary   = Color(dark: .white, light: .black)
+    static let textSecondary = Color(dark: NSColor(hex: 0x808080), light: NSColor(hex: 0x6B6B6B))
 }
 
 extension Color {
@@ -30,6 +47,26 @@ extension Color {
             green: Double((hex >> 8) & 0xFF) / 255,
             blue:  Double(hex & 0xFF) / 255,
             opacity: 1
+        )
+    }
+
+    /// Resolved against whatever appearance is current when the colour is
+    /// drawn, which for the notch is the panel's: `nil` for glass (so the Mac
+    /// decides) and `darkAqua` for solid.
+    init(dark: NSColor, light: NSColor) {
+        self.init(nsColor: NSColor(name: nil) { appearance in
+            appearance.bestMatch(from: [.aqua, .darkAqua]) == .darkAqua ? dark : light
+        })
+    }
+}
+
+extension NSColor {
+    convenience init(hex: UInt32) {
+        self.init(
+            srgbRed: CGFloat((hex >> 16) & 0xFF) / 255,
+            green:   CGFloat((hex >> 8) & 0xFF) / 255,
+            blue:    CGFloat(hex & 0xFF) / 255,
+            alpha:   1
         )
     }
 }

--- a/Sources/Features/SettingsHandle.swift
+++ b/Sources/Features/SettingsHandle.swift
@@ -68,11 +68,36 @@ struct SettingsOrb: View {
     /// button being pushed.
     private static let squeezeScale: CGFloat = 0.84
 
+    @Environment(\.notchSurfaceStyle) private var surfaceStyle
+    @Environment(\.codenotchReduceTransparency) private var reduceTransparency
 
+    /// Reduce transparency means "no see-through chrome", which for the orb is
+    /// the solid style — the same precedence the Settings window applies to its
+    /// own translucent chrome.
+    private var glassy: Bool { surfaceStyle.effective == .glass && !reduceTransparency }
 
-    var body: some View {
-        ZStack {
-            // The resting arc, on a circle one gap inside the flare's own.
+    /// The resting arc, on a circle one gap inside the flare's own.
+    ///
+    /// On glass the arc is the material itself rather than a stroke of our
+    /// paint, so it reads as the same substance as the flare it hugs instead of
+    /// a line drawn beside it.
+    @ViewBuilder
+    private var restingArc: some View {
+        if glassy {
+            // `effective` is only ever `.glass` where `glassEffect` exists; the
+            // availability check is what tells the compiler so.
+            if #available(macOS 26.0, *) {
+                Color.clear
+                    .glassEffect(
+                        .regular,
+                        in: ArcBand(trim: restingTrim, lineWidth: NotchLayout.orbStroke)
+                    )
+                    // The band's own inset cancels the extra stroke width here,
+                    // so this is the same circle the stroked arc follows.
+                    .frame(width: arcRadius * 2 + NotchLayout.orbStroke,
+                           height: arcRadius * 2 + NotchLayout.orbStroke)
+            }
+        } else {
             Circle()
                 .trim(from: restingTrim.lowerBound, to: restingTrim.upperBound)
                 .stroke(
@@ -80,13 +105,34 @@ struct SettingsOrb: View {
                     style: StrokeStyle(lineWidth: NotchLayout.orbStroke, lineCap: .round)
                 )
                 .frame(width: arcRadius * 2, height: arcRadius * 2)
+        }
+    }
+
+    /// The filled disc the arc becomes on hover. It is the one thing here you
+    /// press, so its glass is `interactive` and reacts to the pointer.
+    @ViewBuilder
+    private var hoverDisc: some View {
+        if glassy {
+            if #available(macOS 26.0, *) {
+                Color.clear
+                    .glassEffect(.regular.interactive(), in: Circle())
+                    .frame(width: NotchLayout.orbDiameter, height: NotchLayout.orbDiameter)
+            }
+        } else {
+            Circle()
+                .fill(Palette.notch)
+                .frame(width: NotchLayout.orbDiameter, height: NotchLayout.orbDiameter)
+        }
+    }
+
+    var body: some View {
+        ZStack {
+            restingArc
                 .opacity(isHovered ? 0 : 1)
                 .scaleEffect(isHovered ? 0.86 : 1)
                 .offset(arcOffset)
 
-            Circle()
-                .fill(Palette.notch)
-                .frame(width: NotchLayout.orbDiameter, height: NotchLayout.orbDiameter)
+            hoverDisc
                 .opacity(isHovered ? 1 : 0)
                 .scaleEffect(isHovered ? 1 : 1.1)
 
@@ -131,5 +177,24 @@ struct SettingsOrb: View {
                            duration: 0.09, spring: .snappy)
             SpringKeyframe(1, duration: 0.34, spring: .bouncy)
         }
+    }
+}
+
+/// A segment of a circle's edge as a filled shape rather than a stroke.
+///
+/// Glass takes a shape, not a `ShapeStyle`, so the resting arc has to be an
+/// area before it can be made of the material. The circle is inset by half the
+/// line width because the glass is masked by this path *within the view's
+/// bounds*: run the band along the frame's edge and the outer half of every
+/// stroke is cut away.
+struct ArcBand: Shape {
+    let trim: ClosedRange<CGFloat>
+    let lineWidth: CGFloat
+
+    func path(in rect: CGRect) -> Path {
+        Circle()
+            .trim(from: trim.lowerBound, to: trim.upperBound)
+            .path(in: rect.insetBy(dx: lineWidth / 2, dy: lineWidth / 2))
+            .strokedPath(StrokeStyle(lineWidth: lineWidth, lineCap: .round))
     }
 }

--- a/Sources/Features/TooltipCard.swift
+++ b/Sources/Features/TooltipCard.swift
@@ -66,6 +66,59 @@ private struct TooltipTail: Shape {
     }
 }
 
+/// The card and its tail as a single outline.
+///
+/// One glass shape, not two: separate ones each grow their own rim highlight
+/// and the seam shows where the tail leaves the card. Internal so the tests can
+/// measure the outline.
+struct TooltipSilhouette: Shape {
+    /// Which side of the notch the card is on, so the tail goes on the other one.
+    let direction: NotchEdge.TooltipDirection
+    /// The same nudge `TooltipShell` applies to the tail view, along the card's
+    /// own axis. The glass is masked by this outline, so a tail that has slid
+    /// along the card to stay on its cell would otherwise be left unpainted.
+    var tailOffset: CGFloat = 0
+
+    func path(in rect: CGRect) -> Path {
+        // The two pieces are placed out of `rect` exactly the way
+        // `TooltipShell.body` stacks them, so the outline keeps following the
+        // card while its height animates.
+        let tail = TooltipTail.size(for: direction)
+        let cardRect: CGRect
+        var tailRect: CGRect
+        switch direction {
+        case .leading:
+            cardRect = CGRect(x: rect.minX, y: rect.minY,
+                              width: rect.width - tail.width, height: rect.height)
+            tailRect = CGRect(x: cardRect.maxX, y: rect.midY - tail.height / 2,
+                              width: tail.width, height: tail.height)
+        case .trailing:
+            tailRect = CGRect(x: rect.minX, y: rect.midY - tail.height / 2,
+                              width: tail.width, height: tail.height)
+            cardRect = CGRect(x: rect.minX + tail.width, y: rect.minY,
+                              width: rect.width - tail.width, height: rect.height)
+        case .down:
+            tailRect = CGRect(x: rect.midX - tail.width / 2, y: rect.minY,
+                              width: tail.width, height: tail.height)
+            cardRect = CGRect(x: rect.minX, y: rect.minY + tail.height,
+                              width: rect.width, height: rect.height - tail.height)
+        case .up:
+            cardRect = CGRect(x: rect.minX, y: rect.minY,
+                              width: rect.width, height: rect.height - tail.height)
+            tailRect = CGRect(x: rect.midX - tail.width / 2, y: cardRect.maxY,
+                              width: tail.width, height: tail.height)
+        }
+        switch direction {
+        case .leading, .trailing: tailRect.origin.y += tailOffset
+        case .up, .down:          tailRect.origin.x += tailOffset
+        }
+
+        return RoundedRectangle(cornerRadius: NotchLayout.cardCorner, style: .circular)
+            .path(in: cardRect)
+            .union(TooltipTail(direction: direction).path(in: tailRect))
+    }
+}
+
 /// The card chrome every tooltip shares: fixed width, the frame's padding and
 /// corner, and the tail welded on so there is no seam between them.
 private struct TooltipShell<Content: View>: View {
@@ -81,6 +134,16 @@ private struct TooltipShell<Content: View>: View {
     @ViewBuilder let content: Content
 
     @Environment(\.codenotchReduceTransparency) private var reduceTransparency
+    @Environment(\.notchSurfaceStyle) private var surfaceStyle
+
+    /// Reduce transparency means "no see-through chrome", which for this card
+    /// is the solid style — the same precedence the Settings window applies to
+    /// its own translucent chrome.
+    private var glassy: Bool { surfaceStyle.effective == .glass && !reduceTransparency }
+
+    /// Clear on glass: anything of ours under it would override the Clear or
+    /// Tinted choice in Appearance settings.
+    private var surfaceFill: Color { glassy ? .clear : Palette.card }
 
     private var card: some View {
         // The same arrangement that makes the notch fold work: the contents
@@ -94,7 +157,7 @@ private struct TooltipShell<Content: View>: View {
         // except the boundary.
         ZStack(alignment: .top) {
             RoundedRectangle(cornerRadius: NotchLayout.cardCorner, style: .circular)
-                .fill(Palette.card)
+                .fill(surfaceFill)
                 .frame(width: NotchLayout.cardWidth, height: height)
 
             content
@@ -118,13 +181,32 @@ private struct TooltipShell<Content: View>: View {
         // The tail is deliberately outside the clip: it is part of the card's
         // silhouette, not of its contents.
         return TooltipTail(direction: direction)
-            .fill(Palette.card)
+            .fill(surfaceFill)
             .frame(width: size.width, height: size.height)
             .offset(x: direction == .up || direction == .down ? tailOffset : 0,
                     y: direction == .leading || direction == .trailing ? tailOffset : 0)
     }
 
     var body: some View {
+        stack
+            // The background takes the stack's bounds — card plus tail — and is
+            // re-solved as `height` animates, so one piece of glass covers both
+            // pieces however tall the card is.
+            .background {
+                // `effective` is only ever `.glass` where `glassEffect` exists;
+                // the availability check is what tells the compiler so. Below
+                // that, `surfaceFill` has already painted the card opaque.
+                if glassy {
+                    if #available(macOS 26.0, *) {
+                        Color.clear
+                            .glassEffect(.regular, in: TooltipSilhouette(direction: direction,
+                                                                         tailOffset: tailOffset))
+                    }
+                }
+            }
+    }
+
+    @ViewBuilder private var stack: some View {
         // Card first or tail first, laid out along whichever axis the tail
         // points. The pair is one silhouette either way.
         switch direction {

--- a/Sources/Notch/NotchFleet.swift
+++ b/Sources/Notch/NotchFleet.swift
@@ -41,6 +41,7 @@ final class NotchFleet {
     private var displayPreference: DisplayPreference = .followActiveWindow
     private var resetTimeFormat: ResetTimeFormat = .automatic
     private var accentColor: AccentColorChoice = .system
+    private var surfaceStyle: NotchSurfaceStyle = .glass
     /// The ⌥-drag nudge along the current edge. One value for the whole
     /// fleet, the same as `edge` itself — displays do not each get their own
     /// edge, so they do not each get their own nudge either.
@@ -143,6 +144,13 @@ final class NotchFleet {
         self.accentColor = accentColor
         for controller in controllers.values {
             controller.model.accentColor = accentColor
+        }
+    }
+
+    func apply(surfaceStyle: NotchSurfaceStyle) {
+        self.surfaceStyle = surfaceStyle
+        for controller in controllers.values {
+            controller.model.surfaceStyle = surfaceStyle
         }
     }
 
@@ -305,6 +313,7 @@ final class NotchFleet {
         controller.model.sizeScale = scale
         controller.model.resetTimeFormat = resetTimeFormat
         controller.model.accentColor = accentColor
+        controller.model.surfaceStyle = surfaceStyle
         controller.onRefresh = onRefresh
         controller.onRefreshProvider = onRefreshProvider
         controller.onOpenSettings = onOpenSettings

--- a/Sources/Notch/NotchRootView.swift
+++ b/Sources/Notch/NotchRootView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct NotchRootView: View {
     @ObservedObject var model: NotchViewModel
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Environment(\.codenotchReduceTransparency) private var reduceTransparency
 
     var body: some View {
         // Measured rather than assumed: the panel's real size is whatever
@@ -87,6 +88,7 @@ struct NotchRootView: View {
         .animation(motion(NotchMotion.unfold), value: model.isExpanded)
         .tint(model.accentColor.color)
         .environment(\.codenotchAccentColor, model.accentColor.color)
+        .environment(\.notchSurfaceStyle, model.surfaceStyle)
     }
 
     /// Opening and closing are not mirror images. Appearing, the arc waits its
@@ -100,8 +102,61 @@ struct NotchRootView: View {
     }
 
     private func notch(_ place: NotchPlacement) -> some View {
-        SideNotchShape(edge: model.edge, joining: model.joinedNotch)
-            .fill(Palette.notch)
+        let shape = SideNotchShape(edge: model.edge, joining: model.joinedNotch)
+        // Glass is for the open notch only. Folded, the pill has to read as
+        // part of the bezel — and as the hardware notch itself on a MacBook —
+        // so it stays black; and glass under a `.statusBar` panel at rest
+        // would only be sampling the desktop for nothing.
+        //
+        // Reduce transparency means "no see-through chrome", which for the
+        // notch is the solid style — the same precedence the Settings window
+        // applies to its own translucent chrome.
+        let glassy = model.surfaceStyle.effective == .glass
+            && !reduceTransparency
+            && model.isExpanded
+
+        return ZStack {
+            // Nothing of ours underneath: a wash of our own would override the
+            // Clear/Tinted choice in Appearance settings, which is the whole
+            // point of handing this surface to the system.
+            //
+            // No `else`: the solid fill below is mounted in every style anyway,
+            // and below macOS 26 `glassy` is always false, so it is simply left
+            // at full opacity.
+            if #available(macOS 26.0, *) {
+                Color.clear
+                    .glassEffect(.regular, in: shape)
+                    .opacity(glassy ? 1 : 0)
+            }
+
+            shape.fill(Palette.notch).opacity(glassy ? 0 : 1)
+
+            // The band at the hardware's height is the strip beside a hole in
+            // the screen. Glass there makes the cutout read as a black
+            // rectangle set into a sheet of glass; black there makes the hole
+            // and the shape we draw one wide notch again, and the glass begins
+            // below it, where the readings begin. A hardware notch only ever
+            // joins the top edge, so `.top` is the right alignment; the band is
+            // clipped by the `.clipShape(shape)` below, which keeps the bezel
+            // fillets at its corners.
+            //
+            // Deeper than the hardware by the bleed below, and undoing the
+            // scale on that one number: the whole shape is pushed `bezelBleed`
+            // points past the screen edge after it is scaled, so a band drawn
+            // exactly `contentInset` deep ends that far short of the hole and
+            // leaves a strip of glass along the bottom of the cutout.
+            if model.joinedNotch != nil {
+                Rectangle()
+                    .fill(Palette.notch)
+                    .frame(height: model.contentInset + Self.bezelBleed / model.sizeScale)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+            }
+        }
+            // The glass and the fill both stay mounted so folding keeps
+            // animating one shape rather than swapping one view for another
+            // mid-flight; the crossfade rides on the unfold animation already
+            // on the root. The band above them is opaque in every state and
+            // takes no part in it.
             .frame(width: model.notchSize.width, height: model.notchSize.height)
             // Aligned to the corner where the stack starts *and* the bezel is,
             // then pushed clear of any hardware notch. Centring the contents in
@@ -114,7 +169,7 @@ struct NotchRootView: View {
             // the cells simply sit on top of a shrinking shape and appear to
             // slide out of the end of it; clipped, they are swallowed by the
             // outline as it closes, which is what a notch should do.
-            .clipShape(SideNotchShape(edge: model.edge, joining: model.joinedNotch))
+            .clipShape(shape)
             // The size choice, applied to the notch and the cells it carries —
             // and to nothing else. Drawn at design-frame size and scaled from
             // there, so `NotchLayout` keeps measuring the one thing it is

--- a/Sources/Notch/NotchViewModel.swift
+++ b/Sources/Notch/NotchViewModel.swift
@@ -128,6 +128,9 @@ final class NotchViewModel: ObservableObject {
     /// Mirrors the persisted Appearance choice so the separate notch window
     /// redraws immediately when Settings changes it.
     @Published var accentColor: AccentColorChoice = .system
+    /// Mirrors the persisted Appearance choice so the separate notch window
+    /// redraws immediately when Settings changes it.
+    @Published var surfaceStyle: NotchSurfaceStyle = .glass
     /// The display's own notch, when this edge has to share the bezel with one.
     ///
     /// Set by the window controller from the screen the panel is on, because

--- a/Sources/Notch/NotchWindowController.swift
+++ b/Sources/Notch/NotchWindowController.swift
@@ -152,6 +152,37 @@ final class NotchWindowController {
             .receive(on: RunLoop.main)
             .sink { [weak self] _ in self?.relocate() }
             .store(in: &cancellables)
+
+        // No `receive(on:)`: the appearance has to be on the window before the
+        // next draw, or the frame's hexes and the glass would be resolved
+        // against the appearance the panel is about to stop having.
+        model.$surfaceStyle
+            .removeDuplicates()
+            .sink { [weak self] style in
+                MainActor.assumeIsolated { self?.applyPanelAppearance(style) }
+            }
+            .store(in: &cancellables)
+
+        // Reduce transparency resolves the glass style to the solid one, so
+        // turning it on or off in System Settings changes what the panel's
+        // appearance has to be. Nothing else republishes that: the style the
+        // model holds has not changed.
+        NSWorkspace.shared.notificationCenter.publisher(
+            for: NSWorkspace.accessibilityDisplayOptionsDidChangeNotification
+        )
+        .sink { [weak self] _ in
+            MainActor.assumeIsolated {
+                guard let self else { return }
+                self.applyPanelAppearance(self.model.surfaceStyle)
+            }
+        }
+        .store(in: &cancellables)
+    }
+
+    private func applyPanelAppearance(_ style: NotchSurfaceStyle) {
+        panel?.appearance = style.panelAppearance(
+            reduceTransparency: NSWorkspace.shared.accessibilityDisplayShouldReduceTransparency
+        )
     }
 
     func stop() {
@@ -199,6 +230,9 @@ final class NotchWindowController {
             panel.setFrame(frame, display: true)
         } else {
             let panel = NotchPanel(contentRect: frame)
+            panel.appearance = model.surfaceStyle.panelAppearance(
+                reduceTransparency: NSWorkspace.shared.accessibilityDisplayShouldReduceTransparency
+            )
             let hosting = NotchHostingView(rootView: NotchRootView(model: model))
             panel.contextMenuProvider = { [weak self] in self?.contextMenu() }
             panel.onClick = { [weak self] point in self?.handleClick(at: point) }

--- a/Sources/Settings/NotchSurfaceStyle.swift
+++ b/Sources/Settings/NotchSurfaceStyle.swift
@@ -1,0 +1,78 @@
+import SwiftUI
+
+/// The material the expanded notch, tooltip and settings orb are painted with.
+///
+/// Raw values are persistence keys, not display copy: keeping them stable lets
+/// labels change without losing an existing choice. The default is `.glass`
+/// because an "on by default" choice must not depend on the user having opened
+/// Settings.
+enum NotchSurfaceStyle: String, CaseIterable, Identifiable {
+    case glass
+    case solid
+
+    var id: String { rawValue }
+
+    /// Whether this Mac has a Liquid Glass to hand the surface to at all.
+    ///
+    /// Codenotch's deployment target is macOS 15, where `glassEffect` does not
+    /// exist. A material is not a stand-in: the notch panel sits over the bezel
+    /// with nothing behind it to blur, so a `.regular` material there would
+    /// come out as a flat grey rectangle rather than as translucency.
+    static var glassAvailable: Bool {
+        if #available(macOS 26.0, *) { return true } else { return false }
+    }
+
+    /// The style that actually gets painted, which is the chosen one only where
+    /// it can be. Every glass branch keys off this rather than off `self`, so a
+    /// preference set on a newer Mac (or restored from one) still draws
+    /// something sensible on an older one instead of drawing nothing.
+    var effective: NotchSurfaceStyle {
+        self == .glass && Self.glassAvailable ? .glass : .solid
+    }
+
+    var title: String {
+        switch self {
+        case .glass: return L10n.t("Liquid Glass")
+        case .solid: return L10n.t("Solid black")
+        }
+    }
+
+    var explanation: String {
+        switch self {
+        case .glass:
+            return L10n.t("System Liquid Glass. Follows this Mac's Appearance settings, including Clear or Tinted glass and light or dark mode.")
+        case .solid:
+            return L10n.t("The original opaque black notch. Always dark, whatever the Mac's appearance.")
+        }
+    }
+
+    /// One window-level switch decides both halves of "how dark is this notch":
+    /// the dynamic `NSColor`s in `Palette` and SwiftUI's `colorScheme` are both
+    /// resolved against the window's appearance, so pinning it here saves
+    /// threading a style through every view that picks a colour.
+    ///
+    /// `nil` is not a fallback — it is the whole point of the glass style. With
+    /// no appearance of our own, light or dark, Clear or Tinted all arrive from
+    /// the Mac's Appearance settings; naming one would quietly overrule the
+    /// user there.
+    ///
+    /// Reduce transparency is the exception the window has to be told about:
+    /// it means "no see-through chrome", which for the notch is the solid
+    /// style, and a light palette on a black surface would be unreadable. The
+    /// precedence is the Settings window's — reduce transparency first, then
+    /// glass, then the opaque fill.
+    func panelAppearance(reduceTransparency: Bool) -> NSAppearance? {
+        effective == .glass && !reduceTransparency ? nil : NSAppearance(named: .darkAqua)
+    }
+}
+
+private struct NotchSurfaceStyleKey: EnvironmentKey {
+    static let defaultValue = NotchSurfaceStyle.glass
+}
+
+extension EnvironmentValues {
+    var notchSurfaceStyle: NotchSurfaceStyle {
+        get { self[NotchSurfaceStyleKey.self] }
+        set { self[NotchSurfaceStyleKey.self] = newValue }
+    }
+}

--- a/Sources/Settings/Preferences.swift
+++ b/Sources/Settings/Preferences.swift
@@ -140,6 +140,11 @@ final class Preferences: ObservableObject {
         didSet { defaults.set(accentColor.rawValue, forKey: Keys.accentColor) }
     }
 
+    /// The material the expanded notch, tooltip and settings orb are painted with.
+    @Published var notchSurfaceStyle: NotchSurfaceStyle {
+        didSet { defaults.set(notchSurfaceStyle.rawValue, forKey: Keys.notchSurfaceStyle) }
+    }
+
     /// The language the app itself speaks.
     ///
     /// `.system` follows the Mac. Written through `L10n.apply` so the store
@@ -250,6 +255,7 @@ final class Preferences: ObservableObject {
         static let resetTimeFormat = "resetTimeFormat"
         static let scope = "notchScope"
         static let accentColor = "accentColor"
+        static let notchSurfaceStyle = "notchSurfaceStyle"
         static let lastSeenVersion = "lastSeenVersion"
         static let order = "providerOrder"
         static let announceSessionEnd = "announceSessionEnd"
@@ -375,6 +381,8 @@ final class Preferences: ObservableObject {
         // Follow the Mac unless the user explicitly chooses a Codenotch colour.
         self.accentColor = defaults.string(forKey: Keys.accentColor)
             .flatMap(AccentColorChoice.init(rawValue:)) ?? .system
+        self.notchSurfaceStyle = defaults.string(forKey: Keys.notchSurfaceStyle)
+            .flatMap(NotchSurfaceStyle.init(rawValue:)) ?? .glass
         // Absent means never chosen, which is follow-the-Mac.
         self.language = defaults.string(forKey: L10n.languageDefaultsKey)
             .flatMap(AppLanguage.init(rawValue:)) ?? .system

--- a/Sources/Settings/SettingsView.swift
+++ b/Sources/Settings/SettingsView.swift
@@ -538,6 +538,21 @@ struct SettingsView: View {
                     .foregroundStyle(.secondary)
                     .fixedSize(horizontal: false, vertical: true)
 
+                // Offered only where there is a glass to choose. Below macOS 26
+                // the choice has one possible answer, and a picker that cannot
+                // be moved is worse than no picker at all.
+                if #available(macOS 26.0, *) {
+                    Picker(L10n.t("Surface"), selection: $preferences.notchSurfaceStyle) {
+                        ForEach(NotchSurfaceStyle.allCases) { Text($0.title).tag($0) }
+                    }
+                    .pickerStyle(.segmented)
+
+                    Text(preferences.notchSurfaceStyle.explanation)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+
                 // Two ways to answer the same question, because they suit
                 // different people: three named sizes for anyone who wants a
                 // decision made for them, and a slider for anyone who has a

--- a/TASKS.md
+++ b/TASKS.md
@@ -790,7 +790,7 @@ hundredths of a point wide; that is a fact about arcs, not a bug.
 - [ ] Threshold notifications (80% / 100%), per-provider mute
 - [ ] Auto-hide: never / on fullscreen / on overlap
 - [ ] Multi-display follow + unplug handling
-- [ ] Reduced-motion / reduced-transparency
+- [ ] Reduced-motion / reduced-transparency — reduced transparency is now the system's on the glass surface; see "The glass surface"
 - [ ] App icon, final name, README screenshots
 
 ## Managing accounts from Settings
@@ -1540,6 +1540,83 @@ Not an icon problem at all: the app had no Dock tile for an icon to sit on.
       window they had just opened.
 - [x] Clicking the Dock icon opens settings, via the `applicationShouldHandle
       Reopen` hook added for the Hide option. The notch stays where it is.
+
+## The glass surface
+
+### One glass, nothing underneath
+
+The expanded notch body, the tooltip and the settings orb are all painted, in
+the glass style, with `.glassEffect(.regular)` and nothing else — no tint, no
+colour underneath. That is deliberate: a wash of our own would sit under the
+glass and override the Clear/Tinted choice, light/dark mode and Reduce
+Transparency that the Mac's Appearance settings already control, so leaving
+the layer empty is what lets those settings reach the notch untouched. The
+tooltip is one shape, `TooltipSilhouette`, covering the card and the tail
+together rather than two separate glass shapes — two shapes each get their
+own rim highlight and show a seam where the tail meets the card.
+`testTheSilhouetteIsOneShapeCoveringCardAndTail`
+in `Tests/TooltipRenderTests.swift` pins it.
+
+### Solid stays the frame's
+
+`NotchSurfaceStyle.solid` — the non-default choice — forces `darkAqua` on the
+panel, so every hex the frame specifies still applies exactly as it did before
+glass existed. `Palette` gained light-appearance variants purely so the default
+glass style can follow the Mac into light mode: `textPrimary` `#000000`,
+`textSecondary` `#6B6B6B`, `ample` `#00A356` and `watch` `#B08800`, plus
+`ringTrack` at alpha 0.16 and `barTrack` at alpha 0.15 on black, all chosen for
+at least 3:1 contrast against white rather than sampled from anything.
+`PaletteAppearanceTests` (`Tests/UsageBandTests.swift`) pins both appearances,
+and `testTheSolidStyleForcesTheDarkAppearance` (`PanelSizingIntegrityTests`,
+`Tests/NotchRenderTests.swift`) pins the forced panel appearance.
+
+### What the tests can see
+
+`ImageRenderer` has no desktop behind it to refract, so almost every pixel test
+that renders the notch renders it in the solid style — glass with nothing
+behind it to sample is not what glass looks like on screen. The one glass
+exception is the hardware's band, below, which is painted the same opaque
+black regardless of style and so needs no desktop to read correctly. The other
+thing the glass style still has to prove headlessly is that the folded pill
+stays opaque black whatever the surface style is; `testTheFoldedPillIsOpaqueInTheGlassStyle`
+pins that rest state.
+
+### The hardware's band stays black
+
+A MacBook check showed the physical cutout, in the glass style, as a black
+rectangle set into a sheet of glass — the band at the hardware's height read
+as glass over nothing rather than as the hole in the screen it actually is.
+The fix keeps that band opaque black in both surface styles: it is a topmost
+layer in `NotchRootView.notch(_:)`, sized to `model.contentInset`, so the
+cutout and the drawn shape read as one wide notch again, and the glass begins
+only below it, where the readings begin. `testTheHardwaresBandStaysBlackInTheGlassStyle`
+pins it next to the solid-style band test.
+
+Upstream 1.7.0 draws the whole notch two points past the bezel
+(`NotchRootView.bezelBleed`, applied after `.scaleEffect`), so a band exactly
+`contentInset` deep ended two points short of the cutout's bottom and left a
+strip of glass inside the hole. The band is now `contentInset + bezelBleed /
+sizeScale` deep, which after scaling and the unscaled offset covers exactly
+`contentInset × sizeScale` on screen — the same region the readings are kept
+out of. It only showed in the full run: rendered alone, `ImageRenderer` draws
+glass transparent and the probe skips it; after earlier tests have exercised
+the effect it draws a light material, and
+`testTheHardwaresBandStaysBlackInTheGlassStyle` caught the strip.
+
+### Below macOS 26, and with Reduce transparency on
+
+Codenotch 1.7.0 targets macOS 15, where `glassEffect` does not exist yet. A
+material in the notch panel would have nothing behind it to blur, so below
+macOS 26 the glass style resolves to solid and the Surface setting is not
+offered at all — there is nothing to choose between. Reduce transparency
+resolves to solid too, following the same precedence the Settings window
+already uses for its own translucent chrome: Reduce transparency wins over
+glass. `testReduceTransparencyForcesTheDarkAppearance` and
+`testReduceTransparencyPaintsTheGlassStyleSolid` pin both cases. The window
+learns about a live accessibility change from
+`NSWorkspace.accessibilityDisplayOptionsDidChangeNotification` and re-applies
+the panel's appearance from that subscription, rather than only checking once
+at launch.
 
 ## Decisions needed
 - [ ] Final app name (`Codenotch` is a placeholder)

--- a/Tests/HardwareNotchTests.swift
+++ b/Tests/HardwareNotchTests.swift
@@ -445,10 +445,15 @@ final class OrbOnAFlushBarTests: XCTestCase {
 /// should meet the screen's frame with a corner rather than a raw edge.
 @MainActor
 final class HardwareClearanceTests: XCTestCase {
-    private func model(cells: Int = 4) -> NotchViewModel {
+    private func model(cells: Int = 4, style: NotchSurfaceStyle = .solid) -> NotchViewModel {
         let model = NotchViewModel()
         model.edge = .top
         model.isExpanded = true
+        // The solid style is the default here because `ImageRenderer` has no
+        // desktop behind it to refract, so glass renders as very little. The
+        // glass style still gets its own case: there the band is painted by a
+        // layer of its own, so it can regress on its own too.
+        model.surfaceStyle = style
         model.snapshots = (0..<cells).map { index in
             ProviderSnapshot(id: "p\(index)", displayName: "P", glyph: .claude,
                              fidelity: .official, status: .ok,
@@ -464,7 +469,19 @@ final class HardwareClearanceTests: XCTestCase {
     /// up 19pt from the top instead of 38, so the top of every ring was inside
     /// the hole — which is what "the notch is blocking the rings" looks like.
     func testTheHardwaresBandHoldsNothingButBlack() {
-        let m = model()
+        assertTheBandHoldsNothingButBlack(model())
+    }
+
+    /// The glass surface paints the band with a layer of its own, so it can go
+    /// wrong on its own: without it the cutout reads as a black rectangle set
+    /// into a sheet of glass.
+    func testTheHardwaresBandStaysBlackInTheGlassStyle() {
+        assertTheBandHoldsNothingButBlack(model(style: .glass))
+    }
+
+    private func assertTheBandHoldsNothingButBlack(
+        _ m: NotchViewModel, file: StaticString = #filePath, line: UInt = #line
+    ) {
         let size = m.notchSize
         let renderer = ImageRenderer(
             content: NotchRootView(model: m).frame(width: m.panelSize.width,
@@ -472,7 +489,7 @@ final class HardwareClearanceTests: XCTestCase {
         )
         renderer.scale = 1
         guard let image = renderer.cgImage, let rep = NSBitmapImageRep(cgImage: image).cgImage
-        else { return XCTFail("nothing rendered") }
+        else { return XCTFail("nothing rendered", file: file, line: line) }
         let bitmap = NSBitmapImageRep(cgImage: rep)
 
         let place = NotchPlacement(edge: .top, panelSize: m.panelSize)
@@ -485,7 +502,8 @@ final class HardwareClearanceTests: XCTestCase {
                 // or a label drawn where the display has a hole in it.
                 XCTAssertLessThan(
                     colour.brightnessComponent, 0.05,
-                    "something is drawn inside the hardware notch at (\(along), \(across))"
+                    "something is drawn inside the hardware notch at (\(along), \(across))",
+                    file: file, line: line
                 )
             }
         }

--- a/Tests/NotchLayoutTests.swift
+++ b/Tests/NotchLayoutTests.swift
@@ -399,6 +399,16 @@ final class SettingsOrbTests: XCTestCase {
     func testTheHitRegionIsLargerThanTheOrb() {
         XCTAssertGreaterThan(NotchLayout.orbHotZone, NotchLayout.orbDiameter)
     }
+
+    /// The glass arc is masked by this path inside the view's bounds, so a band
+    /// running along the frame's edge would lose the outer half of its stroke.
+    func testTheArcBandStaysInsideItsFrame() {
+        let frame = CGRect(x: 0, y: 0, width: 100, height: 100)
+        let path = ArcBand(trim: 0...0.25, lineWidth: NotchLayout.orbStroke).path(in: frame)
+        XCTAssertFalse(path.isEmpty)
+        XCTAssertTrue(frame.insetBy(dx: -0.5, dy: -0.5).contains(path.boundingRect),
+                      "\(path.boundingRect) escapes the band's frame")
+    }
 }
 
 /// Hiding a provider is stored as the hidden set, so one added in a later
@@ -491,6 +501,28 @@ final class PreferencesTests: XCTestCase {
         defaults.set("ultraviolet", forKey: "accentColor")
 
         XCTAssertEqual(Preferences(defaults: defaults).accentColor, .system)
+    }
+
+    func testSurfaceStyleDefaultsToLiquidGlass() {
+        XCTAssertEqual(preferences().notchSurfaceStyle, .glass)
+    }
+
+    func testSurfaceStyleSurvivesARestart() {
+        let name = "PreferencesSurfaceStyleTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: name)!
+        defaults.removePersistentDomain(forName: name)
+
+        Preferences(defaults: defaults).notchSurfaceStyle = .solid
+        XCTAssertEqual(Preferences(defaults: defaults).notchSurfaceStyle, .solid)
+    }
+
+    func testAnUnknownSurfaceStyleFallsBackToLiquidGlass() {
+        let name = "PreferencesSurfaceStyleFallbackTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: name)!
+        defaults.removePersistentDomain(forName: name)
+        defaults.set("frosted", forKey: "notchSurfaceStyle")
+
+        XCTAssertEqual(Preferences(defaults: defaults).notchSurfaceStyle, .glass)
     }
 
     /// The key is deliberately unchanged across the rename, so choices made

--- a/Tests/NotchRenderTests.swift
+++ b/Tests/NotchRenderTests.swift
@@ -11,6 +11,9 @@ final class NotchRenderTests: XCTestCase {
         let model = NotchViewModel()
         model.edge = edge
         model.isExpanded = true
+        // `ImageRenderer` has no desktop behind it to refract; these tests
+        // measure the outline, which both styles share.
+        model.surfaceStyle = .solid
         model.snapshots = (0..<cells).map { index in
             ProviderSnapshot(
                 id: "p\(index)", displayName: "P\(index)", glyph: .claude,
@@ -22,10 +25,13 @@ final class NotchRenderTests: XCTestCase {
         return model
     }
 
-    private func render(_ model: NotchViewModel) -> NSBitmapImageRep? {
+    private func render(_ model: NotchViewModel, reduceTransparency: Bool = false)
+        -> NSBitmapImageRep? {
         let size = model.panelSize
         let renderer = ImageRenderer(
-            content: NotchRootView(model: model).frame(width: size.width, height: size.height)
+            content: NotchRootView(model: model)
+                .frame(width: size.width, height: size.height)
+                .environment(\.codenotchReduceTransparency, reduceTransparency)
         )
         renderer.scale = 1
         guard let image = renderer.cgImage else { return nil }
@@ -130,6 +136,65 @@ final class NotchRenderTests: XCTestCase {
                                         "\(size.rawValue): something is painted before the near end")
         }
     }
+
+    /// The glass style only reaches the notch once it is open. At rest the pill
+    /// has to read as part of the bezel — as the hardware notch itself, on a
+    /// MacBook — and a translucent one would not.
+    func testTheFoldedPillIsOpaqueInTheGlassStyle() {
+        for edge in NotchEdge.allCases {
+            let m = model(edge: edge)
+            m.surfaceStyle = .glass
+            m.isExpanded = false
+            guard let rep = render(m) else {
+                XCTFail("\(edge): no image")
+                continue
+            }
+            let place = NotchPlacement(edge: edge, panelSize: m.panelSize)
+            // The same centre line the expanded body is probed on: folded or
+            // open, the shape is centred on it.
+            let onBezel = place.point(
+                along: m.slack + m.shapeLength / 2, across: 1
+            )
+            let colour = rep.colorAt(
+                x: min(rep.pixelsWide - 1, max(0, Int(onBezel.x))),
+                y: min(rep.pixelsHigh - 1, max(0, Int(onBezel.y)))
+            )
+            XCTAssertEqual(
+                colour?.alphaComponent ?? 0, 1, accuracy: 0.01,
+                "\(edge): the folded pill is see-through in the glass style"
+            )
+        }
+    }
+
+    /// Reduce transparency wins over the chosen style: the open notch is
+    /// painted solid black even when the preference says glass, the way the
+    /// Settings window prefers an opaque fill to its own translucent chrome.
+    func testReduceTransparencyPaintsTheGlassStyleSolid() {
+        for edge in NotchEdge.allCases {
+            let m = model(edge: edge)
+            m.surfaceStyle = .glass
+            guard let rep = render(m, reduceTransparency: true) else {
+                XCTFail("\(edge): no image")
+                continue
+            }
+            let place = NotchPlacement(edge: edge, panelSize: m.panelSize)
+            let onBezel = place.point(
+                along: m.slack + m.shapeLength / 2, across: 1
+            )
+            let colour = rep.colorAt(
+                x: min(rep.pixelsWide - 1, max(0, Int(onBezel.x))),
+                y: min(rep.pixelsHigh - 1, max(0, Int(onBezel.y)))
+            )
+            XCTAssertEqual(
+                colour?.alphaComponent ?? 0, 1, accuracy: 0.01,
+                "\(edge): the body is see-through with Reduce transparency on"
+            )
+            XCTAssertLessThan(
+                colour?.brightnessComponent ?? 1, 0.05,
+                "\(edge): the body is not black with Reduce transparency on"
+            )
+        }
+    }
 }
 
 /// The panel's size is worked out by `NotchGeometry` and by nobody else.
@@ -176,6 +241,53 @@ final class PanelSizingIntegrityTests: XCTestCase {
         }
         XCTAssertEqual(hosting.frame.size, content.bounds.size,
                        "the hosting view stopped filling the panel after a re-frame")
+    }
+
+    /// The solid style is the frame's white-on-black, and a Mac in light mode
+    /// must not be able to turn it into black-on-white. Glass is the opposite
+    /// bargain: no appearance of ours, so Appearance settings decide.
+    func testTheSolidStyleForcesTheDarkAppearance() {
+        let controller = NotchWindowController()
+        controller.model.surfaceStyle = .solid
+        controller.show()
+        defer { controller.stop() }
+
+        guard let window = controller.panelContentViewForTesting?.window else {
+            return XCTFail("no panel")
+        }
+        XCTAssertEqual(window.appearance?.name, .darkAqua,
+                       "the solid style left the panel following the Mac's appearance")
+
+        controller.model.surfaceStyle = .glass
+        // Only where glass is what actually gets painted: below macOS 26, and
+        // with Reduce transparency on, the glass style resolves to the solid
+        // one and the panel keeps its dark appearance on purpose.
+        if NotchSurfaceStyle.glassAvailable,
+           !NSWorkspace.shared.accessibilityDisplayShouldReduceTransparency {
+            XCTAssertNil(window.appearance,
+                         "the glass style pinned an appearance instead of inheriting one")
+        }
+    }
+
+    /// Reduce transparency means "no see-through chrome", and the window has to
+    /// know: the light palette resolved against a black surface would be
+    /// unreadable. Pure function, so this holds whatever the test Mac's own
+    /// accessibility settings are.
+    func testReduceTransparencyForcesTheDarkAppearance() {
+        XCTAssertEqual(
+            NotchSurfaceStyle.glass.panelAppearance(reduceTransparency: true)?.name, .darkAqua,
+            "Reduce transparency left the panel following the Mac's appearance"
+        )
+        if NotchSurfaceStyle.glassAvailable {
+            XCTAssertNil(
+                NotchSurfaceStyle.glass.panelAppearance(reduceTransparency: false),
+                "the glass style pinned an appearance instead of inheriting one"
+            )
+        }
+        XCTAssertEqual(
+            NotchSurfaceStyle.solid.panelAppearance(reduceTransparency: false)?.name, .darkAqua,
+            "the solid style left the panel following the Mac's appearance"
+        )
     }
 }
 

--- a/Tests/TooltipRenderTests.swift
+++ b/Tests/TooltipRenderTests.swift
@@ -104,4 +104,85 @@ final class TooltipRenderTests: XCTestCase {
             try png.write(to: URL(fileURLWithPath: path))
         }
     }
+
+    /// The glass is masked by this one outline, so anything it fails to cover
+    /// is a piece of the tooltip left unpainted.
+    func testTheSilhouetteIsOneShapeCoveringCardAndTail() {
+        for direction in [NotchEdge.TooltipDirection.leading, .trailing, .down, .up] {
+            let horizontal = direction == .leading || direction == .trailing
+            // The tail is long in the direction it points, whichever that is.
+            let tailLength = NotchLayout.tailLength
+            let rect = horizontal
+                ? CGRect(x: 0, y: 0, width: NotchLayout.cardWidth + tailLength, height: 200)
+                : CGRect(x: 0, y: 0, width: NotchLayout.cardWidth, height: 200 + tailLength)
+
+            let path = TooltipSilhouette(direction: direction).path(in: rect)
+            XCTAssertFalse(path.isEmpty, "\(direction) produced no outline at all")
+
+            let bounds = path.boundingRect
+            XCTAssertEqual(bounds.minX, rect.minX, accuracy: 0.5, "\(direction)")
+            XCTAssertEqual(bounds.minY, rect.minY, accuracy: 0.5, "\(direction)")
+            XCTAssertEqual(bounds.maxX, rect.maxX, accuracy: 0.5, "\(direction)")
+            XCTAssertEqual(bounds.maxY, rect.maxY, accuracy: 0.5, "\(direction)")
+
+            // The middle of the card, then a point just past the card's edge on
+            // the tail's centre line: one shape has to hold both.
+            let cardCentre: CGPoint
+            let insideTail: CGPoint
+            switch direction {
+            case .leading:
+                cardCentre = CGPoint(x: (rect.width - tailLength) / 2, y: rect.midY)
+                insideTail = CGPoint(x: rect.width - tailLength + 1, y: rect.midY)
+            case .trailing:
+                cardCentre = CGPoint(x: tailLength + (rect.width - tailLength) / 2, y: rect.midY)
+                insideTail = CGPoint(x: tailLength - 1, y: rect.midY)
+            case .down:
+                cardCentre = CGPoint(x: rect.midX, y: tailLength + (rect.height - tailLength) / 2)
+                insideTail = CGPoint(x: rect.midX, y: tailLength - 1)
+            case .up:
+                cardCentre = CGPoint(x: rect.midX, y: (rect.height - tailLength) / 2)
+                insideTail = CGPoint(x: rect.midX, y: rect.height - tailLength + 1)
+            }
+
+            XCTAssertTrue(path.contains(cardCentre), "\(direction) missed the card")
+            XCTAssertTrue(path.contains(insideTail), "\(direction) missed the tail")
+        }
+    }
+
+    /// The tail slides along the card to stay on the cell it points at, and the
+    /// glass is masked by this outline — a silhouette that ignored the nudge
+    /// would leave the tail unpainted where it actually is.
+    func testTheSilhouetteFollowsTheTailsOffset() {
+        for direction in [NotchEdge.TooltipDirection.leading, .trailing, .down, .up] {
+            let horizontal = direction == .leading || direction == .trailing
+            let tailLength = NotchLayout.tailLength
+            let rect = horizontal
+                ? CGRect(x: 0, y: 0, width: NotchLayout.cardWidth + tailLength, height: 200)
+                : CGRect(x: 0, y: 0, width: NotchLayout.cardWidth, height: 200 + tailLength)
+            // A whole tail's width, so the centre line the tail used to sit on
+            // is now clear of it.
+            let nudge = NotchLayout.tailHeight
+
+            let path = TooltipSilhouette(direction: direction, tailOffset: nudge).path(in: rect)
+
+            // Just past the card's edge on the unmoved centre line: a point only
+            // the tail can ever cover.
+            let wasOnCentre: CGPoint
+            switch direction {
+            case .leading:  wasOnCentre = CGPoint(x: rect.width - tailLength + 1, y: rect.midY)
+            case .trailing: wasOnCentre = CGPoint(x: tailLength - 1, y: rect.midY)
+            case .down:     wasOnCentre = CGPoint(x: rect.midX, y: tailLength - 1)
+            case .up:       wasOnCentre = CGPoint(x: rect.midX, y: rect.height - tailLength + 1)
+            }
+            // The offset runs along the card: across the tail's own direction.
+            let nowOnCentre = horizontal
+                ? CGPoint(x: wasOnCentre.x, y: wasOnCentre.y + nudge)
+                : CGPoint(x: wasOnCentre.x + nudge, y: wasOnCentre.y)
+
+            XCTAssertTrue(path.contains(nowOnCentre),
+                          "\(direction): the outline did not follow the tail's offset")
+            XCTAssertFalse(path.contains(wasOnCentre),
+                           "\(direction): the outline left a tail behind where the tail no longer is")
+        }
+    }
 }

--- a/Tests/UsageBandTests.swift
+++ b/Tests/UsageBandTests.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 import XCTest
 @testable import Codenotch
@@ -31,5 +32,85 @@ final class UsageBandTests: XCTestCase {
         XCTAssertEqual(UsageBand.watch.color(accent: accent), Palette.watch)
         XCTAssertEqual(UsageBand.critical.color(accent: accent), Palette.critical)
         XCTAssertEqual(UsageBand.exhausted.color(accent: accent), Palette.critical)
+    }
+}
+
+/// The palette went dynamic when the notch gained a glass surface, so the
+/// frame's hexes are no longer visible in the source — they are one branch of
+/// a colour that only resolves against an appearance. These tests keep that
+/// branch honest: `darkAqua` must still be pixel-for-pixel the frame, and the
+/// light branch must actually be different ink rather than a silent fallback.
+final class PaletteAppearanceTests: XCTestCase {
+    func testTheDarkAppearanceKeepsTheFramesHexes() {
+        assertOpaque(Palette.textPrimary, .darkAqua, is: 0xFFFFFF)
+        assertOpaque(Palette.textSecondary, .darkAqua, is: 0x808080)
+        assertOpaque(Palette.ample, .darkAqua, is: 0x00FF88)
+        assertOpaque(Palette.watch, .darkAqua, is: 0xF2FF00)
+        assertOpaque(Palette.critical, .darkAqua, is: 0xFF3F00)
+
+        // #303030 and #2D2D2D over black, so the solid style is unchanged.
+        assertTrack(Palette.ringTrack, .darkAqua, white: 1, alpha: 0.188)
+        assertTrack(Palette.barTrack, .darkAqua, white: 1, alpha: 0.176)
+    }
+
+    func testTheLightAppearanceHasItsOwnInk() {
+        assertOpaque(Palette.textPrimary, .aqua, is: 0x000000)
+        assertOpaque(Palette.textSecondary, .aqua, is: 0x6B6B6B)
+        assertOpaque(Palette.ample, .aqua, is: 0x00A356)
+        assertOpaque(Palette.watch, .aqua, is: 0xB08800)
+        assertOpaque(Palette.critical, .aqua, is: 0xFF3F00)
+
+        assertTrack(Palette.ringTrack, .aqua, white: 0, alpha: 0.16)
+        assertTrack(Palette.barTrack, .aqua, white: 0, alpha: 0.15)
+    }
+
+    // MARK: -
+
+    /// The `NSColor` has to be built *inside* the drawing appearance: a dynamic
+    /// colour created outside it resolves against whatever the test host's
+    /// appearance happens to be.
+    private func resolve(
+        _ color: Color,
+        _ appearance: NSAppearance.Name,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) -> NSColor? {
+        var resolved: NSColor?
+        NSAppearance(named: appearance)?.performAsCurrentDrawingAppearance {
+            resolved = NSColor(color).usingColorSpace(.sRGB)
+        }
+        XCTAssertNotNil(resolved, "\(appearance.rawValue) did not resolve", file: file, line: line)
+        return resolved
+    }
+
+    private func assertOpaque(
+        _ color: Color,
+        _ appearance: NSAppearance.Name,
+        is hex: UInt32,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        guard let resolved = resolve(color, appearance, file: file, line: line) else { return }
+        let tolerance = 1.0 / 255
+        XCTAssertEqual(resolved.redComponent, Double((hex >> 16) & 0xFF) / 255, accuracy: tolerance, file: file, line: line)
+        XCTAssertEqual(resolved.greenComponent, Double((hex >> 8) & 0xFF) / 255, accuracy: tolerance, file: file, line: line)
+        XCTAssertEqual(resolved.blueComponent, Double(hex & 0xFF) / 255, accuracy: tolerance, file: file, line: line)
+        XCTAssertEqual(resolved.alphaComponent, 1, accuracy: tolerance, file: file, line: line)
+    }
+
+    private func assertTrack(
+        _ color: Color,
+        _ appearance: NSAppearance.Name,
+        white: Double,
+        alpha: Double,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        guard let resolved = resolve(color, appearance, file: file, line: line) else { return }
+        let tolerance = 1.0 / 255
+        XCTAssertEqual(resolved.redComponent, white, accuracy: tolerance, file: file, line: line)
+        XCTAssertEqual(resolved.greenComponent, white, accuracy: tolerance, file: file, line: line)
+        XCTAssertEqual(resolved.blueComponent, white, accuracy: tolerance, file: file, line: line)
+        XCTAssertEqual(resolved.alphaComponent, alpha, accuracy: 0.005, file: file, line: line)
     }
 }


### PR DESCRIPTION
## What

The expanded notch body, the tooltip card with its tail and the settings orb are painted with the system's Liquid Glass (`.glassEffect(.regular)`) instead of flat black. Nothing of our own is painted underneath and no tint is applied, so the Mac's Appearance settings decide how the surface looks: Liquid Glass Clear or Tinted, light or dark mode, and Reduce transparency. The folded pill stays opaque black, and so does the band at the hardware notch's height on a MacBook — glass there made the camera housing read as a black rectangle set into glass.

- New Appearance → Notch setting **Surface**: *Liquid Glass* (default) or *Solid black*, the original look. Solid forces `darkAqua` on the panel so the frame's hexes hold whatever the Mac's appearance.
- `Palette` follows the appearance: the dark values are the frame's hexes, unchanged; the light ones were chosen for at least 3:1 on white; ring and bar tracks are translucent so they sit on glass rather than looking painted on.
- The tooltip is one `TooltipSilhouette` (card and tail): two glass shapes show a seam at the tail's base.
- Below macOS 26 the glass style resolves to solid and the Surface row is not shown. With Reduce transparency on, the surface is solid as well, matching the Settings window's precedence.

## Tests

`make test` passes (1029 tests). New: `PaletteAppearanceTests`, `testTheSolidStyleForcesTheDarkAppearance`, `testReduceTransparencyForcesTheDarkAppearance`, `testReduceTransparencyPaintsTheGlassStyleSolid`, `testTheFoldedPillIsOpaqueInTheGlassStyle`, `testTheHardwaresBandStaysBlackInTheGlassStyle`, `testTheSilhouetteIsOneShapeCoveringCardAndTail`, `testTheArcBandStaysInsideItsFrame`, and the Surface preference tests. Pixel tests render the solid style because `ImageRenderer` has no desktop to refract; the rest state and the hardware band are pinned in the glass style too.

## Notes for review

- Checked by eye on macOS 26/27 hardware on every edge and on a MacBook with a notch. The macOS 15 path compiles under the 15.0 target but I could not run it on a 15 machine.
- This SDK's `glassEffect` has no `isEnabled:`, so the glass layer stays mounted at zero opacity while folded.
- No `GlassEffectContainer` yet, so the orb's arc does not merge with the body's glass — a possible follow-up.
- The hardware band is drawn `contentInset + bezelBleed / sizeScale` deep so the two-point bezel bleed does not leave a strip of glass inside the cutout (`testTheHardwaresBandStaysBlackInTheGlassStyle` caught it in the full run). Pre-existing and untouched here: `contentInset` scales with `sizeScale`, so at a size other than medium the band covers `38 × scale` points of the 38pt cutout.
- Decision record in `TASKS.md` → "The glass surface". No version bump; the new strings go through `L10n.t` with no catalog entries (English falls back from the key, as `CatalogCoverageTests` documents).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016eMmEShXhoX2W5Ze2gTXhb
