### PR TITLE
Disable CI workflows for forked repositories

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   test:
+    if: github.repository == 'vinzdg/codenotch'
     name: Unit tests
     # macOS 26, because that is what the app targets. An older image ships an
     # Xcode that cannot read the project at all — `objectVersion 77` is a

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -13,6 +13,7 @@ on:
 
 jobs:
   package:
+    if: github.repository == 'vinzdg/codenotch'
     name: Unsigned app bundle
     # Only the preview release step writes anything; the token is read-only by
     # default on this repository, and `gh release create` fails without this.


### PR DESCRIPTION
**The Issue**
Currently, when a user forks this repository and updates their branch from the upstream repository, the GitHub Actions workflows (`ci.yml` and `package.yml`) are automatically triggered in their fork. This causes unnecessary runner usage on forks for standard updates that don't need to be built or tested on the fork side until an actual PR is opened against the upstream repo. 

**The Fix**
Added an `if: github.repository == 'vinzdg/codenotch'` condition to the jobs inside both `ci.yml` and `package.yml`. This explicitly restricts the workflow from executing on any repository other than the main upstream repository (`vinzdg/codenotch`), preventing automatic workflow runs across all forks.