### PR TITLE
fix: account for camera notch inset and cursor poll in full-screen auto-fold

### DIFF
--- a/Sources/Notch/FullScreenDetector.swift
+++ b/Sources/Notch/FullScreenDetector.swift
@@ -8,12 +8,35 @@ enum FullScreenDetector {
     static func isFullScreen(
         screenBounds: CGRect,
         frontmostPID: pid_t,
-        windows: [(pid: pid_t, layer: Int, bounds: CGRect)]
+        windows: [(pid: pid_t, layer: Int, bounds: CGRect)],
+        safeAreaTopInset: CGFloat = 0
     ) -> Bool {
         for window in windows {
             guard window.pid == frontmostPID, window.layer == 0 else { continue }
-            if abs(window.bounds.width - screenBounds.width) <= 2 &&
-               abs(window.bounds.height - screenBounds.height) <= 2 {
+            let b = window.bounds
+
+            // Must match screen width (within small tolerance for window borders/rounding)
+            guard abs(b.origin.x - screenBounds.origin.x) <= 4,
+                  abs(b.width - screenBounds.width) <= 4 else {
+                continue
+            }
+
+            // Case 1: Spans full screen height (e.g. video, game, or non-notched screen with hidden menu bar)
+            if abs(b.origin.y - screenBounds.origin.y) <= 4 &&
+               abs(b.height - screenBounds.height) <= 4 {
+                return true
+            }
+
+            // Case 2: Full-screen window on a notched MacBook or with menu bar present.
+            // Starts right below notch/menu bar, reaches bottom of screen,
+            // and occupies the available display area.
+            let maxTopInset = max(safeAreaTopInset, 40.0) + 4.0
+            let reachesBottom = abs(b.maxY - screenBounds.maxY) <= 4
+            let startsNearTop = b.origin.y >= screenBounds.origin.y - 4 &&
+                                b.origin.y <= screenBounds.origin.y + maxTopInset
+            let occupiesMainArea = b.height >= screenBounds.height - (maxTopInset + 10)
+
+            if reachesBottom && startsNearTop && occupiesMainArea {
                 return true
             }
         }
@@ -29,6 +52,23 @@ enum FullScreenDetector {
         // Ignore Codenotch itself (settings panel, etc.)
         guard frontApp.bundleIdentifier != Bundle.main.bundleIdentifier else { return false }
 
+        // Convert NSScreen (AppKit coordinates: origin bottom-left of primary screen)
+        // to CoreGraphics coordinates (origin top-left of primary screen).
+        let primaryHeight = NSScreen.screens.first?.frame.height ?? screen.frame.height
+        let cgScreenBounds = CGRect(
+            x: screen.frame.minX,
+            y: primaryHeight - screen.frame.maxY,
+            width: screen.frame.width,
+            height: screen.frame.height
+        )
+
+        let safeTop: CGFloat
+        if #available(macOS 12.0, *) {
+            safeTop = screen.safeAreaInsets.top
+        } else {
+            safeTop = 0
+        }
+
         if let windowInfoList = CGWindowListCopyWindowInfo([.optionOnScreenOnly, .excludeDesktopElements], kCGNullWindowID) as? [[String: Any]] {
             var extractedWindows: [(pid: pid_t, layer: Int, bounds: CGRect)] = []
             for info in windowInfoList {
@@ -41,16 +81,17 @@ enum FullScreenDetector {
             }
 
             if isFullScreen(
-                screenBounds: screen.frame,
+                screenBounds: cgScreenBounds,
                 frontmostPID: frontApp.processIdentifier,
-                windows: extractedWindows
+                windows: extractedWindows,
+                safeAreaTopInset: safeTop
             ) {
                 return true
             }
         }
 
-        // Supplementary check: on a full-screen Space, macOS autohides the menu bar,
-        // causing visibleFrame to match the entire screen frame.
+        // Supplementary check: on a full-screen Space without camera notch,
+        // macOS autohides the menu bar, causing visibleFrame to match the entire screen frame.
         if abs(screen.visibleFrame.width - screen.frame.width) <= 1 &&
            abs(screen.visibleFrame.height - screen.frame.height) <= 1 &&
            frontApp.bundleIdentifier != "com.apple.finder" {

--- a/Sources/Notch/NotchWindowController.swift
+++ b/Sources/Notch/NotchWindowController.swift
@@ -84,6 +84,15 @@ final class NotchWindowController {
     /// When returning to a desktop space with `isAlwaysOn`, restores the unfolded state.
     func handleActiveSpaceOrAppChange() {
         if isFullScreenActive() {
+            if let panel {
+                let local = localCursor(in: panel.frame)
+                let overTooltip = model.hoveredIndex
+                    .flatMap(tooltipRect(index:))
+                    .map { model.isExpanded && $0.contains(local) } ?? false
+                if liveRect.contains(local) || overTooltip {
+                    return
+                }
+            }
             foldForFullScreen()
         } else if model.isAlwaysOn && !model.isExpanded {
             withAnimation(NotchMotion.unfold) {
@@ -93,13 +102,11 @@ final class NotchWindowController {
         }
     }
 
-    /// Immediately folds the notch and clears pending peek/hover timers when a full-screen app takes focus.
+    /// Immediately folds the notch and clears pending hover timers when a full-screen app takes focus.
     func foldForFullScreen() {
+        if let peekUntil, peekUntil > Date() { return }
         foldWork?.cancel()
         foldWork = nil
-        peekWork?.cancel()
-        peekWork = nil
-        peekUntil = nil
         model.isPinned = false
         guard model.isExpanded else { return }
         withAnimation(NotchMotion.unfold) {
@@ -421,6 +428,7 @@ final class NotchWindowController {
     private func startWatchingCursor() {
         let poll = Timer(timeInterval: 0.3, repeats: true) { [weak self] _ in
             MainActor.assumeIsolated {
+                self?.handleActiveSpaceOrAppChange()
                 self?.cursorMoved()
             }
         }
@@ -453,7 +461,7 @@ final class NotchWindowController {
         let overTooltip = model.hoveredIndex
             .flatMap(tooltipRect(index:))
             .map { model.isExpanded && $0.contains(local) } ?? false
-        setExpanded(liveRect.contains(local) || overTooltip)
+        setExpanded(liveRect.contains(local) || overTooltip, ignoreAlwaysOn: isFullScreenActive())
 
         var target: Int?
         if model.isExpanded, notchRect.contains(local) {
@@ -497,7 +505,7 @@ final class NotchWindowController {
 
     /// Opens on contact, folds shut after a pause — unless it has been pinned
     /// open, in which case the pointer is not what decides.
-    private func setExpanded(_ wanted: Bool) {
+    private func setExpanded(_ wanted: Bool, ignoreAlwaysOn: Bool = false) {
         if wanted {
             foldWork?.cancel()
             foldWork = nil
@@ -509,12 +517,14 @@ final class NotchWindowController {
         // A peek holds the notch open for its own duration; only after that
         // does the pointer get a say again.
         if let peekUntil, peekUntil > Date() { return }
-        guard model.isExpanded, !model.staysOpen, foldWork == nil else { return }
+        let holdsOpen = ignoreAlwaysOn ? model.isPinned : model.staysOpen
+        guard model.isExpanded, !holdsOpen, foldWork == nil else { return }
         let work = DispatchWorkItem { [weak self] in
             MainActor.assumeIsolated {
                 guard let self else { return }
                 self.foldWork = nil
-                guard !self.model.staysOpen else { return }
+                let stillHoldsOpen = ignoreAlwaysOn ? self.model.isPinned : self.model.staysOpen
+                guard !stillHoldsOpen else { return }
                 withAnimation(NotchMotion.unfold) {
                     self.model.isExpanded = false
                     self.model.hoveredIndex = nil

--- a/Tests/FullScreenAutoFoldTests.swift
+++ b/Tests/FullScreenAutoFoldTests.swift
@@ -18,6 +18,28 @@ final class FullScreenAutoFoldTests: XCTestCase {
         XCTAssertTrue(FullScreenDetector.isFullScreen(screenBounds: screen, frontmostPID: pid, windows: windows))
     }
 
+    func testDetectorFindsFullScreenWindowOnNotchedDisplay() {
+        // On a MacBook with camera notch, CoreGraphics screen origin is (0, 0)
+        // and full-screen windows start below the notch/menu bar (e.g. y=44)
+        // extending to the bottom edge (height = 1117 - 44 = 1073).
+        let screen = CGRect(x: 0, y: 0, width: 1728, height: 1117)
+        let pid: pid_t = 12345
+        let windows: [(pid: pid_t, layer: Int, bounds: CGRect)] = [
+            (pid: pid, layer: 0, bounds: CGRect(x: 0, y: 44, width: 1728, height: 1073))
+        ]
+
+        XCTAssertTrue(
+            FullScreenDetector.isFullScreen(
+                screenBounds: screen,
+                frontmostPID: pid,
+                windows: windows,
+                safeAreaTopInset: 44
+            ),
+            "Full-screen window starting below the notch and reaching screen bottom must be detected"
+        )
+    }
+
+
     func testDetectorRejectsWindowWhenNotMatchingScreenBounds() {
         let screen = CGRect(x: 0, y: 0, width: 1728, height: 1117)
         let pid: pid_t = 12345


### PR DESCRIPTION
### Summary
Follow-up to #88 for MacBooks equipped with camera notches and space-transition edge cases:

1. **Notch Insets & Coordinate Alignment**:
   - On MacBooks with a physical camera notch, full-screen spaces leave the menu bar area around the notch unallocated or inset, so the frontmost full-screen window starts right below the notch/menu bar (at `safeAreaInsets.top` / ~40-44pt) and extends to the bottom of the screen.
   - CoreGraphics window origins (`CGWindowListCopyWindowInfo`) use top-left coordinates, whereas `NSScreen.frame` uses bottom-left coordinates. Converted `screen.frame` to CG coordinates when evaluating window bounds in `FullScreenDetector`.
   - Updated `FullScreenDetector.isFullScreen` with a condition to detect full-screen windows that start below the camera notch / menu bar and reach the bottom screen edge (`reachesBottom && startsNearTop && occupiesMainArea`).

2. **Periodic Hover & Space State Sync**:
   - Wired `handleActiveSpaceOrAppChange()` into the 0.3s cursor polling timer (`startWatchingCursor`) so that space switches without immediate system notifications are evaluated promptly.
   - Protected ongoing hover interactions from folding abruptly during transition if the cursor is actively over the notch or a tooltip.
   - When hovering over the notch in a full-screen app while "Always On" is enabled, folding respects cursor departure (`ignoreAlwaysOn: isFullScreenActive()`) rather than keeping the notch permanently unfolded over the full-screen window.
   - Preserved active peeks in `foldForFullScreen` so temporary notifications aren't cut short.

3. **Tests**:
   - Added unit test `testDetectorFindsFullScreenWindowOnNotchedDisplay` verifying that window bounds starting below the notch safe area and reaching the screen bottom are detected as full-screen.