### PR TITLE
Fix the ad-hoc signing fallback never triggering

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,12 @@ DEST    := platform=macOS,arch=arm64
 # changes nothing: project.yml's stable identity is what keeps a keychain
 # "Always Allow" grant alive across rebuilds, and forcing ad-hoc there would
 # throw that away and bring the prompt back on every `make run`.
-ifeq (,$(shell security find-identity -v -p codesigning 2>/dev/null | grep -c "Developer ID Application"))
+# `grep`, not `grep -c`: `-c` prints a count, so the shell output is "0" when
+# the certificate is absent and never the empty string this test compares
+# against. The guard was therefore false on exactly the machines it exists for,
+# DEV_SIGN stayed unset, and `make build` failed asking for a Developer ID
+# certificate with the maintainer's team ID — on every machine but one.
+ifeq (,$(shell security find-identity -v -p codesigning 2>/dev/null | grep "Developer ID Application"))
 DEV_SIGN := CODE_SIGN_IDENTITY="-" DEVELOPMENT_TEAM="" CODE_SIGN_STYLE=Automatic
 endif
 


### PR DESCRIPTION
`grep -c` prints a count, so the shell output is `0` when no Developer ID
certificate is present — never the empty string the `ifeq` compares against.
The guard is therefore false on exactly the machines it exists for, `DEV_SIGN`
stays unset, and Debug falls through to project.yml's release identity.

On any machine without your certificate, `make build` / `make test` / `make run`
all fail:

```
No signing certificate "Developer ID Application" found: No "Developer ID
Application" signing certificate matching team ID "6WFPL8B9FB" with a private
key was found. (in target 'Codenotch')
```

That is the opposite of what CONTRIBUTING.md promises. Dropping `-c` restores
it: absent certificate means empty output, the guard matches, Debug ad-hoc
signs itself.

**Tests:** no new test — this is `make` conditional logic, out of reach of the
Swift suite. Verified by building clean `main` on a machine without the
certificate (fails as above) and this branch (`make test`, 552 pass).