### PR TITLE
Stop the keychain password prompt from coming back

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,12 +10,25 @@ make run                 # build and launch
 ```
 
 None of these need an Apple Developer account. `xcodebuild` ad-hoc signs a
-Debug build automatically, which is enough to run and debug locally. The one
-thing an unsigned build can't do is keep a keychain "Always Allow" grant across
-rebuilds — Claude Code's and Antigravity's credentials are guarded by an ACL
-keyed on the signing identity, and an ad-hoc identity changes every build. In
-practice this means the keychain prompt reappears each time you rebuild during
-development; that's expected and doesn't affect anything else.
+Debug build automatically, which is enough to run and debug locally. An ad-hoc
+identity changes every build, so a keychain "Always Allow" grant does not
+survive a rebuild and the prompt reappears during development.
+
+That prompt is no longer shown, in Debug or in a release build. It was never
+only a development annoyance: a keychain item has an access list, which is what
+"Always Allow" writes to, and a *partition list*, which nothing in the GUI ever
+writes to. An app outside the partition list is refused before the access list
+is consulted, so approving the dialogue is good for exactly one read. Claude
+Code recreates its keychain items on every token rotation rather than updating
+them, and a freshly created item's partition list holds only `apple-tool:` —
+which evicts a properly signed release build just as surely as an ad-hoc one.
+Shipped users got the dialogue on a timer.
+
+`ClaudeCredentials.read` therefore disables keychain interaction for the length
+of the read and falls back to `/usr/bin/security`, which is Apple-signed and so
+is never the client that gets refused. A refusal it cannot recover from becomes
+`.accessDenied`, and `Scripts/fix-keychain-partitions.sh` is the one thing that
+actually restores direct access.
 
 `make release` is different: it archives, signs with a Developer ID
 certificate, notarizes with Apple, and regenerates the Sparkle auto-update

--- a/Scripts/fix-keychain-partitions.sh
+++ b/Scripts/fix-keychain-partitions.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+# Add Codenotch's Team ID to the partition list of every Claude Code keychain
+# item.
+#
+# Why this is needed at all: a keychain item carries two separate gates. The
+# ACL says *which apps* may read it — that is the list "Always Allow" writes
+# to. The partition list says which *code-signing partitions* may read it, and
+# nothing in the GUI ever writes to that one. An app whose signing identity is
+# outside the partition list is refused before the ACL is even consulted, so
+# clicking Always Allow records an approval that is discarded on the next read.
+# That is the prompt-every-60-seconds loop.
+#
+# Codenotch used to be ad-hoc signed, so its identity was a cdhash that changed
+# on every build; now it is signed with a real Team ID and the identity is
+# stable, but these items were written before that and only list "apple-tool:"
+# (the /usr/bin/security CLI, which is how Claude Code writes them).
+#
+# Run once. The password is read silently and passed on stdin, never on argv,
+# because argv is readable by any process via ps.
+set -euo pipefail
+
+TEAM_ID="$(codesign -dv /Applications/Codenotch.app 2>&1 | sed -nE 's/^TeamIdentifier=([A-Z0-9]{10})$/\1/p')"
+if [ -z "$TEAM_ID" ] || [ "$TEAM_ID" = "not" ]; then
+  echo "Codenotch is not signed with a Team ID — rebuild with 'make install' first." >&2
+  exit 1
+fi
+
+# apple-tool: and apple: are kept, not replaced: Claude Code and the token
+# refresher both reach these items through /usr/bin/security, and dropping
+# apple-tool: would lock *them* out to let Codenotch in.
+PARTITIONS="apple-tool:,apple:,teamid:${TEAM_ID}"
+
+# Claude Code's own naming rule: the bare service for ~/.claude, and a suffix
+# of the first 8 hex of sha256(absolute path) for every other profile.
+services() {
+  echo "Claude Code-credentials"
+  for dir in "$HOME"/.claude-*; do
+    [ -d "$dir" ] || continue
+    [ -e "$dir/.credentials.json" ] || [ -e "$dir/settings.json" ] || continue
+    printf 'Claude Code-credentials-%s\n' \
+      "$(printf '%s' "$dir" | shasum -a 256 | cut -c1-8)"
+  done
+}
+
+printf 'Login keychain password: '
+read -rs PASSWORD
+printf '\n\n'
+
+failed=0
+while IFS= read -r service; do
+  # Skip items that do not exist rather than reporting a failure for them.
+  if ! /usr/bin/security find-generic-password -a "$USER" -s "$service" >/dev/null 2>&1; then
+    echo "  skip  $service (no such item)"
+    continue
+  fi
+  if printf '%s' "$PASSWORD" | /usr/bin/security set-generic-password-partition-list \
+       -a "$USER" -s "$service" -S "$PARTITIONS" >/dev/null 2>&1; then
+    echo "  ok    $service"
+  else
+    echo "  FAIL  $service"
+    failed=1
+  fi
+done < <(services)
+
+unset PASSWORD
+echo
+if [ "$failed" -eq 0 ]; then
+  echo "Done. Partition list is now: $PARTITIONS"
+  echo "Codenotch should stop asking for the password."
+else
+  echo "Some items could not be updated — check the password and re-run." >&2
+  exit 1
+fi

--- a/Sources/Model/UsageModel.swift
+++ b/Sources/Model/UsageModel.swift
@@ -176,8 +176,13 @@ struct ProviderSnapshot: Identifiable, Equatable {
         case .accessDenied:
             // Says what happened and what fixes it. "Sign in to Claude Code"
             // would send someone who *is* signed in to fix the wrong thing.
-            return "Codenotch was refused access to \(displayName)'s saved "
-                 + "login. Click this ring to ask again, and choose Always Allow."
+            // Not "choose Always Allow". That writes the item's access list,
+            // and what refuses this read is its *partition list*, which no
+            // dialogue ever writes — so the button it points at cannot fix the
+            // problem, and an hour later the same advice is offered again.
+            return "macOS is holding \(displayName)'s saved login back from "
+                 + "Codenotch. Run Scripts/fix-keychain-partitions.sh once to "
+                 + "grant it."
         case .unsupported(let why): return why
         case .error(let why): return "Couldn't read usage — \(why)"
         case .stale, .ok:     return "Waiting for the first reading…"

--- a/Sources/Providers/ClaudeCredentials.swift
+++ b/Sources/Providers/ClaudeCredentials.swift
@@ -43,6 +43,24 @@ struct ClaudeCredentials {
     /// winner's actual data does, which is why it costs the same single prompt
     /// as before, per profile.
     static func read(service: String) throws -> ClaudeCredentials {
+        // Never raise a password dialogue from a poll. A menu-bar app on a
+        // timer has no business interrupting anyone, and this particular
+        // dialogue is one the user cannot get rid of: it comes from the item's
+        // *partition list*, not its access list, and "Always Allow" only
+        // writes the access list. Approving it buys exactly one read.
+        //
+        // `kSecUseAuthenticationUI` below is set for the same reason and is not
+        // enough on its own — it governs the data-protection keychain, and
+        // anything carrying a partition list is the old file-backed kind.
+        // Legacy items honour this call instead. With only the key set, the
+        // prompt still appeared once a minute.
+        //
+        // Process-wide, so it is restored in a `defer` on every path: leaving
+        // interaction off would silently break a prompt some other part of the
+        // app legitimately wants to show.
+        SecKeychainSetUserInteractionAllowed(false)
+        defer { SecKeychainSetUserInteractionAllowed(true) }
+
         guard let winner = KeychainItem.newest(service: service) else {
             Log.usage.error("keychain read failed: no item under \(service, privacy: .public)")
             throw UsageProviderError.needsAuth
@@ -53,8 +71,16 @@ struct ClaudeCredentials {
             kSecClass: kSecClassGenericPassword,
             kSecValuePersistentRef: winner.persistentRef,
             kSecReturnData: true,
-            kSecMatchLimit: kSecMatchLimitOne
+            kSecMatchLimit: kSecMatchLimitOne,
+            kSecUseAuthenticationUI: kSecUseAuthenticationUIFail
         ] as CFDictionary, &item)
+
+        // Refused, but the item is right there. Ask the one reader macOS never
+        // refuses before giving up — see `readViaSecurityTool`.
+        if Self.wasRefused(status), let rescued = Self.readViaSecurityTool(service: service) {
+            Log.usage.notice("\(service, privacy: .public) read via the security tool after a partition refusal")
+            return try decode(rescued, service: service)
+        }
 
         guard status == errSecSuccess, let data = item as? Data else {
             // The status matters: "not found" means the item was deleted
@@ -81,6 +107,12 @@ struct ClaudeCredentials {
                 : UsageProviderError.needsAuth
         }
 
+        return try decode(data, service: service)
+    }
+
+    /// Turn the stored JSON into a credential. Shared by both readers, so a
+    /// rescued read is judged identically to a direct one.
+    private static func decode(_ data: Data, service: String) throws -> ClaudeCredentials {
         struct Payload: Decodable {
             struct OAuth: Decodable {
                 let accessToken: String
@@ -101,6 +133,48 @@ struct ClaudeCredentials {
             expiresAt: Date(timeIntervalSince1970: payload.claudeAiOauth.expiresAt / 1000),
             subscriptionType: payload.claudeAiOauth.subscriptionType
         )
+    }
+
+    /// Read the item by shelling out to `/usr/bin/security`.
+    ///
+    /// The last resort, and the only one that survives what actually breaks
+    /// this. Claude Code does not update its keychain items, it recreates them
+    /// on every token rotation, and a freshly created item's partition list
+    /// contains just `apple-tool:`. Every app with a Team ID — this one
+    /// included — is evicted the moment that happens, and the only way back in
+    /// is the login password. `/usr/bin/security` is Apple-signed, so it *is*
+    /// `apple-tool:` and is never the one refused. Claude Code writes these
+    /// items through it, which is why it is always on the access list too.
+    ///
+    /// Not the primary path: it costs a process per read, and the direct
+    /// `SecItemCopyMatching` above is both cheaper and the honest way to ask.
+    /// This runs only after a refusal.
+    private static func readViaSecurityTool(service: String) -> Data? {
+        let tool = Process()
+        tool.executableURL = URL(fileURLWithPath: "/usr/bin/security")
+        // `-w` prints only the password. The account is this user, matching
+        // how Claude Code files it.
+        tool.arguments = ["find-generic-password", "-a", NSUserName(), "-s", service, "-w"]
+        let out = Pipe()
+        tool.standardOutput = out
+        tool.standardError = Pipe()
+        do {
+            try tool.run()
+        } catch {
+            Log.usage.error("could not run the security tool: \(error.localizedDescription, privacy: .public)")
+            return nil
+        }
+        // Read before waiting: a full pipe buffer with nobody draining it is a
+        // deadlock, and this payload is comfortably under the limit only until
+        // Claude Code adds another key to it.
+        let data = out.fileHandleForReading.readDataToEndOfFile()
+        tool.waitUntilExit()
+        guard tool.terminationStatus == 0 else { return nil }
+        // `-w` ends its output with a newline; an empty answer has to stay
+        // distinguishable from a newline-only one.
+        var trimmed = data
+        while trimmed.last == 0x0A || trimmed.last == 0x0D { trimmed.removeLast() }
+        return trimmed.isEmpty ? nil : trimmed
     }
 
     /// Which keychain refusal this was. "Not found" means Claude Code has never

--- a/Tests/AntigravityTests.swift
+++ b/Tests/AntigravityTests.swift
@@ -860,8 +860,14 @@ final class KeychainRefusalTests: XCTestCase {
             fidelity: .official, status: .accessDenied, windows: []
         )
         let message = snapshot.statusMessage ?? ""
-        XCTAssertTrue(message.contains("refused"))
-        XCTAssertTrue(message.contains("Always Allow"))
+        XCTAssertTrue(message.contains("holding"))
+        XCTAssertTrue(message.contains("fix-keychain-partitions"),
+                      "it has to name the one thing that actually grants access")
+        // "Always Allow" writes the access list; a partition-list refusal is
+        // untouched by it. Offering it sends someone to press a button that
+        // cannot work, and then to press it again an hour later.
+        XCTAssertFalse(message.contains("Always Allow"),
+                       "it offers a button that cannot fix a partition refusal")
         XCTAssertFalse(message.contains("Sign in"), "it tells a signed-in user to sign in")
     }
 


### PR DESCRIPTION
A keychain item has two gates. The access list is what "Always Allow" writes
to. The **partition list** is written by no dialogue, and an app outside it is
refused before the access list is consulted — so approving the prompt records a
grant that is discarded on the next read.

Claude Code recreates its keychain items on every token rotation rather than
updating them (`cdat == mdat` on each new item), and a fresh item's partition
list holds only `apple-tool:`. That evicts any app with a Team ID — release
build included — roughly every eight hours:

```
securityd: ACL partition mismatch: client teamid:<TEAMID> ACL ( "apple-tool:" )
securityd: displaying keychain prompt for /Applications/Codenotch.app
```

Filed upstream as anthropics/claude-code#22144 (by the author of another menu
bar app) and closed as not planned, so it has to be handled here.

**Fix:** never raise the dialogue from a poll, and recover without it.
`SecKeychainSetUserInteractionAllowed(false)` is what legacy login-keychain
items honour — `kSecUseAuthenticationUI` alone governs the data-protection
keychain and is silently ignored by anything carrying a partition list, which
is every item involved. On a refusal, read through `/usr/bin/security`, which
is Apple-signed and therefore *is* `apple-tool:`:

```
codenotch:usage  Claude Code-credentials-<hash> read via the security tool after a partition refusal
```

A refusal even that cannot rescue stays `.accessDenied`, with copy naming the
one thing that restores direct access instead of a button that cannot.

Also corrects the CONTRIBUTING.md paragraph describing this as a
development-only annoyance.

**Tests:** 552 pass; the status copy has one. The fallback spawns a process
against the real keychain and the suppression is a process-wide macOS setting,
so neither is reachable in-process — `WebSessionProvider` has no unit tests for
the same reason. Verified on a machine that had the prompt once a minute: zero
prompts over seven minutes of active polling, including the partition refusal
above recovered silently.