### PR TITLE
Stop the back-off beating against the refresh tick

### DIFF
--- a/Sources/Providers/ClaudeOAuthProvider.swift
+++ b/Sources/Providers/ClaudeOAuthProvider.swift
@@ -56,8 +56,28 @@ actor ClaudeOAuthProvider: UsageProvider {
         self.retryNoEarlierThan = archive.loadBackoffUntil(providerID: profile.id)
     }
 
+    /// How close to expiry a back-off counts as already expired.
+    ///
+    /// The server hands back a 60s hint and `UsageStore` also ticks every 60s,
+    /// so the two run at the same period and the tick lands a few milliseconds
+    /// *before* the window opens — `retryAfter: 0.015` in the log. Refusing
+    /// that costs far more than the 15ms it saves: the caller is a timer, not a
+    /// retry loop, so the next attempt is not a moment later but a whole
+    /// refresh interval later. A 60s penalty silently becomes 120s and every
+    /// other tick is spent on nothing.
+    private let backoffSlack: TimeInterval = 1
+
+    /// Pure, so the resonance this exists to break can be tested without a
+    /// timer and a live endpoint.
+    nonisolated static func shouldHoldOff(until: Date?, slack: TimeInterval,
+                                          now: Date = Date()) -> Bool {
+        guard let until else { return false }
+        return until.timeIntervalSince(now) > slack
+    }
+
     func fetchSnapshot() async throws -> ProviderSnapshot {
-        if let retryNoEarlierThan, retryNoEarlierThan > Date() {
+        if Self.shouldHoldOff(until: retryNoEarlierThan, slack: backoffSlack),
+           let retryNoEarlierThan {
             let remaining = retryNoEarlierThan.timeIntervalSinceNow
             Log.usage.debug("skipping fetch, backing off for \(remaining, format: .fixed(precision: 0))s")
             throw UsageProviderError.rateLimited(retryAfter: remaining)

--- a/Tests/ClaudeOAuthProviderTests.swift
+++ b/Tests/ClaudeOAuthProviderTests.swift
@@ -13,6 +13,30 @@ import XCTest
 /// never touching the keychain or the network.
 final class ClaudeOAuthProviderTests: XCTestCase {
 
+    // MARK: - Back-off against the refresh tick
+
+    /// A window that opens in 15ms is open. Refusing it does not delay the
+    /// fetch by 15ms — the caller is a timer, so it delays it by a whole
+    /// refresh interval, and the server's 60s penalty becomes 120s.
+    func testAWindowAboutToOpenCountsAsOpen() {
+        let now = Date()
+        XCTAssertFalse(ClaudeOAuthProvider.shouldHoldOff(
+            until: now.addingTimeInterval(0.015), slack: 1, now: now))
+        XCTAssertFalse(ClaudeOAuthProvider.shouldHoldOff(
+            until: now.addingTimeInterval(0.42), slack: 1, now: now))
+    }
+
+    func testARealPenaltyIsStillHonoured() {
+        let now = Date()
+        XCTAssertTrue(ClaudeOAuthProvider.shouldHoldOff(
+            until: now.addingTimeInterval(45), slack: 1, now: now))
+    }
+
+    func testNoPenaltyMeansNoHoldOff() {
+        XCTAssertFalse(ClaudeOAuthProvider.shouldHoldOff(until: nil, slack: 1))
+    }
+
+
     override func tearDown() {
         StubEndpoint.reset([])
         super.tearDown()


### PR DESCRIPTION
The usage endpoint answers a 429 with a 60s hint, and `UsageStore` also ticks
every 60s. Running at the same period, a tick lands a few milliseconds *before*
the window opens:

```
codenotch:usage  claude-<profile> failed: rateLimited(retryAfter: 0.015)
codenotch:usage  claude-<profile> failed: rateLimited(retryAfter: 0.42)
```

Refusing there saves 15ms and costs a whole refresh interval, because the
caller is a timer rather than a retry loop — the next attempt is 60s away, not
a moment away. A 60s penalty becomes 120s, every other tick produces nothing,
and a rate-limited provider takes twice as long to recover as the server asked.

Treat a window with under a second left as open.

**Tests:** 555 pass. Extracted as a pure `shouldHoldOff(until:slack:now:)` so
the resonance is testable without a timer or a live endpoint; three cases added
to `ClaudeOAuthProviderTests`.