### PR TITLE
Retry a keychain read that failed for reasons outside the item

### DIFF
--- a/Sources/Providers/ClaudeCredentials.swift
+++ b/Sources/Providers/ClaudeCredentials.swift
@@ -126,7 +126,12 @@ struct ClaudeCredentials {
     /// would be needed. Security doesn't export a named constant for it, so
     /// the raw value is what there is to check.
     static func wasTransient(_ status: OSStatus) -> Bool {
-        status == -25320   // errSecInDarkWake
+        status == -25320       // errSecInDarkWake
+            // errAuthorizationInternal. What a refusal looks like when macOS
+            // decided a prompt was needed and there was no way to show one —
+            // observed five seconds before a clamshell sleep. The credential is
+            // untouched, so this is "not right now", not "signed out".
+            || status == -60008
     }
 
     static func explain(_ status: OSStatus) -> String {
@@ -152,7 +157,21 @@ final class ClaudeKeychain: @unchecked Sendable {
     /// Read once, then held until the token expires — see `CredentialCache`.
     /// Claude Code rotates this roughly hourly, so this is about one keychain
     /// read an hour instead of two a minute.
-    private let cache = CredentialCache<ClaudeCredentials> { $0.isExpired }
+    /// A refusal and an unanswerable prompt are both environmental: the item is
+    /// fine and macOS simply would not hand it over this time, so remembering
+    /// the failure against the item's modification date — which will not move —
+    /// is remembering it forever.
+    private let cache = CredentialCache<ClaudeCredentials>(
+        isEnvironmental: {
+            switch $0 {
+            case UsageProviderError.accessDenied, UsageProviderError.credentialExpired:
+                return true
+            default:
+                return false
+            }
+        },
+        isExpired: { $0.isExpired }
+    )
 
     init(service: String) {
         self.service = service

--- a/Sources/Providers/CredentialCache.swift
+++ b/Sources/Providers/CredentialCache.swift
@@ -32,6 +32,19 @@ final class CredentialCache<Credential>: @unchecked Sendable {
     private var lastError: Error?
 
     private let isExpired: (Credential) -> Bool
+    /// Whether a failure was about the *environment* rather than about the item.
+    ///
+    /// The stamp below is the right memory for a failure the item caused — a
+    /// payload that will not decode gives the same answer every time it is
+    /// read, so asking again is pure noise. It is exactly the wrong memory for
+    /// a failure the item had nothing to do with. A prompt that could not be
+    /// shown because the lid was closing does not change `mdat`, so
+    /// `alreadyAsked` stays true for as long as the owning app leaves the item
+    /// alone — forever, in practice. One such blip cost 2h42m of "signed out"
+    /// over a valid token, ended only by quitting the app.
+    ///
+    /// So these failures fall through to the *timer*, which does expire.
+    private let isEnvironmental: (Error) -> Bool
     /// How long to sit with what we have when the probe cannot tell us whether
     /// the item moved. Long enough not to nag, short enough that a rotation is
     /// picked up while you are still looking at the notch.
@@ -44,10 +57,12 @@ final class CredentialCache<Credential>: @unchecked Sendable {
     init(recheckAfter: TimeInterval = 5 * 60,
          retryAfterFailure: TimeInterval = 5 * 60,
          now: @escaping () -> Date = Date.init,
+         isEnvironmental: @escaping (Error) -> Bool = { _ in false },
          isExpired: @escaping (Credential) -> Bool) {
         self.recheckAfter = recheckAfter
         self.retryAfterFailure = retryAfterFailure
         self.now = now
+        self.isEnvironmental = isEnvironmental
         self.isExpired = isExpired
     }
 
@@ -110,7 +125,12 @@ final class CredentialCache<Credential>: @unchecked Sendable {
             lock.lock()
             // The attempt is recorded, the credential is not: a failure must
             // never be handed back as if it were one.
-            attemptedStamp = current
+            //
+            // `nil` for an environmental failure, so the stamp comparison
+            // cannot match and the retry falls to `retryAfterFailure`. Storing
+            // `current` here would pin the error to a version of an item that
+            // nothing is going to write again.
+            attemptedStamp = isEnvironmental(error) ? nil : current
             attemptedAt = now()
             lastError = error
             lock.unlock()

--- a/Tests/AntigravityTests.swift
+++ b/Tests/AntigravityTests.swift
@@ -367,6 +367,73 @@ final class AntigravityBridgeTests: XCTestCase {
 final class CredentialCacheTests: XCTestCase {
     private struct Token { let expired: Bool }
 
+    private enum Refusal: Error { case denied, brokenPayload }
+
+    /// The bug this exists for. A failure that was nothing to do with the item
+    /// used to be recorded against the item's modification date, and that date
+    /// does not move when macOS declines to show a prompt — so the error was
+    /// pinned to a version of the item nothing would ever write again, and the
+    /// read was never retried. It cost 2h42m of "signed out" over a token that
+    /// was valid the whole time.
+    func testAnEnvironmentalRefusalIsRetriedOnceItsTimerExpires() {
+        var reads = 0
+        var clock = Date(timeIntervalSince1970: 1_000)
+        let stamp = Date(timeIntervalSince1970: 500)   // never moves
+        let cache = CredentialCache<Token>(
+            retryAfterFailure: 60,
+            now: { clock },
+            isEnvironmental: { _ in true },
+            isExpired: { $0.expired }
+        )
+        for _ in 0..<3 {
+            _ = try? cache.value(itemModifiedAt: { stamp }) {
+                reads += 1
+                throw Refusal.denied
+            }
+        }
+        XCTAssertEqual(reads, 1, "the unchanged item should hold it off for now")
+
+        clock = clock.addingTimeInterval(120)
+        _ = try? cache.value(itemModifiedAt: { stamp }) {
+            reads += 1
+            throw Refusal.denied
+        }
+        XCTAssertEqual(reads, 2, "the timer expired, so it must ask again")
+    }
+
+    /// And the case the stamp is right for is untouched: a payload that will
+    /// not decode answers the same way every time, so re-reading an unchanged
+    /// item is pure noise.
+    func testAFailureCausedByTheItemStaysPinnedToIt() {
+        var reads = 0
+        var clock = Date(timeIntervalSince1970: 1_000)
+        let stamp = Date(timeIntervalSince1970: 500)
+        let cache = CredentialCache<Token>(
+            retryAfterFailure: 60,
+            now: { clock },
+            isEnvironmental: { _ in false },
+            isExpired: { $0.expired }
+        )
+        _ = try? cache.value(itemModifiedAt: { stamp }) {
+            reads += 1
+            throw Refusal.brokenPayload
+        }
+        clock = clock.addingTimeInterval(120)
+        _ = try? cache.value(itemModifiedAt: { stamp }) {
+            reads += 1
+            throw Refusal.brokenPayload
+        }
+        XCTAssertEqual(reads, 1, "an unchanged item cannot decode differently")
+    }
+
+    /// -60008 is what a refusal looks like when a prompt was needed and could
+    /// not be shown — seen five seconds before a clamshell sleep.
+    func testAPromptThatCouldNotBeShownIsTransientNotASignOut() {
+        XCTAssertTrue(ClaudeCredentials.wasTransient(-60008))
+        XCTAssertTrue(ClaudeCredentials.wasTransient(-25320))
+        XCTAssertFalse(ClaudeCredentials.wasTransient(errSecItemNotFound))
+    }
+
     func testItReadsOnceAndThenHoldsWhatItHas() throws {
         var reads = 0
         let cache = CredentialCache<Token> { $0.expired }


### PR DESCRIPTION
`CredentialCache` remembers a failed read against the item's modification date.
That is right for a failure the item caused — a payload that will not decode
gives the same answer every time, so re-reading an unchanged item is noise.

It is exactly wrong for a failure the item had nothing to do with. macOS
declining to show a prompt does not move `mdat`, so the error stays pinned to a
version of the item nothing will ever write again and the read is never
retried. One blip five seconds before a clamshell sleep produced 2h42m of
"signed out" over a token that was valid throughout — one logged error, then
fifty silent replays, ending only when the app was quit.

Environmental failures now fall through to `retryAfterFailure`, which does
expire. `-60008` (`errAuthorizationInternal`) joins `-25320` as transient for
the same reason: both mean "not right now", not "signed out" — and reporting a
sign-out also makes `supersedesHistory` discard the archived reading.

**Tests:** 555 pass. Three cases added to the existing `CredentialCacheTests`,
including the pinned-error regression and the case the stamp is still right for.