### PR TITLE
Keep the last reading when the owning app empties its own credential

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,12 +10,25 @@ make run                 # build and launch
 ```
 
 None of these need an Apple Developer account. `xcodebuild` ad-hoc signs a
-Debug build automatically, which is enough to run and debug locally. The one
-thing an unsigned build can't do is keep a keychain "Always Allow" grant across
-rebuilds — Claude Code's and Antigravity's credentials are guarded by an ACL
-keyed on the signing identity, and an ad-hoc identity changes every build. In
-practice this means the keychain prompt reappears each time you rebuild during
-development; that's expected and doesn't affect anything else.
+Debug build automatically, which is enough to run and debug locally. An ad-hoc
+identity changes every build, so a keychain "Always Allow" grant does not
+survive a rebuild and the prompt reappears during development.
+
+That prompt is no longer shown, in Debug or in a release build. It was never
+only a development annoyance: a keychain item has an access list, which is what
+"Always Allow" writes to, and a *partition list*, which nothing in the GUI ever
+writes to. An app outside the partition list is refused before the access list
+is consulted, so approving the dialogue is good for exactly one read. Claude
+Code recreates its keychain items on every token rotation rather than updating
+them, and a freshly created item's partition list holds only `apple-tool:` —
+which evicts a properly signed release build just as surely as an ad-hoc one.
+Shipped users got the dialogue on a timer.
+
+`ClaudeCredentials.read` therefore disables keychain interaction for the length
+of the read and falls back to `/usr/bin/security`, which is Apple-signed and so
+is never the client that gets refused. A refusal it cannot recover from becomes
+`.accessDenied`, and `Scripts/fix-keychain-partitions.sh` is the one thing that
+actually restores direct access.
 
 `make release` is different: it archives, signs with a Developer ID
 certificate, notarizes with Apple, and regenerates the Sparkle auto-update

--- a/Scripts/fix-keychain-partitions.sh
+++ b/Scripts/fix-keychain-partitions.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+# Add Codenotch's Team ID to the partition list of every Claude Code keychain
+# item.
+#
+# Why this is needed at all: a keychain item carries two separate gates. The
+# ACL says *which apps* may read it — that is the list "Always Allow" writes
+# to. The partition list says which *code-signing partitions* may read it, and
+# nothing in the GUI ever writes to that one. An app whose signing identity is
+# outside the partition list is refused before the ACL is even consulted, so
+# clicking Always Allow records an approval that is discarded on the next read.
+# That is the prompt-every-60-seconds loop.
+#
+# Codenotch used to be ad-hoc signed, so its identity was a cdhash that changed
+# on every build; now it is signed with a real Team ID and the identity is
+# stable, but these items were written before that and only list "apple-tool:"
+# (the /usr/bin/security CLI, which is how Claude Code writes them).
+#
+# Run once. The password is read silently and passed on stdin, never on argv,
+# because argv is readable by any process via ps.
+set -euo pipefail
+
+TEAM_ID="$(codesign -dv /Applications/Codenotch.app 2>&1 | sed -nE 's/^TeamIdentifier=([A-Z0-9]{10})$/\1/p')"
+if [ -z "$TEAM_ID" ] || [ "$TEAM_ID" = "not" ]; then
+  echo "Codenotch is not signed with a Team ID — rebuild with 'make install' first." >&2
+  exit 1
+fi
+
+# apple-tool: and apple: are kept, not replaced: Claude Code and the token
+# refresher both reach these items through /usr/bin/security, and dropping
+# apple-tool: would lock *them* out to let Codenotch in.
+PARTITIONS="apple-tool:,apple:,teamid:${TEAM_ID}"
+
+# Claude Code's own naming rule: the bare service for ~/.claude, and a suffix
+# of the first 8 hex of sha256(absolute path) for every other profile.
+services() {
+  echo "Claude Code-credentials"
+  for dir in "$HOME"/.claude-*; do
+    [ -d "$dir" ] || continue
+    [ -e "$dir/.credentials.json" ] || [ -e "$dir/settings.json" ] || continue
+    printf 'Claude Code-credentials-%s\n' \
+      "$(printf '%s' "$dir" | shasum -a 256 | cut -c1-8)"
+  done
+}
+
+printf 'Login keychain password: '
+read -rs PASSWORD
+printf '\n\n'
+
+failed=0
+while IFS= read -r service; do
+  # Skip items that do not exist rather than reporting a failure for them.
+  if ! /usr/bin/security find-generic-password -a "$USER" -s "$service" >/dev/null 2>&1; then
+    echo "  skip  $service (no such item)"
+    continue
+  fi
+  if printf '%s' "$PASSWORD" | /usr/bin/security set-generic-password-partition-list \
+       -a "$USER" -s "$service" -S "$PARTITIONS" >/dev/null 2>&1; then
+    echo "  ok    $service"
+  else
+    echo "  FAIL  $service"
+    failed=1
+  fi
+done < <(services)
+
+unset PASSWORD
+echo
+if [ "$failed" -eq 0 ]; then
+  echo "Done. Partition list is now: $PARTITIONS"
+  echo "Codenotch should stop asking for the password."
+else
+  echo "Some items could not be updated — check the password and re-run." >&2
+  exit 1
+fi

--- a/Sources/Model/UsageModel.swift
+++ b/Sources/Model/UsageModel.swift
@@ -176,8 +176,13 @@ struct ProviderSnapshot: Identifiable, Equatable {
         case .accessDenied:
             // Says what happened and what fixes it. "Sign in to Claude Code"
             // would send someone who *is* signed in to fix the wrong thing.
-            return "Codenotch was refused access to \(displayName)'s saved "
-                 + "login. Click this ring to ask again, and choose Always Allow."
+            // Not "choose Always Allow". That writes the item's access list,
+            // and what refuses this read is its *partition list*, which no
+            // dialogue ever writes — so the button it points at cannot fix the
+            // problem, and an hour later the same advice is offered again.
+            return "macOS is holding \(displayName)'s saved login back from "
+                 + "Codenotch. Run Scripts/fix-keychain-partitions.sh once to "
+                 + "grant it."
         case .unsupported(let why): return why
         case .error(let why): return "Couldn't read usage — \(why)"
         case .stale, .ok:     return "Waiting for the first reading…"

--- a/Sources/Model/UsageModel.swift
+++ b/Sources/Model/UsageModel.swift
@@ -15,6 +15,9 @@ enum ProviderStatus: Equatable {
     case ok
     case stale(since: Date)
     case needsAuth
+    /// The owning app emptied its own credential. Distinct from `needsAuth`
+    /// because the last reading is kept — see `UsageProviderError`.
+    case signedOutByOwner
     /// macOS was asked for a credential that exists, and refused.
     case accessDenied
     case unsupported(String)
@@ -173,6 +176,14 @@ struct ProviderSnapshot: Identifiable, Equatable {
         if hasReading { return nil }
         switch status {
         case .needsAuth:      return authPrompt
+        case .signedOutByOwner:
+            // Names the cause, because "sign in again" on its own invites the
+            // reasonable conclusion that this app lost the login.
+            let again = authPrompt.replacingOccurrences(
+                of: "Sign in to", with: "Sign in again to")
+            return "Claude Code emptied this profile's saved login — it does "
+                 + "that to every profile at once after it updates itself. "
+                 + again
         case .accessDenied:
             // Says what happened and what fixes it. "Sign in to Claude Code"
             // would send someone who *is* signed in to fix the wrong thing.

--- a/Sources/Model/UsageStore.swift
+++ b/Sources/Model/UsageStore.swift
@@ -392,6 +392,10 @@ final class UsageStore: ObservableObject {
         // and still valid, we were simply not let in to re-read it. Discarding
         // the last number would punish someone for pressing the wrong button.
         case .accessDenied:            return false
+        // The account was not closed and the numbers were not wrong — the
+        // owning app dropped its own token. Blanking the ring here is what
+        // turned a recurring overnight glitch into apparent data loss.
+        case .signedOutByOwner:        return false
         case .ok, .stale, .error:      return false
         }
     }
@@ -418,6 +422,8 @@ final class UsageStore: ObservableObject {
             // Not an error the user can do anything about, and the last good
             // reading is still roughly true, so it reads as staleness.
             return .stale(since: Date())
+        case UsageProviderError.signedOutByOwner:
+            return .signedOutByOwner
         case UsageProviderError.accessDenied:
             return .accessDenied
         case UsageProviderError.nothingMetered(let why):

--- a/Sources/Providers/ClaudeCredentials.swift
+++ b/Sources/Providers/ClaudeCredentials.swift
@@ -43,6 +43,24 @@ struct ClaudeCredentials {
     /// winner's actual data does, which is why it costs the same single prompt
     /// as before, per profile.
     static func read(service: String) throws -> ClaudeCredentials {
+        // Never raise a password dialogue from a poll. A menu-bar app on a
+        // timer has no business interrupting anyone, and this particular
+        // dialogue is one the user cannot get rid of: it comes from the item's
+        // *partition list*, not its access list, and "Always Allow" only
+        // writes the access list. Approving it buys exactly one read.
+        //
+        // `kSecUseAuthenticationUI` below is set for the same reason and is not
+        // enough on its own — it governs the data-protection keychain, and
+        // anything carrying a partition list is the old file-backed kind.
+        // Legacy items honour this call instead. With only the key set, the
+        // prompt still appeared once a minute.
+        //
+        // Process-wide, so it is restored in a `defer` on every path: leaving
+        // interaction off would silently break a prompt some other part of the
+        // app legitimately wants to show.
+        SecKeychainSetUserInteractionAllowed(false)
+        defer { SecKeychainSetUserInteractionAllowed(true) }
+
         guard let winner = KeychainItem.newest(service: service) else {
             Log.usage.error("keychain read failed: no item under \(service, privacy: .public)")
             throw UsageProviderError.needsAuth
@@ -53,8 +71,16 @@ struct ClaudeCredentials {
             kSecClass: kSecClassGenericPassword,
             kSecValuePersistentRef: winner.persistentRef,
             kSecReturnData: true,
-            kSecMatchLimit: kSecMatchLimitOne
+            kSecMatchLimit: kSecMatchLimitOne,
+            kSecUseAuthenticationUI: kSecUseAuthenticationUIFail
         ] as CFDictionary, &item)
+
+        // Refused, but the item is right there. Ask the one reader macOS never
+        // refuses before giving up — see `readViaSecurityTool`.
+        if Self.wasRefused(status), let rescued = Self.readViaSecurityTool(service: service) {
+            Log.usage.notice("\(service, privacy: .public) read via the security tool after a partition refusal")
+            return try decode(rescued, service: service)
+        }
 
         guard status == errSecSuccess, let data = item as? Data else {
             // The status matters: "not found" means the item was deleted
@@ -81,6 +107,12 @@ struct ClaudeCredentials {
                 : UsageProviderError.needsAuth
         }
 
+        return try decode(data, service: service)
+    }
+
+    /// Turn the stored JSON into a credential. Shared by both readers, so a
+    /// rescued read is judged identically to a direct one.
+    private static func decode(_ data: Data, service: String) throws -> ClaudeCredentials {
         struct Payload: Decodable {
             struct OAuth: Decodable {
                 let accessToken: String
@@ -101,6 +133,48 @@ struct ClaudeCredentials {
             expiresAt: Date(timeIntervalSince1970: payload.claudeAiOauth.expiresAt / 1000),
             subscriptionType: payload.claudeAiOauth.subscriptionType
         )
+    }
+
+    /// Read the item by shelling out to `/usr/bin/security`.
+    ///
+    /// The last resort, and the only one that survives what actually breaks
+    /// this. Claude Code does not update its keychain items, it recreates them
+    /// on every token rotation, and a freshly created item's partition list
+    /// contains just `apple-tool:`. Every app with a Team ID — this one
+    /// included — is evicted the moment that happens, and the only way back in
+    /// is the login password. `/usr/bin/security` is Apple-signed, so it *is*
+    /// `apple-tool:` and is never the one refused. Claude Code writes these
+    /// items through it, which is why it is always on the access list too.
+    ///
+    /// Not the primary path: it costs a process per read, and the direct
+    /// `SecItemCopyMatching` above is both cheaper and the honest way to ask.
+    /// This runs only after a refusal.
+    private static func readViaSecurityTool(service: String) -> Data? {
+        let tool = Process()
+        tool.executableURL = URL(fileURLWithPath: "/usr/bin/security")
+        // `-w` prints only the password. The account is this user, matching
+        // how Claude Code files it.
+        tool.arguments = ["find-generic-password", "-a", NSUserName(), "-s", service, "-w"]
+        let out = Pipe()
+        tool.standardOutput = out
+        tool.standardError = Pipe()
+        do {
+            try tool.run()
+        } catch {
+            Log.usage.error("could not run the security tool: \(error.localizedDescription, privacy: .public)")
+            return nil
+        }
+        // Read before waiting: a full pipe buffer with nobody draining it is a
+        // deadlock, and this payload is comfortably under the limit only until
+        // Claude Code adds another key to it.
+        let data = out.fileHandleForReading.readDataToEndOfFile()
+        tool.waitUntilExit()
+        guard tool.terminationStatus == 0 else { return nil }
+        // `-w` ends its output with a newline; an empty answer has to stay
+        // distinguishable from a newline-only one.
+        var trimmed = data
+        while trimmed.last == 0x0A || trimmed.last == 0x0D { trimmed.removeLast() }
+        return trimmed.isEmpty ? nil : trimmed
     }
 
     /// Which keychain refusal this was. "Not found" means Claude Code has never

--- a/Sources/Providers/ClaudeCredentials.swift
+++ b/Sources/Providers/ClaudeCredentials.swift
@@ -128,6 +128,18 @@ struct ClaudeCredentials {
             throw UsageProviderError.needsAuth
         }
 
+        // A present-but-emptied credential is a real state, not a theoretical
+        // one: Claude Code rewrites this item with `accessToken: ""`, no
+        // refresh token and `expiresAt: 0`. It decodes perfectly and is worth
+        // nothing. Left alone it becomes `Bearer ` on the wire and a puzzling
+        // 401. Reporting it as `needsAuth` is worse still — that means "never
+        // signed in", which makes `supersedesHistory` erase a perfectly good
+        // archived reading every time the owning app does this.
+        guard !payload.claudeAiOauth.accessToken.isEmpty else {
+            Log.usage.error("\(service, privacy: .public) holds an emptied credential — needs a fresh sign-in")
+            throw UsageProviderError.signedOutByOwner
+        }
+
         return ClaudeCredentials(
             accessToken: payload.claudeAiOauth.accessToken,
             expiresAt: Date(timeIntervalSince1970: payload.claudeAiOauth.expiresAt / 1000),

--- a/Sources/Providers/UsageProvider.swift
+++ b/Sources/Providers/UsageProvider.swift
@@ -55,6 +55,17 @@ enum UsageProviderError: Error {
     /// refresh it the next time it runs. Not the same as being signed out: the
     /// last reading is still true, just old.
     case credentialExpired
+    /// The owning app emptied its own stored credential — the keychain item is
+    /// still there, with an empty token in it.
+    ///
+    /// Not the same as `needsAuth`, and the difference decides whether the last
+    /// reading survives. `needsAuth` means nobody ever signed in here, so there
+    /// is nothing to show. This means somebody *was* signed in, worked, and had
+    /// the credential taken out from under them. Claude Code does exactly that
+    /// to every profile at once after it auto-updates and then wakes from sleep
+    /// (anthropics/claude-code#19456, closed as not planned). The numbers taken
+    /// before that happened are still the truth about the account.
+    case signedOutByOwner
     /// The endpoint answered, but not with anything we understand.
     case badResponse(status: Int)
     /// Asked to slow down. Carries the server's own retry hint when it gave one.

--- a/Tests/AntigravityTests.swift
+++ b/Tests/AntigravityTests.swift
@@ -871,6 +871,38 @@ final class KeychainRefusalTests: XCTestCase {
         XCTAssertFalse(message.contains("Sign in"), "it tells a signed-in user to sign in")
     }
 
+    /// An emptied credential is not the same as never having signed in, and
+    /// the difference is the whole point: the last reading survives. Claude
+    /// Code empties every profile at once after it updates itself, and blanking
+    /// the rings turned an overnight glitch into "the app lost my data".
+    func testAnEmptiedCredentialKeepsTheLastReading() {
+        XCTAssertFalse(UsageStore.supersedesHistory(.signedOutByOwner))
+    }
+
+    /// Whereas a profile nobody ever signed into has nothing worth keeping.
+    func testNeverSignedInStillClearsTheHistory() {
+        XCTAssertTrue(UsageStore.supersedesHistory(.needsAuth))
+    }
+
+    func testAnEmptiedCredentialMapsToItsOwnStatus() {
+        guard case .signedOutByOwner =
+            UsageStore.statusForTesting(UsageProviderError.signedOutByOwner) else {
+            return XCTFail("an emptied credential was reported as something else")
+        }
+    }
+
+    func testTheMessageNamesTheCauseAndSaysSignInAgain() {
+        let snapshot = ProviderSnapshot(
+            id: "claude-work", displayName: "Claude (work)", glyph: .claude,
+            fidelity: .official, status: .signedOutByOwner, windows: []
+        )
+        let message = snapshot.statusMessage ?? ""
+        XCTAssertTrue(message.contains("Claude Code emptied"))
+        XCTAssertTrue(message.contains("updates itself"),
+                      "it has to name the trigger, or this reads as our bug")
+        XCTAssertTrue(message.contains("Sign in again"))
+    }
+
     /// The credential is still valid — we were simply not let in to re-read it.
     /// Throwing the last reading away would punish a mis-click.
     func testARefusalKeepsTheLastReading() {

--- a/Tests/AntigravityTests.swift
+++ b/Tests/AntigravityTests.swift
@@ -860,8 +860,14 @@ final class KeychainRefusalTests: XCTestCase {
             fidelity: .official, status: .accessDenied, windows: []
         )
         let message = snapshot.statusMessage ?? ""
-        XCTAssertTrue(message.contains("refused"))
-        XCTAssertTrue(message.contains("Always Allow"))
+        XCTAssertTrue(message.contains("holding"))
+        XCTAssertTrue(message.contains("fix-keychain-partitions"),
+                      "it has to name the one thing that actually grants access")
+        // "Always Allow" writes the access list; a partition-list refusal is
+        // untouched by it. Offering it sends someone to press a button that
+        // cannot work, and then to press it again an hour later.
+        XCTAssertFalse(message.contains("Always Allow"),
+                       "it offers a button that cannot fix a partition refusal")
         XCTAssertFalse(message.contains("Sign in"), "it tells a signed-in user to sign in")
     }
 


### PR DESCRIPTION
> **Stacked on #117** — it needs the shared decode path extracted there, so this
> branch contains that commit too. Merge #117 first and this reduces to a single
> commit touching 4 files.

Claude Code rewrites its keychain item with an empty access token, no refresh
token and `expiresAt: 0`. It decodes perfectly and is worth nothing. Reading it
reported `needsAuth`, which means "nobody ever signed in here" — and
`supersedesHistory` treats that as reason to erase the archived reading.

So a glitch in another program empties the notch. Three profiles went at once,
within two seconds, after Claude Code auto-updated overnight and the machine
woke:

```
security[94183] integrity: no previous integrity acl exists; making a new one   (x6)
codenotch:usage  Claude Code-credentials-<hash> holds an emptied credential
```

That is anthropics/claude-code#19456, closed as not planned; nothing here can
prevent it.

What this side can do is tell the two states apart. An item that exists and has
been hollowed out is evidence somebody *was* signed in and did work, so the
numbers from before are still true about the account. `signedOutByOwner` keeps
them, shows them as stale, and says what happened — while `needsAuth` still
blanks a profile nobody has ever used.

**Tests:** 556 pass. Four cases added beside the existing refusal tests:
history retention, that `needsAuth` still clears, the error/status mapping, and
the copy.