### PR TITLE
Add Simplified Chinese for 1.8 copy

### DIFF
--- a/Sources/Localizable.xcstrings
+++ b/Sources/Localizable.xcstrings
@@ -5950,6 +5950,798 @@
           }
         }
       }
+    },
+    "complete": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已完成"
+          }
+        }
+      }
+    },
+    "Complete": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已完成"
+          }
+        }
+      }
+    },
+    "Waiting": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "等待中"
+          }
+        }
+      }
+    },
+    "Local Session": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "本地会话"
+          }
+        }
+      }
+    },
+    "Active": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "使用中"
+          }
+        }
+      }
+    },
+    "Ensure Antigravity IDE is running to read this account.": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "请先运行 Antigravity IDE，才能读取此账号。"
+          }
+        }
+      }
+    },
+    "Automatic": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自动"
+          }
+        }
+      }
+    },
+    "5-Hour Limit": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "5 小时额度"
+          }
+        }
+      }
+    },
+    "Weekly Limit": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "每周额度"
+          }
+        }
+      }
+    },
+    "Liquid Glass": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "液态玻璃"
+          }
+        }
+      }
+    },
+    "Solid black": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "纯黑"
+          }
+        }
+      }
+    },
+    "System Liquid Glass. Follows this Mac's Appearance settings, including Clear or Tinted glass and light or dark mode.": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "系统液态玻璃。跟随这台 Mac 的外观设置，包括通透或着色玻璃，以及浅色或深色模式。"
+          }
+        }
+      }
+    },
+    "The original opaque black notch. Always dark, whatever the Mac's appearance.": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "原来的不透明黑刘海。无论 Mac 外观如何，始终是深色。"
+          }
+        }
+      }
+    },
+    "A second ring for the week, Liquid Glass, French, and Claude Desktop read straight from its own cache.": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "周额度有了自己的圆环，液态玻璃，法语，以及直接从 Claude Desktop 自己的缓存读取用量。"
+          }
+        }
+      }
+    },
+    "The week gets a ring of its own": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "周额度有了自己的圆环"
+          }
+        }
+      }
+    },
+    "A second arc, inside the headline ring or outside it, for providers that publish a weekly limit as well as a session one. Off by default; Appearance has the switch.": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "第二条弧，画在主环内侧或外侧，给同时公布每周额度和会话额度的服务。默认关闭；外观里有开关。"
+          }
+        }
+      }
+    },
+    "The open notch, its tooltip and the settings orb take the system's own glass surface, so they refract what is behind them instead of sitting on it. Reduce Transparency turns it solid.": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "展开的刘海、提示卡和设置圆球用上系统自己的玻璃表面，折射背后的内容，而不是盖在上面。「降低透明度」会变成实心。"
+          }
+        }
+      }
+    },
+    "Français": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Français"
+          }
+        }
+      }
+    },
+    "A third language in Appearance, alongside English and 简体中文.": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "外观里第三种语言，与 English 和 简体中文并列。"
+          }
+        }
+      }
+    },
+    "Claude Desktop usage, read from its own cache": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Claude Desktop 用量，从它自己的缓存读取"
+          }
+        }
+      }
+    },
+    "A third way to read a Claude account, used when the CLI and the token cannot answer. Nothing is sent anywhere: the cache is on this Mac and is only decompressed.": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "读取 Claude 账号的第三条路径，在 CLI 和令牌答不上来时使用。什么都不会发出去：缓存就在这台 Mac 上，只做解压。"
+          }
+        }
+      }
+    },
+    "Claude Code found where npm puts it": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "能找到 npm 安装的 Claude Code"
+          }
+        }
+      }
+    },
+    "An install under nvm, Volta or pnpm is discovered like any other, which also restores the background sign-in renewal for those setups.": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "nvm、Volta 或 pnpm 下的安装也会被找到，这些安装的后台登录续期也一并恢复。"
+          }
+        }
+      }
+    },
+    "No more transcript folders left behind": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "不再留下 transcript 文件夹"
+          }
+        }
+      }
+    },
+    "Reading Claude usage ran in a fresh directory every poll, and Claude Code filed a transcript folder for each one. It now runs from a single place, in print mode, writing no session at all.": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "以前每次轮询 Claude 用量都在一个新目录里跑，Claude Code 会给每一次建一个 transcript 文件夹。现在固定在一处、以 print 模式运行，不再写任何会话。"
+          }
+        }
+      }
+    },
+    "Reset times follow the Mac's clock": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重置时间跟随 Mac 的时钟"
+          }
+        }
+      }
+    },
+    "A 24-hour Mac gets 24-hour reset times instead of AM and PM.": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "24 小时制的 Mac 会显示 24 小时制的重置时间，而不是上午、下午。"
+          }
+        }
+      }
+    },
+    "A finished session says so": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "结束的会话会标明"
+          }
+        }
+      }
+    },
+    "Agent sessions carry a success state, so a run that has completed reads differently from one still going.": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "助手会话带有完成状态，已经跑完的和还在进行的看起来不一样。"
+          }
+        }
+      }
+    },
+    "Antigravity: choose which limit leads": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Antigravity：选择哪项额度打头"
+          }
+        }
+      }
+    },
+    "The headline ring can follow a named limit rather than whichever happens to be tightest, and a CLI-only install counts as a real account.": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "主圆环可以跟着指定的额度走，而不一定是最紧的那项；只有 CLI 的安装也算真实账号。"
+          }
+        }
+      }
+    },
+    "Only the hardware notch wakes a notch joined to it": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "只有硬件刘海才会唤醒贴上去的刘海"
+          }
+        }
+      }
+    },
+    "A notch merged with the camera housing no longer wakes from a pointer anywhere along the whole top edge.": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "和摄像头凹槽合在一起的刘海，不再被整条上边缘任意位置的指针唤醒。"
+          }
+        }
+      }
+    },
+    "Weekly ring": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "每周圆环"
+          }
+        }
+      }
+    },
+    "Surface": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "表面"
+          }
+        }
+      }
+    },
+    "Notch reads": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "刘海显示"
+          }
+        }
+      }
+    },
+    "Choose which limit appears in the main notch for Antigravity.": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "选择 Antigravity 在主刘海里显示哪项额度。"
+          }
+        }
+      }
+    },
+    "Off": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "关闭"
+          }
+        }
+      }
+    },
+    "Inside": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "内侧"
+          }
+        }
+      }
+    },
+    "Outside": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "外侧"
+          }
+        }
+      }
+    },
+    "One ring per provider, showing the headline limit. The weekly allowance stays in the hover card.": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "每个服务一个圆环，显示主额度。每周额度仍在提示卡里。"
+          }
+        }
+      }
+    },
+    "A thinner ring for the weekly limit, drawn inside the main one. It shares the gap with the working indicator.": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "一条更细的每周额度圆环，画在主环内侧。和工作指示共用那个空隙。"
+          }
+        }
+      }
+    },
+    "A thinner ring for the weekly limit, drawn around the main one, in the margin between the ring and the notch edge.": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "一条更细的每周额度圆环，画在主环外侧，圆环和刘海边缘之间的空隙里。"
+          }
+        }
+      }
+    },
+    "Run %@ in Terminal to sign in to %@.": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在终端运行 %@ 以登录 %@。"
+          }
+        }
+      }
+    },
+    "Requests today · last used %@": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "今日请求 · 上次使用 %@"
+          }
+        }
+      }
+    },
+    "yesterday": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "昨天"
+          }
+        }
+      }
+    },
+    "%lld days ago": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld 天前"
+          }
+        }
+      }
+    },
+    "Personal": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "个人"
+          }
+        }
+      }
+    },
+    "Gemini Models": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gemini 模型"
+          }
+        }
+      }
+    },
+    "5-hour Limit": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "5 小时额度"
+          }
+        }
+      }
+    },
+    "Claude and GPT models": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Claude 和 GPT 模型"
+          }
+        }
+      }
+    },
+    "Question": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "提问"
+          }
+        }
+      }
+    },
+    "Approval": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "批准"
+          }
+        }
+      }
+    },
+    "Permission": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "权限"
+          }
+        }
+      }
+    },
+    "needs your input": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "需要你的输入"
+          }
+        }
+      }
+    },
+    "Working in %@": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在 %@ 中工作"
+          }
+        }
+      }
+    },
+    "Connection": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "连接"
+          }
+        }
+      }
+    },
+    "Preset": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "预设"
+          }
+        }
+      }
+    },
+    "Custom": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自定"
+          }
+        }
+      }
+    },
+    "Preset size": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "预设大小"
+          }
+        }
+      }
+    },
+    "Scales the whole surface — rings, text and tooltip together — so the proportions stay as drawn. 100% is the size the notch was designed at.": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "整体缩放表面 — 圆环、文字和提示卡一起变，比例保持原样。100% 是刘海设计时的尺寸。"
+          }
+        }
+      }
+    },
+    "Ollama API key": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ollama API 密钥"
+          }
+        }
+      }
+    },
+    "Paste your key": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "粘贴密钥"
+          }
+        }
+      }
+    },
+    "Save": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "保存"
+          }
+        }
+      }
+    },
+    "Saved": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已保存"
+          }
+        }
+      }
+    },
+    "%@ usage needs its sign-in renewed — run `claude` once in a terminal.": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 用量需要重新登录 — 在终端里运行一次 `claude`。"
+          }
+        }
+      }
+    },
+    "%@ %@ · via Ollama": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ %@ · 来自 Ollama"
+          }
+        }
+      }
+    },
+    "Hidden from the notch · Loaded in Ollama": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已从刘海隐藏 · 仍加载在 Ollama"
+          }
+        }
+      }
+    },
+    "Show or hide this model in the notch. It stays loaded in Ollama.": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在刘海里显示或隐藏此模型。它仍加载在 Ollama 中。"
+          }
+        }
+      }
+    },
+    "Thinking": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "思考中"
+          }
+        }
+      }
+    },
+    "%@ · Local": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ · 本地"
+          }
+        }
+      }
+    },
+    "No Ollama usage recorded yet for this period.": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "这段时间还没有 Ollama 用量记录。"
+          }
+        }
+      }
     }
   },
   "version": "1.0"

--- a/Sources/Providers/AntigravityActivity.swift
+++ b/Sources/Providers/AntigravityActivity.swift
@@ -122,9 +122,9 @@ struct AntigravityActivity: Equatable {
     /// unnoticed. Saying when it *was* last used tells the two apart.
     func label(now: Date = Date()) -> String {
         guard requestsToday == 0, let lastRequest else {
-            return "Requests today · no limit published"
+            return L10n.t("Requests today · no limit published")
         }
-        return "Requests today · last used \(Self.lastUsed(lastRequest, now: now))"
+        return L10n.t("Requests today · last used \(Self.lastUsed(lastRequest, now: now))")
     }
 
     /// Counted in calendar days, not in elapsed time, because the number beside
@@ -148,8 +148,8 @@ struct AntigravityActivity: Equatable {
 
         switch days {
         case ..<1:  return ElapsedCopy.ago(since: date, now: now)
-        case 1:     return "yesterday"
-        default:    return "\(days) days ago"
+        case 1:     return L10n.t("yesterday")
+        default:    return L10n.t("\(days) days ago")
         }
     }
 }

--- a/Sources/Providers/AntigravityProvider.swift
+++ b/Sources/Providers/AntigravityProvider.swift
@@ -67,7 +67,7 @@ actor AntigravityProvider: UsageProvider {
     nonisolated func account() -> ProviderAccount? {
         if AntigravityCredentials.isSignedIn(), let held = AntigravityCredentials.held {
             let email = held.email
-            let plan = held.authMethod == "consumer" ? "Personal" : held.authMethod
+            let plan = held.authMethod == "consumer" ? L10n.t("Personal") : held.authMethod
             return ProviderAccount(
                 label: email,
                 plan: plan,
@@ -267,29 +267,20 @@ actor AntigravityProvider: UsageProvider {
                 (group.buckets ?? []).compactMap { bucket in
                     let rawID = bucket.bucketId ?? bucket.modelId ?? bucket.name ?? group.displayName ?? "quota"
                     if let remaining = bucket.remainingFraction, remaining >= 0, remaining <= 1 {
-                        var bucketLabel = bucket.displayName ?? L10n.t("Usage")
-                        if bucketLabel.hasSuffix(" Remaining") {
-                            bucketLabel = String(bucketLabel.dropLast(" Remaining".count))
-                        }
-                        if bucketLabel == "Five Hour Limit" {
-                            bucketLabel = "5-hour Limit"
-                        }
-                        let groupLabel = group.displayName ?? ""
                         return LimitWindow(
                             id: rawID,
-                            group: groupLabel.isEmpty ? nil : groupLabel,
-                            label: bucketLabel,
+                            group: quotaGroupName(group.displayName),
+                            label: quotaWindowLabel(bucket.displayName ?? L10n.t("Usage")),
                             usedFraction: 1 - remaining,
                             resetsAt: bucket.resetTime.flatMap(AntigravityCredentials.parse),
                             duration: bucket.window == "weekly" ? 7 * 86400 : nil
                         )
                     }
                     if let limit = bucket.limit, limit > 0, let used = bucket.used, used >= 0, used <= limit * 1.5 {
-                        let label = bucket.displayName ?? rawID
                         return LimitWindow(
                             id: rawID,
-                            group: group.displayName,
-                            label: label,
+                            group: quotaGroupName(group.displayName),
+                            label: quotaWindowLabel(bucket.displayName ?? rawID),
                             usedFraction: used / limit,
                             resetsAt: bucket.resetTime.flatMap(AntigravityCredentials.parse)
                         )
@@ -309,10 +300,9 @@ actor AntigravityProvider: UsageProvider {
                       let used = bucket.used, used >= 0, used <= limit * 1.5
                 else { return nil }
                 let rawID = bucket.name ?? bucket.modelId ?? bucket.bucketId ?? "quota"
-                let label = bucket.displayName ?? rawID
                 return LimitWindow(
                     id: rawID,
-                    label: label,
+                    label: quotaWindowLabel(bucket.displayName ?? rawID),
                     usedFraction: used / limit,
                     resetsAt: bucket.resetTime.flatMap(AntigravityCredentials.parse)
                 )
@@ -360,16 +350,16 @@ actor AntigravityProvider: UsageProvider {
         }
 
         var windows: [LimitWindow] = []
-        if let w = aggregate(candidates: geminiHourly, id: "gemini-hourly", group: "Gemini Models", label: "5-hour Limit", isWeekly: false) {
+        if let w = aggregate(candidates: geminiHourly, id: "gemini-hourly", group: L10n.t("Gemini Models"), label: L10n.t("5-hour Limit"), isWeekly: false) {
             windows.append(w)
         }
-        if let w = aggregate(candidates: geminiWeekly, id: "gemini-weekly", group: "Gemini Models", label: "Weekly Limit", isWeekly: true) {
+        if let w = aggregate(candidates: geminiWeekly, id: "gemini-weekly", group: L10n.t("Gemini Models"), label: L10n.t("Weekly Limit"), isWeekly: true) {
             windows.append(w)
         }
-        if let w = aggregate(candidates: thirdPartyHourly, id: "3p-hourly", group: "Claude and GPT models", label: "5-hour Limit", isWeekly: false) {
+        if let w = aggregate(candidates: thirdPartyHourly, id: "3p-hourly", group: L10n.t("Claude and GPT models"), label: L10n.t("5-hour Limit"), isWeekly: false) {
             windows.append(w)
         }
-        if let w = aggregate(candidates: thirdPartyWeekly, id: "3p-weekly", group: "Claude and GPT models", label: "Weekly Limit", isWeekly: true) {
+        if let w = aggregate(candidates: thirdPartyWeekly, id: "3p-weekly", group: L10n.t("Claude and GPT models"), label: L10n.t("Weekly Limit"), isWeekly: true) {
             windows.append(w)
         }
         return windows
@@ -430,9 +420,9 @@ actor AntigravityProvider: UsageProvider {
             let resetsAt = (resetsAtMs > 0) ? Date(timeIntervalSince1970: resetsAtMs / 1000.0) : nil
 
             let isGemini = limitId.contains(":google:") || rawLabel.contains("Google")
-            let groupName = isGemini ? "Gemini Models" : "Claude and GPT models"
+            let groupName = isGemini ? L10n.t("Gemini Models") : L10n.t("Claude and GPT models")
             let isWeekly = windowLabel.contains("weekly")
-            let labelName = isWeekly ? "Weekly Limit" : "5-hour Limit"
+            let labelName = isWeekly ? L10n.t("Weekly Limit") : L10n.t("5-hour Limit")
             let standardID = isGemini ? (isWeekly ? "gemini-weekly" : "gemini-hourly") : (isWeekly ? "3p-weekly" : "3p-hourly")
 
             if latestByID[standardID] == nil {
@@ -441,10 +431,10 @@ actor AntigravityProvider: UsageProvider {
         }
 
         let standardSlots: [(id: String, group: String, label: String, isWeekly: Bool)] = [
-            ("gemini-hourly", "Gemini Models", "5-hour Limit", false),
-            ("gemini-weekly", "Gemini Models", "Weekly Limit", true),
-            ("3p-hourly", "Claude and GPT models", "5-hour Limit", false),
-            ("3p-weekly", "Claude and GPT models", "Weekly Limit", true)
+            ("gemini-hourly", L10n.t("Gemini Models"), L10n.t("5-hour Limit"), false),
+            ("gemini-weekly", L10n.t("Gemini Models"), L10n.t("Weekly Limit"), true),
+            ("3p-hourly", L10n.t("Claude and GPT models"), L10n.t("5-hour Limit"), false),
+            ("3p-weekly", L10n.t("Claude and GPT models"), L10n.t("Weekly Limit"), true)
         ]
 
         var windows: [LimitWindow] = []
@@ -471,6 +461,30 @@ actor AntigravityProvider: UsageProvider {
         }
         return windows
     }
+
+    /// Known quota group names, so an English API value still localizes.
+    private static func quotaGroupName(_ name: String?) -> String? {
+        guard let name, !name.isEmpty else { return nil }
+        switch name {
+        case "Gemini Models": return L10n.t("Gemini Models")
+        case "Claude and GPT models": return L10n.t("Claude and GPT models")
+        default: return name
+        }
+    }
+
+    /// Known window titles, including the wording the language server uses.
+    private static func quotaWindowLabel(_ name: String) -> String {
+        var label = name
+        if label.hasSuffix(" Remaining") {
+            label = String(label.dropLast(" Remaining".count))
+        }
+        switch label {
+        case "Five Hour Limit", "5-hour Limit": return L10n.t("5-hour Limit")
+        case "Weekly Limit": return L10n.t("Weekly Limit")
+        default: return label
+        }
+    }
+
     /// The plan's display name, for the message the cell shows.
     static func tier(in data: Data) -> String {
         struct Response: Decodable {

--- a/Sources/Providers/CodexLocalProvider.swift
+++ b/Sources/Providers/CodexLocalProvider.swift
@@ -29,7 +29,7 @@ actor CodexLocalProvider: UsageProvider {
 
     nonisolated var signInRoute: SignInRoute {
         guard profile.slug != nil else { return .openApp(bundleID: "com.openai.codex", name: "Codex") }
-        return .guidance("Run \(profile.signInCommand) in Terminal to sign in to \(displayName).")
+        return .guidance(L10n.t("Run \(profile.signInCommand) in Terminal to sign in to \(displayName)."))
     }
 
     nonisolated func account() -> ProviderAccount? {

--- a/Sources/Sessions/AntigravityActivityMonitor.swift
+++ b/Sources/Sessions/AntigravityActivityMonitor.swift
@@ -115,13 +115,13 @@ final class AntigravityActivityMonitor: AgentActivityMonitor {
                     for call in toolCalls {
                         guard let name = call["name"] as? String else { continue }
                         if name.contains("ask_question") {
-                            return (.waiting, "Question")
+                            return (.waiting, L10n.t("Question"))
                         }
                         if name.contains("multi_replace_file_content") || name.contains("write_to_file") || name.contains("replace_file_content") {
                             if let args = call["arguments"] as? [String: Any],
                                let meta = args["ArtifactMetadata"] as? [String: Any],
                                meta["RequestFeedback"] as? Bool == true {
-                                return (.waiting, "Approval")
+                                return (.waiting, L10n.t("Approval"))
                             }
                         }
                     }
@@ -160,7 +160,7 @@ final class AntigravityActivityMonitor: AgentActivityMonitor {
                 let rows = SQLiteStore.rows(in: db, sql: "SELECT status FROM steps ORDER BY idx DESC LIMIT 1")
                 if let first = rows.first, first.first == "2" {
                     state = .waiting
-                    waitingFor = "Permission"
+                    waitingFor = L10n.t("Permission")
                 }
             }
         }

--- a/Sources/Sessions/CursorActivityMonitor.swift
+++ b/Sources/Sessions/CursorActivityMonitor.swift
@@ -237,7 +237,7 @@ final class CursorActivityMonitor: ObservableObject, AgentActivityMonitor {
             name: (head["name"] as? String) ?? L10n.t("Untitled chat"),
             detail: (head["subtitle"] as? String) ?? "Cursor",
             state: state,
-            waitingFor: isWaiting ? "needs your input" : nil,
+            waitingFor: isWaiting ? L10n.t("needs your input") : nil,
             since: since
         )
     }

--- a/Sources/Sessions/GeminiCLIActivityMonitor.swift
+++ b/Sources/Sessions/GeminiCLIActivityMonitor.swift
@@ -82,7 +82,7 @@ final class GeminiCLIActivityMonitor: AgentActivityMonitor {
         return [AgentSession(
             id: "gemini-api.\(newest.session.deletingPathExtension().lastPathComponent)",
             name: "Gemini CLI",
-            detail: "Working in \(projectName(of: newest.project))",
+            detail: L10n.t("Working in \(projectName(of: newest.project))"),
             state: .busy,
             waitingFor: nil,
             since: newest.modified

--- a/Sources/Settings/AntigravityHeadlineLimit.swift
+++ b/Sources/Settings/AntigravityHeadlineLimit.swift
@@ -6,12 +6,14 @@ enum AntigravityHeadlineLimit: String, CaseIterable, Identifiable {
     case weekly = "weekly"
     
     var id: String { rawValue }
-    
-    var explanation: String {
+
+    var title: String {
         switch self {
         case .automatic: return L10n.t("Automatic")
         case .fiveHour: return L10n.t("5-Hour Limit")
         case .weekly: return L10n.t("Weekly Limit")
         }
     }
+
+    var explanation: String { title }
 }

--- a/Sources/Settings/SettingsView.swift
+++ b/Sources/Settings/SettingsView.swift
@@ -416,7 +416,7 @@ struct SettingsView: View {
         case .ollama:
             if let usageStore {
                 Form {
-                    Section("Connection") {
+                    Section(L10n.t("Connection")) {
                         OllamaSettingsRow(preferences: preferences, store: usageStore, relay: ollamaRelay)
                     }
                 }
@@ -591,14 +591,12 @@ struct SettingsView: View {
                             .frame(width: 46, alignment: .trailing)
                     }
 
-                    Text("Scales the whole surface — rings, text and tooltip "
-                         + "together — so the proportions stay as drawn. "
-                         + "100% is the size the notch was designed at.")
+                    Text(L10n.t("Scales the whole surface — rings, text and tooltip together — so the proportions stay as drawn. 100% is the size the notch was designed at."))
                         .font(.caption)
                         .foregroundStyle(.secondary)
                         .fixedSize(horizontal: false, vertical: true)
                 } else {
-                    Picker("Preset size", selection: $preferences.notchSize) {
+                    Picker(L10n.t("Preset size"), selection: $preferences.notchSize) {
                         ForEach(NotchSize.allCases) { Text($0.title).tag($0) }
                     }
                     .pickerStyle(.segmented)
@@ -1297,8 +1295,7 @@ private struct AccountRow: View {
             // inside, this warning would be swallowed by the very row that
             // makes everything look fine.
             if isConnected, provider.needsSignInRenewal {
-                Text("\(provider.name) usage needs its sign-in renewed — run "
-                     + "`claude` once in a terminal.")
+                Text(L10n.t("\(provider.name) usage needs its sign-in renewed — run `claude` once in a terminal."))
                     .font(.caption)
                     .foregroundStyle(.orange)
                     .padding(.leading, 48)
@@ -1365,7 +1362,7 @@ private struct AccountRow: View {
                         .foregroundStyle(.secondary)
                     Picker(L10n.t("Notch reads"), selection: $preferences.antigravityHeadlineLimit) {
                         ForEach(AntigravityHeadlineLimit.allCases) { limit in
-                            Text(limit.explanation).tag(limit)
+                            Text(limit.title).tag(limit)
                         }
                     }
                     .labelsHidden()
@@ -1421,15 +1418,15 @@ private struct AccountRow: View {
         // own line instead, and `.small` comes off the controls — it bought
         // nothing but a cramped row.
         VStack(alignment: .leading, spacing: 4) {
-            Text("Ollama API key")
+            Text(L10n.t("Ollama API key"))
                 .foregroundStyle(.secondary)
             HStack(spacing: 8) {
-                SecureField("Paste your key", text: $ollamaKey)
+                SecureField(L10n.t("Paste your key"), text: $ollamaKey)
                     .textContentType(.password)
                     .textFieldStyle(.roundedBorder)
                     .labelsHidden()
                     .frame(maxWidth: 260)
-                Button("Save") {
+                Button(L10n.t("Save")) {
                     guard !ollamaKey.isEmpty else { return }
                     OllamaCredentials.store(ollamaKey)
                     ollamaKey = ""
@@ -1438,7 +1435,7 @@ private struct AccountRow: View {
                 }
                 .disabled(ollamaKey.isEmpty)
                 if ollamaKeySaved {
-                    Text("Saved")
+                    Text(L10n.t("Saved"))
                         .foregroundStyle(.green)
                 }
             }


### PR DESCRIPTION
## Summary

1.8 added weekly ring, Liquid Glass, Claude Desktop, Antigravity headline choice, and related Settings copy. Those strings already went through `L10n.t`, but most had no zh-Hans catalog entry, so a Chinese Mac still showed English.

This fills those catalog entries and wraps a few leftover visible strings. English source wording is unchanged. Incomplete locales still fall back to English; CI does not require zh-Hans to be complete.

## Test plan

- [x] `make build` on this branch
- [ ] Switch Codenotch to 简体中文 and check Appearance (weekly ring, surface), What's New 1.8.0, and Antigravity headline labels