### PR TITLE
Show unused Codex rate-limit resets on the hover card

### DIFF
--- a/Sources/Features/TooltipCard.swift
+++ b/Sources/Features/TooltipCard.swift
@@ -637,6 +637,75 @@ private struct CodexDailyUsageChart: View {
     }
 }
 
+/// Unused rate-limit resets on the Codex account.
+private struct CodexResetCreditsSection: View {
+    let credits: CodexResetCredits
+    let now: Date
+
+    private var countText: String {
+        switch credits.availableCount {
+        case 0: return L10n.t("No unused resets")
+        case 1: return L10n.t("1 unused reset")
+        case let n: return L10n.t("\(n) unused resets")
+        }
+    }
+
+    private var expiryText: String? {
+        guard credits.availableCount > 0, let date = credits.nextExpiry, date > now else {
+            return nil
+        }
+        let stamp = Self.stamp(for: date, now: now)
+        return credits.availableCount > 1
+            ? L10n.t("Next expires \(stamp)")
+            : L10n.t("Expires \(stamp)")
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Rectangle()
+                .fill(Palette.ringTrack)
+                .frame(height: NotchLayout.hairline)
+                .padding(.top, NotchLayout.codexUsageTop)
+
+            VStack(alignment: .leading, spacing: 0) {
+                Text(L10n.t("Unused resets"))
+                    .font(Typography.cardBody)
+                    .fontWeight(.semibold)
+                    .foregroundStyle(Palette.textPrimary)
+                    .padding(.top, NotchLayout.blockSpacing)
+
+                Text(countText)
+                    .font(Typography.cardBody)
+                    .foregroundStyle(Palette.textPrimary)
+                    .lineLimit(1)
+                    .padding(.top, NotchLayout.codexUsageRowGap)
+
+                if let expiryText {
+                    Text(expiryText)
+                        .font(Typography.cardBody)
+                        .foregroundStyle(Palette.textSecondary)
+                        .lineLimit(1)
+                        .padding(.top, NotchLayout.codexUsageRowGap)
+                }
+            }
+            .frame(height: NotchLayout.codexResetCreditsHeight, alignment: .top)
+        }
+    }
+
+    /// Same date templates `ResetCopy` uses past the hour, so this line and
+    /// the quota rows agree on what "soon" looks like.
+    private static func stamp(for date: Date, now: Date, calendar: Calendar = .current) -> String {
+        let formatter = ResetCopy.formatter(for: calendar)
+        formatter.locale = L10n.locale
+        if ResetCopy.daysApart(from: now, to: date, calendar: calendar) >= 7 {
+            formatter.setLocalizedDateFormatFromTemplate("MMM d")
+        } else {
+            formatter.setLocalizedDateFormatFromTemplate("E j:mm")
+        }
+        return formatter.string(from: date)
+    }
+}
+
 /// Account-wide Codex activity. Unlike the quota rows above, this is sourced
 /// from the Codex profile usage endpoint and is not a local estimate.
 private struct CodexUsageSection: View {
@@ -839,6 +908,7 @@ struct TooltipCard: View {
             statusMessage: snapshot.statusMessage,
             blockMessage: snapshot.block?.summary(now: now),
             hasTokenUsage: snapshot.tokenUsage != nil,
+            hasResetCredits: snapshot.resetCredits != nil,
             localModelName: snapshot.localModel?.name,
             showsLocalPerformance: snapshot.showsLocalPerformance,
             compactRowCount: snapshot.compactRowCount
@@ -855,6 +925,9 @@ struct TooltipCard: View {
                 VStack(alignment: .leading, spacing: 0) {
                     ProviderTooltip(isThinking: snapshot.localModel != nil && activity?.state == .working, snapshot: snapshot, now: now, resetTimeFormat: resetTimeFormat,
                                     showUsagePace: showUsagePace)
+                    if let resetCredits = snapshot.resetCredits {
+                        CodexResetCreditsSection(credits: resetCredits, now: now)
+                    }
                     if let tokenUsage = snapshot.tokenUsage {
                         CodexUsageSection(usage: tokenUsage, now: now)
                     }

--- a/Sources/Localizable.xcstrings
+++ b/Sources/Localizable.xcstrings
@@ -5950,6 +5950,72 @@
           }
         }
       }
+    },
+    "Unused resets": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未使用重置"
+          }
+        }
+      }
+    },
+    "No unused resets": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "暂无未使用重置"
+          }
+        }
+      }
+    },
+    "1 unused reset": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 次未使用重置"
+          }
+        }
+      }
+    },
+    "%lld unused resets": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld 次未使用重置"
+          }
+        }
+      }
+    },
+    "Expires %@": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 到期"
+          }
+        }
+      }
+    },
+    "Next expires %@": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "下次 %@ 到期"
+          }
+        }
+      }
     }
   },
   "version": "1.0"

--- a/Sources/Model/UsageModel.swift
+++ b/Sources/Model/UsageModel.swift
@@ -215,6 +215,9 @@ struct ProviderSnapshot: Identifiable, Equatable {
     /// endpoint; it never changes the profile token buckets. Other providers
     /// leave this nil because they do not expose the same account-level data.
     var tokenUsage: CodexTokenUsage? = nil
+    /// Unused rate-limit resets on this Codex account, listed by the same
+    /// backend as usage.
+    var resetCredits: CodexResetCredits? = nil
 
     /// The number on the cell: the provider's declared primary window — for
     /// Claude, the current session.

--- a/Sources/Notch/NotchLayout.swift
+++ b/Sources/Notch/NotchLayout.swift
@@ -165,6 +165,11 @@ enum NotchLayout {
     static let codexUsageRowGap = Design.px(12)
     static let codexChartTop   = Design.px(15)
     static let codexChartHeight = Design.px(115)
+    /// Title, count, and expiry. The third line is reserved so a missing
+    /// expiry cannot shrink the hover region under the card.
+    static var codexResetCreditsHeight: CGFloat {
+        blockSpacing + 3 * cardBodyLineHeight + 2 * codexUsageRowGap
+    }
 
     /// The percent label's line box. Fixed rather than intrinsic so the panel
     /// geometry can be worked out in AppKit before SwiftUI lays anything out.
@@ -307,6 +312,7 @@ enum NotchLayout {
                            statusMessage: String? = nil,
                            blockMessage: String? = nil,
                            hasTokenUsage: Bool = false,
+                           hasResetCredits: Bool = false,
                            localModelName: String? = nil, showsLocalPerformance: Bool = false,
                            compactRowCount: Int = 0) -> CGFloat {
         let header = max(glyphSize, cardTitleLineHeight)
@@ -349,6 +355,10 @@ enum NotchLayout {
         } else {
             // The status message, at whatever height it actually wraps to.
             height += headerToBlock + bodyTextHeight(statusMessage ?? "")
+        }
+
+        if hasResetCredits {
+            height += codexUsageTop + hairline + codexResetCreditsHeight
         }
 
         if hasTokenUsage {
@@ -434,7 +444,8 @@ enum NotchLayout {
     /// costs nothing.
     static func sessionsFitting(cardBudget: CGFloat, windowCount: Int,
                                 groupCount: Int = 2,
-                                hasTokenUsage: Bool = false) -> Int {
+                                hasTokenUsage: Bool = false,
+                                hasResetCredits: Bool = false) -> Int {
         var fits = 0
         for n in 1...sessionCeiling {
             // Costed as though something were still hidden, so that admitting
@@ -442,7 +453,8 @@ enum NotchLayout {
             // bottom of the card.
             let height = cardHeight(windowCount: windowCount, groupCount: groupCount,
                                     sessionCount: n + 1, sessionCap: n,
-                                    hasTokenUsage: hasTokenUsage)
+                                    hasTokenUsage: hasTokenUsage,
+                                    hasResetCredits: hasResetCredits)
             guard height <= cardBudget else { break }
             fits = n
         }
@@ -463,10 +475,12 @@ enum NotchLayout {
     /// clicks through everywhere the chrome is not — but it cannot be so
     /// generous that the panel runs off the screen, which is what the cap is
     /// solved for.
-    static func maxCardHeight(sessionCap: Int, hasTokenUsage: Bool = false) -> CGFloat {
+    static func maxCardHeight(sessionCap: Int, hasTokenUsage: Bool = false,
+                              hasResetCredits: Bool = false) -> CGFloat {
         cardHeight(windowCount: maxWindowCount, groupCount: 2,
                    sessionCount: sessionCap + 1, sessionCap: sessionCap,
-                   hasTokenUsage: hasTokenUsage)
+                   hasTokenUsage: hasTokenUsage,
+                   hasResetCredits: hasResetCredits)
     }
 
     static let defaultMaxCardHeight = maxCardHeight(sessionCap: defaultSessionCap)

--- a/Sources/Notch/NotchRootView.swift
+++ b/Sources/Notch/NotchRootView.swift
@@ -326,6 +326,7 @@ struct NotchRootView: View {
                 statusMessage: snapshot.statusMessage,
                 blockMessage: snapshot.block?.summary(now: model.now),
                 hasTokenUsage: snapshot.tokenUsage != nil,
+                hasResetCredits: snapshot.resetCredits != nil,
                 localModelName: snapshot.localModel?.name,
                 showsLocalPerformance: snapshot.showsLocalPerformance,
                 compactRowCount: snapshot.compactRowCount
@@ -353,6 +354,7 @@ struct NotchRootView: View {
                 statusMessage: snapshot.statusMessage,
                 blockMessage: snapshot.block?.summary(now: model.now),
                 hasTokenUsage: snapshot.tokenUsage != nil,
+                hasResetCredits: snapshot.resetCredits != nil,
                 localModelName: snapshot.localModel?.name,
                 showsLocalPerformance: snapshot.showsLocalPerformance,
                 compactRowCount: snapshot.compactRowCount

--- a/Sources/Notch/NotchViewModel.swift
+++ b/Sources/Notch/NotchViewModel.swift
@@ -437,11 +437,16 @@ final class NotchViewModel: ObservableObject {
         snapshots.contains { $0.tokenUsage != nil }
     }
 
+    private var hasResetCredits: Bool {
+        snapshots.contains { $0.resetCredits != nil }
+    }
+
     func sessionCap(cellCount: Int) -> Int {
         guard screenSize != .zero else { return NotchLayout.defaultSessionCap }
         return NotchLayout.sessionsFitting(cardBudget: cardBudget(cellCount: cellCount),
                                            windowCount: NotchLayout.maxWindowCount,
-                                           hasTokenUsage: hasTokenUsage)
+                                           hasTokenUsage: hasTokenUsage,
+                                           hasResetCredits: hasResetCredits)
     }
 
     private func contentCardHeight(sessionCap: Int) -> CGFloat {
@@ -453,6 +458,7 @@ final class NotchViewModel: ObservableObject {
                 statusMessage: snapshot.statusMessage,
                 blockMessage: snapshot.block?.summary(now: now),
                 hasTokenUsage: snapshot.tokenUsage != nil,
+                hasResetCredits: snapshot.resetCredits != nil,
                 localModelName: snapshot.localModel?.name,
                 showsLocalPerformance: snapshot.showsLocalPerformance,
                 compactRowCount: snapshot.compactRowCount)
@@ -462,7 +468,8 @@ final class NotchViewModel: ObservableObject {
     func maxCardHeight(cellCount: Int) -> CGFloat {
         let cap = sessionCap(cellCount: cellCount)
         return snapshots.isEmpty
-            ? NotchLayout.maxCardHeight(sessionCap: cap, hasTokenUsage: hasTokenUsage)
+            ? NotchLayout.maxCardHeight(sessionCap: cap, hasTokenUsage: hasTokenUsage,
+                                        hasResetCredits: hasResetCredits)
             : contentCardHeight(sessionCap: cap)
     }
 

--- a/Sources/Notch/NotchWindowController.swift
+++ b/Sources/Notch/NotchWindowController.swift
@@ -379,6 +379,7 @@ final class NotchWindowController {
             statusMessage: snapshot.statusMessage,
             blockMessage: snapshot.block?.summary(now: model.now),
             hasTokenUsage: snapshot.tokenUsage != nil,
+            hasResetCredits: snapshot.resetCredits != nil,
             localModelName: snapshot.localModel?.name,
             showsLocalPerformance: snapshot.showsLocalPerformance,
             compactRowCount: snapshot.compactRowCount

--- a/Sources/Providers/CodexLocalProvider.swift
+++ b/Sources/Providers/CodexLocalProvider.swift
@@ -72,6 +72,8 @@ actor CodexLocalProvider: UsageProvider {
 
         let windows = try CodexUsage.windows(from: data)
 
+        async let resetCredits = Self.fetchResetCredits(session: session, credential: credential)
+
         // The profile page's token statistics are the source for the chart and
         // totals.
         let profileUsage = try? await Self.fetchProfileUsage(
@@ -84,7 +86,8 @@ actor CodexLocalProvider: UsageProvider {
             fidelity: .official, status: .ok, windows: windows,
             headlineID: windows.first?.id,
             weeklyID: "secondary",
-            tokenUsage: profileUsage
+            tokenUsage: profileUsage,
+            resetCredits: await resetCredits
         )
     }
 
@@ -110,6 +113,34 @@ actor CodexLocalProvider: UsageProvider {
             throw UsageProviderError.badResponse(status: status)
         }
         return try CodexUsage.profileUsage(from: data)
+    }
+
+    /// Unused rate-limit resets on this Codex account, listed by the same
+    /// backend as usage.
+    private static func fetchResetCredits(
+        session: URLSession,
+        credential: CodexCredentials.Credential
+    ) async -> CodexResetCredits? {
+        var request = URLRequest(
+            url: URL(string: "https://chatgpt.com/backend-api/wham/rate-limit-reset-credits")!,
+            cachePolicy: .reloadIgnoringLocalCacheData,
+            timeoutInterval: 15
+        )
+        request.httpMethod = "GET"
+        request.setValue("Bearer \(credential.accessToken)", forHTTPHeaderField: "Authorization")
+        request.setValue(credential.accountID, forHTTPHeaderField: "ChatGPT-Account-Id")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.setValue("no-cache, no-store", forHTTPHeaderField: "Cache-Control")
+        request.setValue("codex-1", forHTTPHeaderField: "OpenAI-Beta")
+
+        do {
+            let (data, response) = try await session.data(for: request)
+            let status = (response as? HTTPURLResponse)?.statusCode ?? 0
+            guard (200..<300).contains(status) else { return nil }
+            return try CodexUsage.resetCredits(from: data)
+        } catch {
+            return nil
+        }
     }
 
     private static func retryAfter(from response: HTTPURLResponse?, now: Date) -> TimeInterval? {

--- a/Sources/Providers/CodexUsage.swift
+++ b/Sources/Providers/CodexUsage.swift
@@ -84,6 +84,40 @@ struct CodexTokenUsage: Codable, Equatable, Sendable {
     }
 }
 
+/// Unused rate-limit resets on the Codex account.
+///
+/// The ChatGPT backend lists credits that can still reset a rate limit, under
+/// the same credential as `/wham/usage`.
+struct CodexResetCredits: Equatable, Sendable {
+    struct Credit: Equatable, Sendable, Identifiable {
+        let id: String
+        let status: String
+        let expiresAt: Date?
+
+        init(id: String, status: String, expiresAt: Date? = nil) {
+            self.id = id
+            self.status = status
+            self.expiresAt = expiresAt
+        }
+    }
+
+    let availableCount: Int
+    let credits: [Credit]
+
+    init(availableCount: Int, credits: [Credit] = []) {
+        self.availableCount = availableCount
+        self.credits = credits
+    }
+
+    /// Credits still available, soonest expiry first.
+    var available: [Credit] {
+        credits.filter { $0.status == "available" }
+            .sorted { ($0.expiresAt ?? .distantFuture) < ($1.expiresAt ?? .distantFuture) }
+    }
+
+    var nextExpiry: Date? { available.compactMap(\.expiresAt).min() }
+}
+
 /// Only the account's main rate-limit windows belong in the usage rings —
 /// `additional_rate_limits` and `code_review_rate_limit` meter something else
 /// and are deliberately left out.
@@ -120,6 +154,54 @@ enum CodexUsage {
         let used_percent: Double?
         let reset_at: Double?
         let reset_after_seconds: Double?
+    }
+
+    private struct ResetCreditsResponse: Decodable {
+        let credits: [ResetCredit]
+        let availableCount: Int?
+
+        private enum CodingKeys: String, CodingKey {
+            case credits
+            case available_count
+        }
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            availableCount = try? container.decode(Int.self, forKey: .available_count)
+            // One unreadable credit must not discard the rest of a valid list.
+            let items = (try? container.decode([FailableResetCredit].self, forKey: .credits)) ?? []
+            credits = items.compactMap(\.value)
+        }
+    }
+
+    private struct FailableResetCredit: Decodable {
+        let value: ResetCredit?
+        init(from decoder: Decoder) throws {
+            value = try? ResetCredit(from: decoder)
+        }
+    }
+
+    private struct ResetCredit: Decodable {
+        let id: String
+        let status: String
+        let expiresAt: Date?
+
+        private enum CodingKeys: String, CodingKey {
+            case id
+            case status
+            case expires_at
+        }
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            id = try container.decodeIfPresent(String.self, forKey: .id) ?? ""
+            status = try container.decodeIfPresent(String.self, forKey: .status) ?? ""
+            if let text = try? container.decode(String.self, forKey: .expires_at) {
+                expiresAt = parseISO8601(text)
+            } else {
+                expiresAt = nil
+            }
+        }
     }
 
     static func windows(from data: Data, now: Date = Date()) throws -> [LimitWindow] {
@@ -176,6 +258,39 @@ enum CodexUsage {
         } catch {
             throw UsageProviderError.badResponse(status: 0)
         }
+    }
+
+    /// Decode the ChatGPT backend list of unused rate-limit resets.
+    ///
+    /// Same credential as `/wham/usage`. `available_count` is trusted even when
+    /// the `credits` array is truncated. Throws only when the body is not JSON
+    /// at all, so an unfamiliar payload cannot fail the usage fetch.
+    static func resetCredits(from data: Data) throws -> CodexResetCredits {
+        let response: ResetCreditsResponse
+        do {
+            response = try JSONDecoder().decode(ResetCreditsResponse.self, from: data)
+        } catch {
+            if (try? JSONSerialization.jsonObject(with: data)) != nil {
+                return CodexResetCredits(availableCount: 0, credits: [])
+            }
+            throw UsageProviderError.badResponse(status: 0)
+        }
+
+        let credits = response.credits.map {
+            CodexResetCredits.Credit(id: $0.id, status: $0.status, expiresAt: $0.expiresAt)
+        }
+        let availableCount = response.availableCount
+            ?? credits.filter { $0.status == "available" }.count
+        return CodexResetCredits(availableCount: availableCount, credits: credits)
+    }
+
+    /// The backend mixes whole-second and fractional ISO-8601 stamps; each
+    /// formatter rejects the other form.
+    private static func parseISO8601(_ text: String) -> Date? {
+        let fractional = ISO8601DateFormatter()
+        fractional.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        if let date = fractional.date(from: text) { return date }
+        return ISO8601DateFormatter().date(from: text)
     }
 
     /// The plan an account is on decides what its primary window actually is

--- a/Tests/CodexResetCreditsTests.swift
+++ b/Tests/CodexResetCreditsTests.swift
@@ -1,0 +1,76 @@
+import XCTest
+@testable import Codenotch
+
+/// Banked rate-limit resets. The count is its own field — the details list
+/// can be shorter than the total — and the next expiry is the soonest credit,
+/// not the first one in the payload.
+final class CodexResetCreditsTests: XCTestCase {
+    private func credits(_ json: String) throws -> CodexResetCredits {
+        try CodexUsage.resetCredits(from: Data(json.utf8))
+    }
+
+    private func utcDate(year: Int, month: Int, day: Int,
+                         hour: Int = 0, minute: Int = 0, second: Int = 0) -> Date {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(identifier: "UTC")!
+        return calendar.date(from: DateComponents(
+            year: year, month: month, day: day,
+            hour: hour, minute: minute, second: second
+        ))!
+    }
+
+    /// Recorded shape: a count plus one row per credit, expiry as an
+    /// internet-date string. Extra keys on a row must not trip the decode.
+    func testDecodesAvailableCountAndExpiryFromTheFixture() throws {
+        let json = """
+        {"available_count":2,"credits":[
+          {"id":"credit-a","reset_type":"codex_rate_limits","status":"available",
+           "title":"Full reset","granted_at":"2026-06-12T01:33:14Z",
+           "expires_at":"2026-07-12T01:33:14Z"},
+          {"id":"credit-b","reset_type":"codex_rate_limits","status":"available",
+           "title":"Full reset","granted_at":"2026-06-18T08:00:00Z",
+           "expires_at":"2026-07-18T08:00:00Z"}]}
+        """
+        let result = try credits(json)
+        let firstExpiry = utcDate(year: 2026, month: 7, day: 12, hour: 1, minute: 33, second: 14)
+        let secondExpiry = utcDate(year: 2026, month: 7, day: 18, hour: 8)
+
+        XCTAssertEqual(result.availableCount, 2)
+        XCTAssertEqual(result.credits[0].expiresAt, firstExpiry)
+        XCTAssertEqual(result.credits[1].expiresAt, secondExpiry)
+        XCTAssertEqual(result.nextExpiry, firstExpiry)
+    }
+
+    /// Arrival order is not expiry order — the next one is the soonest date,
+    /// not whichever row happened to come first.
+    func testNextExpiryIsTheSoonestCredit() throws {
+        let json = """
+        {"available_count":2,"credits":[
+          {"status":"available","expires_at":"2026-08-01T00:00:00Z"},
+          {"status":"available","expires_at":"2026-07-01T00:00:00Z"}]}
+        """
+        let result = try credits(json)
+        XCTAssertEqual(result.nextExpiry, utcDate(year: 2026, month: 7, day: 1))
+    }
+
+    /// The details list can be capped, so the count field is the total rather
+    /// than `credits.count`.
+    func testAvailableCountIsTrustedWhenTheCreditsArrayIsShorter() throws {
+        let json = """
+        {"available_count":5,"credits":[
+          {"status":"available","expires_at":"2026-07-12T01:33:14Z"}]}
+        """
+        let result = try credits(json)
+        XCTAssertEqual(result.availableCount, 5)
+        XCTAssertEqual(result.credits.count, 1)
+        XCTAssertLessThan(result.credits.count, result.availableCount)
+    }
+
+    /// The reset-credit block is extra card, so the hover region has to grow
+    /// with it or the pointer falls out of a card it is still over.
+    func testTheCardGrowsWhenResetCreditsAreShown() {
+        let plain = NotchLayout.cardHeight(windowCount: 2)
+        let withCredits = NotchLayout.cardHeight(windowCount: 2, hasResetCredits: true)
+        XCTAssertGreaterThan(withCredits, plain)
+    }
+}

--- a/Tests/CodexUsageTests.swift
+++ b/Tests/CodexUsageTests.swift
@@ -157,6 +157,86 @@ final class CodexUsageTests: XCTestCase {
                        "a missing current-day bucket should be shown as Pending")
     }
 
+    /// `/wham/rate-limit-reset-credits` reports how many unused resets remain
+    /// and when the next one expires. The count is its own field because the
+    /// credits array can be truncated.
+    func testResetCreditsReadsAvailableCountAndSoonestExpiry() throws {
+        let json = """
+        {"credits":[
+          {"id":"later","reset_type":"rate_limit","status":"available",
+           "granted_at":"2026-09-01T12:00:00Z",
+           "expires_at":"2026-09-20T12:00:00.250Z",
+           "title":"Reset","description":"Unused reset","extra":true},
+          {"id":"spent","reset_type":"rate_limit","status":"redeemed",
+           "granted_at":"2026-08-01T00:00:00Z",
+           "expires_at":"2026-09-12T00:00:00Z"},
+          {"id":"sooner","reset_type":"rate_limit","status":"available",
+           "granted_at":"2026-09-02T00:00:00Z",
+           "expires_at":"2026-09-15T08:00:00Z"}
+         ],
+         "available_count":2,
+         "server_time":"2026-09-10T00:00:00Z"}
+        """
+        let result = try CodexUsage.resetCredits(from: Data(json.utf8))
+        XCTAssertEqual(result.availableCount, 2)
+        XCTAssertEqual(result.credits.map(\.id), ["later", "spent", "sooner"])
+        XCTAssertEqual(result.available.map(\.id), ["sooner", "later"])
+        XCTAssertEqual(result.nextExpiry, ISO8601DateFormatter().date(from: "2026-09-15T08:00:00Z"))
+
+        let fractional = ISO8601DateFormatter()
+        fractional.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        XCTAssertEqual(result.available.last?.expiresAt,
+                       fractional.date(from: "2026-09-20T12:00:00.250Z"))
+    }
+
+    func testResetCreditsTrustsAvailableCountWhenTheArrayIsTruncated() throws {
+        let result = try CodexUsage.resetCredits(from: Data("""
+        {"available_count":3,"credits":[
+          {"id":"only","status":"available","expires_at":"2026-09-18T00:00:00Z"}
+        ]}
+        """.utf8))
+        XCTAssertEqual(result.availableCount, 3)
+        XCTAssertEqual(result.credits.map(\.id), ["only"])
+        XCTAssertEqual(result.available.count, 1)
+        XCTAssertEqual(result.nextExpiry, ISO8601DateFormatter().date(from: "2026-09-18T00:00:00Z"))
+    }
+
+    func testResetCreditsCountsAvailableCreditsWhenThePayloadOmitsTheCount() throws {
+        let result = try CodexUsage.resetCredits(from: Data("""
+        {"credits":[
+          {"id":"a","status":"available","expires_at":"2026-09-18T00:00:00Z"},
+          {"id":"b","status":"redeemed","expires_at":"2026-09-10T00:00:00Z"}
+        ]}
+        """.utf8))
+        XCTAssertEqual(result.availableCount, 1)
+        XCTAssertEqual(result.available.map(\.id), ["a"])
+    }
+
+    /// A non-object entry is skipped; an unreadable date becomes no expiry.
+    /// None of that is a reason to fail the usage fetch.
+    func testResetCreditsSkipsMalformedCreditsRatherThanFailing() throws {
+        let result = try CodexUsage.resetCredits(from: Data("""
+        {"credits":[
+          "nope",
+          {"id":"ok","status":"available","expires_at":null}
+        ],"available_count":1}
+        """.utf8))
+        XCTAssertEqual(result.credits.map(\.id), ["ok"])
+        XCTAssertNil(result.credits.first?.expiresAt)
+        XCTAssertEqual(result.availableCount, 1)
+        XCTAssertNil(result.nextExpiry)
+    }
+
+    func testResetCreditsThrowsOnlyOnInvalidJSON() throws {
+        XCTAssertThrowsError(try CodexUsage.resetCredits(from: Data("not-json".utf8))) { error in
+            guard case UsageProviderError.badResponse = error else {
+                return XCTFail("expected badResponse, got \(error)")
+            }
+        }
+        XCTAssertEqual(try CodexUsage.resetCredits(from: Data("{}".utf8)).availableCount, 0)
+        XCTAssertEqual(try CodexUsage.resetCredits(from: Data("[]".utf8)).credits, [])
+    }
+
     func testAccountUsageCardGetsRoomForTheActivitySection() {
         let plain = NotchLayout.cardHeight(windowCount: 2)
         let withTokens = NotchLayout.cardHeight(windowCount: 2, hasTokenUsage: true)


### PR DESCRIPTION
## Summary

Codex accounts can hold unused rate-limit resets that expire. The hover card now shows how many remain and when the next one expires, read from the same ChatGPT backend already used for usage.

A failed credits fetch does not take down the rings. Display only — nothing is redeemed from Codenotch.

## Test plan

- [x] `make test` — 1119 tests, 0 failures, including decode fixtures for count and expiry
- [ ] Hover a signed-in Codex ring and confirm the unused-reset count and next expiry
- [ ] Confirm usage still appears if the credits request fails