### PR TITLE
Show OpenCode and Hermes turns on the Gemini API ring

### DIFF
--- a/Sources/App/AppDelegate.swift
+++ b/Sources/App/AppDelegate.swift
@@ -410,7 +410,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             "cursor": CursorActivityMonitor(),
             "gemini": AntigravityActivityMonitor(),
             "grok": GrokActivityMonitor(),
-            "gemini-api": GeminiCLIActivityMonitor(),
+            "gemini-api": GeminiAPIActivityMonitor(),
         ]
         var claudeMonitors: [ClaudeSessionMonitor] = []
         for profile in claudeProfiles {

--- a/Sources/Sessions/GeminiAPIActivityMonitor.swift
+++ b/Sources/Sessions/GeminiAPIActivityMonitor.swift
@@ -1,0 +1,83 @@
+import Combine
+import Foundation
+
+/// What the `gemini-api` ring shows as running.
+///
+/// Three tools spend the same API key and each records a turn in flight in its
+/// own way, so the monitor is one timer over three readers rather than three
+/// monitors sharing an id: `GeminiCLIActivity` on the chat files' modification
+/// dates, `OpenCodeGeminiActivity` on an assistant message with no
+/// `time.completed`, `HermesGeminiActivity` on an open session's lease.
+///
+/// The order is fixed and matches the provider's tooltip rows. Sessions are
+/// drawn in the order they arrive, so concatenating by whichever reader
+/// answered first would reshuffle the ring every couple of seconds.
+///
+/// None of the three writes a "waiting for you" marker to disk, so every
+/// session here is `.busy` or absent, the way Cursor and Antigravity report
+/// rather than the way Claude does.
+final class GeminiAPIActivityMonitor: AgentActivityMonitor {
+    @Published private(set) var sessions: [AgentSession] = []
+    var sessionsPublisher: AnyPublisher<[AgentSession], Never> { $sessions.eraseToAnyPublisher() }
+
+    private let geminiRoot: URL
+    private let opencodeDatabase: URL
+    private let hermesDatabase: URL
+    private let interval: TimeInterval
+    /// How recently a source must have been touched to count as live. Generous,
+    /// because a model can think for a while between two lines.
+    private let staleAfter: TimeInterval
+    private var timer: Timer?
+
+    init(geminiRoot: URL = GeminiCLIUsage.sessionsRoot,
+         opencodeDatabase: URL = OpenCodeGeminiActivity.database,
+         hermesDatabase: URL = HermesGeminiUsage.database,
+         interval: TimeInterval = 2,
+         staleAfter: TimeInterval = 45) {
+        self.geminiRoot = geminiRoot
+        self.opencodeDatabase = opencodeDatabase
+        self.hermesDatabase = hermesDatabase
+        self.interval = interval
+        self.staleAfter = staleAfter
+    }
+
+    func start() {
+        stop()
+        poll()
+        let timer = Timer(timeInterval: interval, repeats: true) { [weak self] _ in
+            self?.poll()
+        }
+        RunLoop.main.add(timer, forMode: .common)
+        self.timer = timer
+    }
+
+    func stop() {
+        timer?.invalidate()
+        timer = nil
+    }
+
+    private func poll() {
+        let found = Self.read(
+            geminiRoot: geminiRoot,
+            opencodeDatabase: opencodeDatabase,
+            hermesDatabase: hermesDatabase,
+            staleAfter: staleAfter
+        )
+        guard found != sessions else { return }
+        sessions = found
+    }
+
+    static func read(
+        geminiRoot: URL,
+        opencodeDatabase: URL,
+        hermesDatabase: URL,
+        staleAfter: TimeInterval,
+        now: Date = Date()
+    ) -> [AgentSession] {
+        GeminiCLIActivity.read(root: geminiRoot, staleAfter: staleAfter, now: now)
+            + OpenCodeGeminiActivity.read(
+                database: opencodeDatabase, staleAfter: staleAfter, now: now)
+            + HermesGeminiActivity.read(
+                database: hermesDatabase, staleAfter: staleAfter, now: now)
+    }
+}

--- a/Sources/Sessions/GeminiCLIActivity.swift
+++ b/Sources/Sessions/GeminiCLIActivity.swift
@@ -1,4 +1,3 @@
-import Combine
 import Foundation
 
 /// Notices when Gemini CLI is working.
@@ -8,51 +7,7 @@ import Foundation
 /// there is. It is a good one: the CLI appends a `$set lastUpdated` patch on
 /// every message, so a file written moments ago is a turn in progress. Cursor
 /// and Antigravity stand on the same substitute.
-///
-/// Only Gemini CLI gets a monitor. OpenCode and Hermes keep their token counts
-/// in databases that are written for reasons that have nothing to do with a
-/// Gemini call, so their modification dates would report work that is not this
-/// provider's.
-final class GeminiCLIActivityMonitor: AgentActivityMonitor {
-    @Published private(set) var sessions: [AgentSession] = []
-    var sessionsPublisher: AnyPublisher<[AgentSession], Never> { $sessions.eraseToAnyPublisher() }
-
-    private let root: URL
-    private let interval: TimeInterval
-    /// How recently a session file must have been written to count as live.
-    /// Generous, because a model can think for a while between two lines.
-    private let staleAfter: TimeInterval
-    private var timer: Timer?
-
-    init(root: URL = GeminiCLIUsage.sessionsRoot,
-         interval: TimeInterval = 2,
-         staleAfter: TimeInterval = 45) {
-        self.root = root
-        self.interval = interval
-        self.staleAfter = staleAfter
-    }
-
-    func start() {
-        stop()
-        poll()
-        let timer = Timer(timeInterval: interval, repeats: true) { [weak self] _ in
-            self?.poll()
-        }
-        RunLoop.main.add(timer, forMode: .common)
-        self.timer = timer
-    }
-
-    func stop() {
-        timer?.invalidate()
-        timer = nil
-    }
-
-    private func poll() {
-        let found = Self.read(root: root, staleAfter: staleAfter)
-        guard found != sessions else { return }
-        sessions = found
-    }
-
+enum GeminiCLIActivity {
     static func read(root: URL, staleAfter: TimeInterval, now: Date = Date()) -> [AgentSession] {
         let manager = FileManager.default
         guard let projects = try? manager.contentsOfDirectory(

--- a/Sources/Sessions/HermesGeminiActivity.swift
+++ b/Sources/Sessions/HermesGeminiActivity.swift
@@ -1,0 +1,105 @@
+import Foundation
+import SQLite3
+
+/// Notices when a Hermes session is spending a `GEMINI_API_KEY` right now.
+///
+/// Hermes keeps its own state beside the usage totals, in the same
+/// `~/.hermes/state.db` (schema_version 30):
+///
+/// ```
+/// sessions(id, source, started_at REAL, ended_at REAL, last_activity_at REAL,
+///          billing_provider, cwd, title, model, …)
+/// session_turn_leases(conversation_id TEXT PRIMARY KEY, holder,
+///                     acquired_at REAL, expires_at REAL)
+/// ```
+///
+/// `ended_at IS NULL` on its own says almost nothing: a desktop session stays
+/// open for hours after the last question, and a crashed one never closes at
+/// all. What narrows it to work in flight is either half of the `OR`:
+///
+/// - `last_activity_at` inside `staleAfter`, the same recency substitute Gemini
+///   CLI and Cursor stand on, or
+/// - a row in `session_turn_leases` that has not expired. That table is
+///   Hermes's own "a turn is running" marker, and because the lease carries a
+///   wall-clock `expires_at` it stops lying by itself when the process dies —
+///   which is why a long model think, quiet on `last_activity_at`, still reads
+///   as busy.
+///
+/// `billing_provider = 'gemini'` is the same id `HermesGeminiUsage` matches:
+/// Google AI Studio through a bare API key, and it survives a
+/// `GEMINI_BASE_URL` override.
+///
+/// Hermes records no "waiting for you" state on disk, so the answer is busy or
+/// nothing, like Cursor and Antigravity rather than Claude.
+enum HermesGeminiActivity {
+    static func read(
+        database: URL = HermesGeminiUsage.database,
+        staleAfter: TimeInterval,
+        now: Date = Date()
+    ) -> [AgentSession] {
+        guard let db = SQLiteStore.open(database) else { return [] }
+        defer { sqlite3_close(db) }
+
+        // A prepare that fails is indistinguishable from a query that matched
+        // nothing through `SQLiteStore.rows`, so the schema is asked about
+        // first: pre-30 databases have no `sessions` at all, and the leases
+        // table arrived separately. Naming a missing table would otherwise turn
+        // an old install into a silent, permanent "nothing running".
+        let tables = Set(SQLiteStore.rows(
+            in: db,
+            sql: """
+            SELECT name FROM sqlite_master
+            WHERE type = 'table' AND name IN ('sessions', 'session_turn_leases')
+            """
+        ))
+        guard tables.contains("sessions") else { return [] }
+
+        // Epoch seconds as REAL, and `SQLiteStore` has no parameter binding, so
+        // the bounds go in as integer literals.
+        let nowSeconds = Int(now.timeIntervalSince1970)
+        let cutoffSeconds = nowSeconds - Int(staleAfter)
+        let lease = tables.contains("session_turn_leases")
+            ? """
+
+                     OR EXISTS (SELECT 1 FROM session_turn_leases l
+                                WHERE l.conversation_id = s.id AND l.expires_at > \(nowSeconds))
+            """
+            : ""
+
+        let rows = SQLiteStore.rows(
+            in: db,
+            sql: """
+            SELECT s.id, s.title, s.cwd, s.started_at, s.last_activity_at
+            FROM sessions s
+            WHERE s.billing_provider = 'gemini' AND s.ended_at IS NULL
+              AND (s.last_activity_at >= \(cutoffSeconds)\(lease))
+            ORDER BY s.last_activity_at DESC
+            """,
+            columns: 5
+        )
+
+        return rows.map { row in
+            let cwd = row[2].trimmingCharacters(in: .whitespacesAndNewlines)
+            let title = row[1].trimmingCharacters(in: .whitespacesAndNewlines)
+            let detail: String
+            if !cwd.isEmpty {
+                detail = "Working in \(URL(fileURLWithPath: cwd).lastPathComponent)"
+            } else if !title.isEmpty {
+                detail = title
+            } else {
+                detail = "Working"
+            }
+            // A session that somehow lost its start time is still running; the
+            // tooltip's elapsed time is the only thing that suffers.
+            let started = Double(row[3]).map(Date.init(timeIntervalSince1970:)) ?? now
+            return AgentSession(
+                id: "gemini-api.hermes.\(row[0])",
+                name: "Hermes",
+                detail: detail,
+                state: .busy,
+                waitingFor: nil,
+                since: started
+            )
+        }
+    }
+}

--- a/Sources/Sessions/OpenCodeGeminiActivity.swift
+++ b/Sources/Sessions/OpenCodeGeminiActivity.swift
@@ -1,0 +1,100 @@
+import Foundation
+import SQLite3
+
+/// Notices when OpenCode is mid-turn against the Gemini API key.
+///
+/// OpenCode's database is written for reasons that have nothing to do with a
+/// Gemini call, so its modification date says nothing this provider may claim.
+/// Each message row, however, records who answered it and whether the answer
+/// finished:
+///
+/// ```
+/// message(id TEXT, session_id TEXT, time_created INTEGER, time_updated INTEGER, data TEXT)
+/// {"role":"assistant","providerID":"google","modelID":"gemini-2.5-pro",
+///  "time":{"created":1789000000000,"completed":1789000004120},"finish":"stop", …}
+/// ```
+///
+/// `time.completed` is written only once the turn is over — while the model is
+/// still answering the key is simply absent — so an assistant row with
+/// `providerID == "google"` and no `completed` is a Gemini call in flight, and
+/// that is the only thing here that is this provider's to report.
+///
+/// The query looks at one message per session, the newest, because `message`'s
+/// only index is `(session_id, time_created, id)`: there is no way to ask "what
+/// changed lately" across the whole table, and this poll runs on the main actor
+/// every couple of seconds. `session.time_updated` is the cheap pre-filter, and
+/// the last message of each recently touched session is then the only JSON that
+/// has to be decoded.
+///
+/// Sub-agent sessions carry `parent_id`, and a sub-agent is the same piece of
+/// work as the session that spawned it — folding it into its parent keeps one
+/// row in the tooltip instead of two that mean the same thing.
+///
+/// `staleAfter` still applies on top of the unfinished-message marker: a server
+/// that crashed mid-turn leaves `completed` missing forever, and without the
+/// recency bound that dead row would spin the ring for the rest of the month.
+enum OpenCodeGeminiActivity {
+    static var database: URL { OpenCodeGeminiUsage.database }
+
+    static func read(
+        database: URL = OpenCodeGeminiActivity.database,
+        staleAfter: TimeInterval,
+        now: Date = Date()
+    ) -> [AgentSession] {
+        guard let db = SQLiteStore.open(database) else { return [] }
+        defer { sqlite3_close(db) }
+
+        let cutoffMillis = Int((now.timeIntervalSince1970 - staleAfter) * 1000)
+        let rows = SQLiteStore.rows(
+            in: db,
+            sql: """
+            SELECT r.id, r.title, r.directory, m.time_created, m.time_updated, m.data
+            FROM session s
+            JOIN session r ON r.id = COALESCE(s.parent_id, s.id)
+            JOIN message m ON m.id = (SELECT id FROM message WHERE session_id = s.id
+                                      ORDER BY time_created DESC LIMIT 1)
+            WHERE s.time_updated >= \(cutoffMillis)
+            ORDER BY m.time_updated DESC
+            """,
+            columns: 6
+        )
+
+        var seen: Set<String> = []
+        var out: [AgentSession] = []
+        for row in rows {
+            let root = row[0]
+            guard !root.isEmpty, !seen.contains(root) else { continue }
+            guard let updated = Double(row[4]), Int(updated) >= cutoffMillis else { continue }
+            guard let created = Double(row[3]) else { continue }
+            guard isUnfinishedGoogleTurn(row[5]) else { continue }
+
+            seen.insert(root)
+            let directory = row[2]
+            let detail = directory.isEmpty
+                ? row[1]
+                : URL(fileURLWithPath: directory).lastPathComponent
+            out.append(AgentSession(
+                id: "gemini-api.opencode.\(root)",
+                name: "OpenCode",
+                detail: "Working in \(detail)",
+                state: .busy,
+                waitingFor: nil,
+                since: Date(timeIntervalSince1970: created / 1000)
+            ))
+        }
+        return out
+    }
+
+    /// A JSON `null` arrives as `NSNull` rather than as a missing key, and both
+    /// shapes mean the same thing here: nobody has recorded an end yet.
+    private static func isUnfinishedGoogleTurn(_ data: String) -> Bool {
+        guard let bytes = data.data(using: .utf8),
+              let object = try? JSONSerialization.jsonObject(with: bytes),
+              let message = object as? [String: Any],
+              message["role"] as? String == "assistant",
+              message["providerID"] as? String == "google" else { return false }
+        guard let time = message["time"] as? [String: Any] else { return true }
+        let completed = time["completed"]
+        return completed == nil || completed is NSNull
+    }
+}

--- a/TASKS.md
+++ b/TASKS.md
@@ -1125,12 +1125,25 @@ it and then notice when the answer changes.
 - [x] Counts are compacted for the ring (`651k`, `1.1M`). A 44 pt ring cannot
       hold seven digits, and below 10 000 the digits are printed verbatim so no
       existing request or credit count changes.
-- [x] Busy detection watches **Gemini CLI only**, by modification date. The
-      session file holds no pid, so `ProcessLiveness` has nothing to verify, but
-      the CLI patches `lastUpdated` on every message — the same mtime substitute
-      Antigravity and Cursor use. OpenCode's and Hermes's databases are written
-      for reasons that have nothing to do with a Gemini call, so their mtimes
-      would report work that is not this provider's.
+- [x] Busy detection watches **Gemini CLI**, by modification date: the session
+      file holds no pid, so `ProcessLiveness` has nothing to verify, but the CLI
+      patches `lastUpdated` on every message — the same mtime substitute
+      Antigravity and Cursor use. The ring now merges three readers under
+      `gemini-api`, in tooltip order (Gemini CLI, OpenCode, Hermes), because
+      OpenCode's and Hermes's databases do carry a per-call marker that is
+      unambiguously a Gemini call, even though their mtimes alone would report
+      work that is not this provider's. OpenCode's marker is the newest
+      assistant message in a recently updated session with `providerID =
+      google` and no `time.completed`; sub-agent sessions fold into their
+      parent via `parent_id`, and the query is restricted to
+      `session.time_updated` within 45 s because `message` has no time index.
+      Hermes's marker is an open (`ended_at IS NULL`) session with
+      `billing_provider = gemini` whose `last_activity_at` is within 45 s, or an
+      unexpired row in `session_turn_leases`. None of the three tools persists
+      a "waiting for the user" state on disk — OpenCode exposes one only on its
+      password-protected local server's SSE stream — so the provider reports
+      busy or nothing, like Cursor and Antigravity, not Claude's busy/waiting/
+      idle.
 - [x] **Two departures from the provider template**, both deliberate. The
       protocol extension's default `signInRoute` offers to sign in, and here
       there is nothing to sign into, so this provider overrides it with a

--- a/Tests/GeminiAPITests.swift
+++ b/Tests/GeminiAPITests.swift
@@ -597,7 +597,7 @@ final class GeminiAPISnapshotTests: XCTestCase {
 /// its own modification date: the machine's clock must not decide whether a
 /// test passes.
 @MainActor
-final class GeminiCLIActivityMonitorTests: XCTestCase {
+final class GeminiCLIActivityTests: XCTestCase {
     private var root: URL!
     private let now = Date(timeIntervalSince1970: 1_789_000_000)
 
@@ -634,7 +634,7 @@ final class GeminiCLIActivityMonitorTests: XCTestCase {
 
     func testAJustWrittenSessionReadsAsWorking() throws {
         try session(project: "9d2c", projectRoot: "/Users/x/Projects/codenotch", modified: now)
-        let sessions = GeminiCLIActivityMonitor.read(root: root, staleAfter: 45, now: now)
+        let sessions = GeminiCLIActivity.read(root: root, staleAfter: 45, now: now)
         XCTAssertEqual(sessions.count, 1)
         XCTAssertEqual(sessions.first?.state, .busy)
         XCTAssertEqual(sessions.first?.name, "Gemini CLI")
@@ -645,12 +645,12 @@ final class GeminiCLIActivityMonitorTests: XCTestCase {
     /// A finished turn is not work in progress.
     func testAnOldSessionIsNotWorking() throws {
         try session(project: "9d2c", modified: now.addingTimeInterval(-60))
-        XCTAssertTrue(GeminiCLIActivityMonitor.read(root: root, staleAfter: 45, now: now).isEmpty)
+        XCTAssertTrue(GeminiCLIActivity.read(root: root, staleAfter: 45, now: now).isEmpty)
     }
 
     func testNoSessionsIsQuietRatherThanAnError() {
         let absent = root.appendingPathComponent("nowhere")
-        XCTAssertTrue(GeminiCLIActivityMonitor.read(root: absent, staleAfter: 45, now: now).isEmpty)
+        XCTAssertTrue(GeminiCLIActivity.read(root: absent, staleAfter: 45, now: now).isEmpty)
     }
 
     /// Projects accumulate under `~/.gemini/tmp`; only the newest file says what
@@ -660,7 +660,7 @@ final class GeminiCLIActivityMonitorTests: XCTestCase {
                     modified: now.addingTimeInterval(-600))
         try session(project: "live", name: "session-live", projectRoot: "/Users/x/live-thing",
                     modified: now)
-        let sessions = GeminiCLIActivityMonitor.read(root: root, staleAfter: 45, now: now)
+        let sessions = GeminiCLIActivity.read(root: root, staleAfter: 45, now: now)
         XCTAssertEqual(sessions.count, 1)
         XCTAssertEqual(sessions.first?.id, "gemini-api.session-live")
         XCTAssertEqual(sessions.first?.detail, "Working in live-thing")
@@ -671,7 +671,462 @@ final class GeminiCLIActivityMonitorTests: XCTestCase {
     /// session its row.
     func testAMissingProjectRootFallsBackToTheDirectoryName() throws {
         try session(project: "9d2c", modified: now)
-        let sessions = GeminiCLIActivityMonitor.read(root: root, staleAfter: 45, now: now)
+        let sessions = GeminiCLIActivity.read(root: root, staleAfter: 45, now: now)
         XCTAssertEqual(sessions.first?.detail, "Working in 9d2c")
+    }
+}
+
+/// Hermes leaves a session open long after the last question, so the tests are
+/// mostly about what does *not* count: an old session, a closed one, another
+/// provider's, and a lease that has run out.
+final class HermesGeminiActivityTests: XCTestCase {
+    private let now = Date(timeIntervalSince1970: 1_789_000_000)
+    private var databases: [URL] = []
+
+    override func tearDownWithError() throws {
+        for url in databases { try? FileManager.default.removeItem(at: url) }
+        databases = []
+    }
+
+    /// One row of `sessions`, defaulted to a live Gemini turn so each test
+    /// states only what it is about.
+    private struct Row {
+        var id = "s1"
+        var provider = "gemini"
+        var startedAt: Date
+        var endedAt: Date?
+        var lastActivityAt: Date
+        var cwd = "/Users/x/Projects/codenotch"
+        var title = "Untitled"
+        /// When set, a `session_turn_leases` row for this session.
+        var leaseExpiresAt: Date?
+    }
+
+    /// Written and closed before the reader opens it, so the WAL is
+    /// checkpointed away — the same state a quit Hermes leaves behind.
+    /// `withLeases: false` is the pre-lease schema.
+    private func makeDatabase(rows: [Row], withLeases: Bool = true) throws -> URL {
+        let url = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("hermes-activity-\(UUID().uuidString).db")
+        databases.append(url)
+
+        var db: OpaquePointer?
+        XCTAssertEqual(sqlite3_open(url.path, &db), SQLITE_OK)
+        sqlite3_exec(db, "PRAGMA journal_mode=WAL;", nil, nil, nil)
+        sqlite3_exec(db, """
+        CREATE TABLE sessions (
+            id TEXT PRIMARY KEY, source TEXT NOT NULL DEFAULT '',
+            started_at REAL, ended_at REAL, last_activity_at REAL,
+            billing_provider TEXT NOT NULL DEFAULT '',
+            cwd TEXT NOT NULL DEFAULT '', title TEXT NOT NULL DEFAULT '',
+            model TEXT NOT NULL DEFAULT '');
+        """, nil, nil, nil)
+        if withLeases {
+            sqlite3_exec(db, """
+            CREATE TABLE session_turn_leases (
+                conversation_id TEXT PRIMARY KEY, holder TEXT NOT NULL DEFAULT '',
+                acquired_at REAL, expires_at REAL);
+            """, nil, nil, nil)
+        }
+        for row in rows {
+            let ended = row.endedAt.map { "\($0.timeIntervalSince1970)" } ?? "NULL"
+            sqlite3_exec(db, """
+            INSERT INTO sessions VALUES (
+                '\(row.id)', 'desktop', \(row.startedAt.timeIntervalSince1970), \(ended),
+                \(row.lastActivityAt.timeIntervalSince1970), '\(row.provider)',
+                '\(row.cwd)', '\(row.title)', 'gemini-2.5-pro');
+            """, nil, nil, nil)
+            if withLeases, let expires = row.leaseExpiresAt {
+                sqlite3_exec(db, """
+                INSERT INTO session_turn_leases VALUES (
+                    '\(row.id)', 'turn', \(expires.timeIntervalSince1970 - 60),
+                    \(expires.timeIntervalSince1970));
+                """, nil, nil, nil)
+            }
+        }
+        sqlite3_close(db)
+        return url
+    }
+
+    func testAnOpenGeminiSessionJustTouchedReadsAsWorking() throws {
+        let url = try makeDatabase(rows: [
+            Row(startedAt: now.addingTimeInterval(-300), lastActivityAt: now)
+        ])
+        let sessions = HermesGeminiActivity.read(database: url, staleAfter: 45, now: now)
+        XCTAssertEqual(sessions.count, 1)
+        XCTAssertEqual(sessions.first?.id, "gemini-api.hermes.s1")
+        XCTAssertEqual(sessions.first?.name, "Hermes")
+        XCTAssertEqual(sessions.first?.detail, "Working in codenotch")
+        XCTAssertEqual(sessions.first?.state, .busy)
+        XCTAssertEqual(sessions.first?.since, now.addingTimeInterval(-300))
+    }
+
+    /// A model can think for minutes without writing anything, and the lease is
+    /// the tool's own word that a turn is running.
+    func testAnUnexpiredLeaseKeepsAQuietSessionBusy() throws {
+        let url = try makeDatabase(rows: [
+            Row(startedAt: now.addingTimeInterval(-600),
+                lastActivityAt: now.addingTimeInterval(-300),
+                leaseExpiresAt: now.addingTimeInterval(120))
+        ])
+        XCTAssertEqual(
+            HermesGeminiActivity.read(database: url, staleAfter: 45, now: now).count, 1)
+    }
+
+    /// The lease expires on a wall clock, so a session whose holder died stops
+    /// claiming to work without anyone tidying up.
+    func testAnExpiredLeaseAndOldActivityIsNotWorking() throws {
+        let url = try makeDatabase(rows: [
+            Row(startedAt: now.addingTimeInterval(-600),
+                lastActivityAt: now.addingTimeInterval(-300),
+                leaseExpiresAt: now.addingTimeInterval(-120))
+        ])
+        XCTAssertTrue(
+            HermesGeminiActivity.read(database: url, staleAfter: 45, now: now).isEmpty)
+    }
+
+    func testAClosedSessionIsNotWorking() throws {
+        let url = try makeDatabase(rows: [
+            Row(startedAt: now.addingTimeInterval(-300), endedAt: now, lastActivityAt: now)
+        ])
+        XCTAssertTrue(
+            HermesGeminiActivity.read(database: url, staleAfter: 45, now: now).isEmpty)
+    }
+
+    /// Hermes bills several providers from the same table; only the Gemini API
+    /// key belongs to this ring.
+    func testAnotherProvidersSessionIsNotWorking() throws {
+        let url = try makeDatabase(rows: [
+            Row(provider: "lmstudio", startedAt: now.addingTimeInterval(-300),
+                lastActivityAt: now)
+        ])
+        XCTAssertTrue(
+            HermesGeminiActivity.read(database: url, staleAfter: 45, now: now).isEmpty)
+    }
+
+    /// A session started outside any project has no folder to name.
+    func testAnEmptyWorkingDirectoryFallsBackToTheTitle() throws {
+        let url = try makeDatabase(rows: [
+            Row(startedAt: now.addingTimeInterval(-300), lastActivityAt: now,
+                cwd: "", title: "Refactor the parser")
+        ])
+        XCTAssertEqual(
+            HermesGeminiActivity.read(database: url, staleAfter: 45, now: now).first?.detail,
+            "Refactor the parser")
+    }
+
+    /// An older Hermes has no lease table. Naming it would fail the whole query,
+    /// which would report every session as idle forever.
+    func testADatabaseWithoutTheLeaseTableStillReportsByRecency() throws {
+        let url = try makeDatabase(rows: [
+            Row(startedAt: now.addingTimeInterval(-300), lastActivityAt: now)
+        ], withLeases: false)
+        XCTAssertEqual(
+            HermesGeminiActivity.read(database: url, staleAfter: 45, now: now).count, 1)
+    }
+
+    func testAMissingDatabaseIsQuietRatherThanAnError() {
+        let absent = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("hermes-nowhere-\(UUID().uuidString).db")
+        XCTAssertTrue(
+            HermesGeminiActivity.read(database: absent, staleAfter: 45, now: now).isEmpty)
+    }
+}
+
+/// The busy signal here is a message OpenCode has not finished writing, not a
+/// file's modification date, so every fixture states the two timestamps and the
+/// recorded `time.completed` shape explicitly.
+final class OpenCodeGeminiActivityTests: XCTestCase {
+    private let now = Date(timeIntervalSince1970: 1_789_000_000)
+    private var databases: [URL] = []
+
+    override func tearDownWithError() throws {
+        for url in databases { try? FileManager.default.removeItem(at: url) }
+        databases = []
+    }
+
+    private struct SessionRow {
+        let id: String
+        var parentID: String?
+        var title: String = ""
+        var directory: String = ""
+        let updated: Date
+    }
+
+    private struct MessageRow {
+        let id: String
+        let sessionID: String
+        let created: Date
+        let updated: Date
+        let data: String
+    }
+
+    /// Written and closed before the reader opens it, so the WAL is
+    /// checkpointed away — the same state a quit OpenCode leaves behind.
+    private func makeDatabase(sessions: [SessionRow], messages: [MessageRow]) throws -> URL {
+        let url = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("opencode-activity-\(UUID().uuidString).db")
+        databases.append(url)
+
+        var db: OpaquePointer?
+        XCTAssertEqual(sqlite3_open(url.path, &db), SQLITE_OK)
+        sqlite3_exec(db, "PRAGMA journal_mode=WAL;", nil, nil, nil)
+        sqlite3_exec(db, """
+        CREATE TABLE session (id TEXT, parent_id TEXT, title TEXT, directory TEXT,
+                              time_updated INTEGER);
+        CREATE TABLE message (id TEXT, session_id TEXT, time_created INTEGER,
+                              time_updated INTEGER, data TEXT);
+        """, nil, nil, nil)
+        for row in sessions {
+            let parent = row.parentID.map { "'\($0)'" } ?? "NULL"
+            sqlite3_exec(db, """
+            INSERT INTO session VALUES ('\(row.id)', \(parent), '\(row.title)',
+                                        '\(row.directory)',
+                                        \(Int(row.updated.timeIntervalSince1970 * 1000)));
+            """, nil, nil, nil)
+        }
+        for row in messages {
+            sqlite3_exec(db, """
+            INSERT INTO message VALUES ('\(row.id)', '\(row.sessionID)',
+                                        \(Int(row.created.timeIntervalSince1970 * 1000)),
+                                        \(Int(row.updated.timeIntervalSince1970 * 1000)),
+                                        '\(row.data)');
+            """, nil, nil, nil)
+        }
+        sqlite3_close(db)
+        return url
+    }
+
+    private func message(
+        provider: String = "google",
+        role: String = "assistant",
+        created: Date,
+        completed: Date? = nil
+    ) -> String {
+        let completedField = completed
+            .map { #","completed":\#(Int($0.timeIntervalSince1970 * 1000))"# } ?? ""
+        return #"{"role":"\#(role)","providerID":"\#(provider)","modelID":"gemini-2.5-pro","#
+            + #""time":{"created":\#(Int(created.timeIntervalSince1970 * 1000))\#(completedField)}}"#
+    }
+
+    func testAnUnfinishedGoogleTurnReadsAsWorking() throws {
+        let url = try makeDatabase(
+            sessions: [SessionRow(id: "s1", directory: "/Users/x/Projects/codenotch",
+                                  updated: now)],
+            messages: [MessageRow(id: "m1", sessionID: "s1", created: now, updated: now,
+                                  data: message(created: now))]
+        )
+        let sessions = OpenCodeGeminiActivity.read(database: url, staleAfter: 45, now: now)
+        XCTAssertEqual(sessions.count, 1)
+        XCTAssertEqual(sessions.first?.id, "gemini-api.opencode.s1")
+        XCTAssertEqual(sessions.first?.name, "OpenCode")
+        XCTAssertEqual(sessions.first?.detail, "Working in codenotch")
+        XCTAssertEqual(sessions.first?.state, .busy)
+        XCTAssertEqual(sessions.first?.since, now)
+        XCTAssertNil(sessions.first?.processID)
+    }
+
+    /// `time.completed` is the whole marker: once OpenCode writes it the turn
+    /// is over, however recently the row was touched.
+    func testAFinishedTurnIsNotWorking() throws {
+        let url = try makeDatabase(
+            sessions: [SessionRow(id: "s1", directory: "/Users/x/Projects/codenotch",
+                                  updated: now)],
+            messages: [MessageRow(id: "m1", sessionID: "s1", created: now, updated: now,
+                                  data: message(created: now, completed: now))]
+        )
+        XCTAssertTrue(OpenCodeGeminiActivity.read(database: url, staleAfter: 45, now: now).isEmpty)
+    }
+
+    /// OpenCode talks to several providers out of one database, and only
+    /// `google` is the Gemini API key this ring is about.
+    func testAnotherProvidersTurnIsNotWorking() throws {
+        let url = try makeDatabase(
+            sessions: [SessionRow(id: "s1", directory: "/Users/x/Projects/codenotch",
+                                  updated: now)],
+            messages: [MessageRow(id: "m1", sessionID: "s1", created: now, updated: now,
+                                  data: message(provider: "lmstudio", created: now))]
+        )
+        XCTAssertTrue(OpenCodeGeminiActivity.read(database: url, staleAfter: 45, now: now).isEmpty)
+    }
+
+    func testAnOldUnfinishedTurnIsNotWorking() throws {
+        let old = now.addingTimeInterval(-600)
+        let url = try makeDatabase(
+            sessions: [SessionRow(id: "s1", directory: "/Users/x/Projects/codenotch",
+                                  updated: old)],
+            messages: [MessageRow(id: "m1", sessionID: "s1", created: old, updated: old,
+                                  data: message(created: old))]
+        )
+        XCTAssertTrue(OpenCodeGeminiActivity.read(database: url, staleAfter: 45, now: now).isEmpty)
+    }
+
+    /// A server that died mid-turn leaves `completed` missing forever while the
+    /// session row keeps being touched, so recency has to be checked on the
+    /// message itself and not only in the SQL pre-filter.
+    func testAFreshSessionWithAStaleMessageIsNotWorking() throws {
+        let old = now.addingTimeInterval(-600)
+        let url = try makeDatabase(
+            sessions: [SessionRow(id: "s1", directory: "/Users/x/Projects/codenotch",
+                                  updated: now)],
+            messages: [MessageRow(id: "m1", sessionID: "s1", created: old, updated: old,
+                                  data: message(created: old))]
+        )
+        XCTAssertTrue(OpenCodeGeminiActivity.read(database: url, staleAfter: 45, now: now).isEmpty)
+    }
+
+    /// A sub-agent is the same piece of work as the session that spawned it.
+    func testASubAgentSessionReportsItsParentOnce() throws {
+        let earlier = now.addingTimeInterval(-5)
+        let url = try makeDatabase(
+            sessions: [
+                SessionRow(id: "p1", directory: "/Users/x/Projects/codenotch", updated: now),
+                SessionRow(id: "c1", parentID: "p1", title: "subagent", updated: now)
+            ],
+            messages: [
+                MessageRow(id: "m1", sessionID: "p1", created: earlier, updated: earlier,
+                           data: message(created: earlier)),
+                MessageRow(id: "m2", sessionID: "c1", created: now, updated: now,
+                           data: message(created: now))
+            ]
+        )
+        let sessions = OpenCodeGeminiActivity.read(database: url, staleAfter: 45, now: now)
+        XCTAssertEqual(sessions.count, 1)
+        XCTAssertEqual(sessions.first?.id, "gemini-api.opencode.p1")
+        XCTAssertEqual(sessions.first?.detail, "Working in codenotch")
+    }
+
+    /// A session started outside a project has no directory to name, and the
+    /// title it was given is the next best thing.
+    func testAnEmptyDirectoryFallsBackToTheTitle() throws {
+        let url = try makeDatabase(
+            sessions: [SessionRow(id: "s1", title: "scratch", updated: now)],
+            messages: [MessageRow(id: "m1", sessionID: "s1", created: now, updated: now,
+                                  data: message(created: now))]
+        )
+        XCTAssertEqual(
+            OpenCodeGeminiActivity.read(database: url, staleAfter: 45, now: now).first?.detail,
+            "Working in scratch"
+        )
+    }
+
+    func testAMissingDatabaseReadsAsNoSessions() {
+        let missing = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("opencode-activity-\(UUID().uuidString).db")
+        XCTAssertTrue(
+            OpenCodeGeminiActivity.read(database: missing, staleAfter: 45, now: now).isEmpty
+        )
+    }
+}
+
+/// The three readers answer under one provider id, and the tooltip draws them
+/// in the order they arrive, so the order the monitor concatenates them in is
+/// the behaviour worth pinning: anything else would reshuffle the ring on every
+/// tick. The fixtures are the smallest shape each reader accepts, repeated here
+/// rather than inherited so a change to one reader's test cannot quietly move
+/// this one.
+@MainActor
+final class GeminiAPIActivityMonitorTests: XCTestCase {
+    private let now = Date(timeIntervalSince1970: 1_789_000_000)
+    private var temporaries: [URL] = []
+
+    override func tearDownWithError() throws {
+        for url in temporaries { try? FileManager.default.removeItem(at: url) }
+        temporaries = []
+    }
+
+    private func temporary(_ name: String) -> URL {
+        let url = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("gemini-api-monitor-\(UUID().uuidString)-\(name)")
+        temporaries.append(url)
+        return url
+    }
+
+    /// One project with one chat file written just now.
+    private func makeGeminiRoot() throws -> URL {
+        let root = temporary("gemini")
+        let chats = root.appendingPathComponent("9d2c/chats")
+        try FileManager.default.createDirectory(at: chats, withIntermediateDirectories: true)
+        try "/Users/x/Projects/codenotch".write(
+            to: root.appendingPathComponent("9d2c/.project_root"),
+            atomically: true, encoding: .utf8)
+        let file = chats.appendingPathComponent("session-a.jsonl")
+        try "{}".write(to: file, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.modificationDate: now],
+                                              ofItemAtPath: file.path)
+        return root
+    }
+
+    /// One session whose newest assistant message has no `time.completed`.
+    private func makeOpenCodeDatabase() throws -> URL {
+        let url = temporary("opencode.db")
+        let millis = Int(now.timeIntervalSince1970 * 1000)
+        var db: OpaquePointer?
+        XCTAssertEqual(sqlite3_open(url.path, &db), SQLITE_OK)
+        sqlite3_exec(db, """
+        CREATE TABLE session (id TEXT, parent_id TEXT, title TEXT, directory TEXT,
+                              time_updated INTEGER);
+        CREATE TABLE message (id TEXT, session_id TEXT, time_created INTEGER,
+                              time_updated INTEGER, data TEXT);
+        INSERT INTO session VALUES ('s1', NULL, 'scratch', '/Users/x/Projects/codenotch',
+                                    \(millis));
+        INSERT INTO message VALUES ('m1', 's1', \(millis), \(millis),
+            '{"role":"assistant","providerID":"google","time":{"created":\(millis)}}');
+        """, nil, nil, nil)
+        sqlite3_close(db)
+        return url
+    }
+
+    /// One open Gemini session touched just now.
+    private func makeHermesDatabase() throws -> URL {
+        let url = temporary("hermes.db")
+        let seconds = now.timeIntervalSince1970
+        var db: OpaquePointer?
+        XCTAssertEqual(sqlite3_open(url.path, &db), SQLITE_OK)
+        sqlite3_exec(db, """
+        CREATE TABLE sessions (
+            id TEXT PRIMARY KEY, source TEXT NOT NULL DEFAULT '',
+            started_at REAL, ended_at REAL, last_activity_at REAL,
+            billing_provider TEXT NOT NULL DEFAULT '',
+            cwd TEXT NOT NULL DEFAULT '', title TEXT NOT NULL DEFAULT '',
+            model TEXT NOT NULL DEFAULT '');
+        CREATE TABLE session_turn_leases (
+            conversation_id TEXT PRIMARY KEY, holder TEXT NOT NULL DEFAULT '',
+            acquired_at REAL, expires_at REAL);
+        INSERT INTO sessions VALUES ('h1', 'desktop', \(seconds - 300), NULL, \(seconds),
+                                     'gemini', '/Users/x/Projects/codenotch', 'Untitled',
+                                     'gemini-2.5-pro');
+        """, nil, nil, nil)
+        sqlite3_close(db)
+        return url
+    }
+
+    func testTheThreeSourcesAreReportedInTooltipOrder() throws {
+        let sessions = GeminiAPIActivityMonitor.read(
+            geminiRoot: try makeGeminiRoot(),
+            opencodeDatabase: try makeOpenCodeDatabase(),
+            hermesDatabase: try makeHermesDatabase(),
+            staleAfter: 45,
+            now: now
+        )
+        XCTAssertEqual(sessions.map(\.name), ["Gemini CLI", "OpenCode", "Hermes"])
+        XCTAssertEqual(sessions.map(\.id), [
+            "gemini-api.session-a",
+            "gemini-api.opencode.s1",
+            "gemini-api.hermes.h1"
+        ])
+        XCTAssertTrue(sessions.allSatisfy { $0.state == .busy })
+    }
+
+    /// A machine with none of the three tools installed must read as quiet, not
+    /// as an error the ring cannot show.
+    func testNoSourceAtAllReadsAsNoSessions() {
+        XCTAssertTrue(GeminiAPIActivityMonitor.read(
+            geminiRoot: temporary("gemini"),
+            opencodeDatabase: temporary("opencode.db"),
+            hermesDatabase: temporary("hermes.db"),
+            staleAfter: 45,
+            now: now
+        ).isEmpty)
     }
 }


### PR DESCRIPTION
## What

The `gemini-api` ring now merges three activity readers instead of one, in the
same order as the provider's tooltip rows: Gemini CLI, then OpenCode, then
Hermes. Fixing the order keeps the ring from reshuffling between ticks.

Gemini CLI is read exactly as before, by the modification date of its chat
files. `TASKS.md` had deliberately left OpenCode and Hermes out because their
databases change for reasons unrelated to a Gemini call. Both of them do carry
a per-call provider marker, which is what removes that ambiguity.

## How each tool is read

**OpenCode** (`~/.local/share/opencode/opencode.db`): the newest message of
each session updated within the last 45 seconds counts as a turn in flight
when it is an assistant message with `providerID = google` and no
`time.completed`. Sub-agent sessions fold into their parent through
`parent_id`, so one ring entry per conversation. The query is pre-filtered on
`session.time_updated` because `message` is large and its only index is
`(session_id, time_created, id)`, with no index on time alone.

**Hermes** (`~/.hermes/state.db`): an open session, meaning
`billing_provider = gemini` and `ended_at IS NULL`, counts as busy when either
`last_activity_at` falls within 45 seconds or an unexpired row exists in
`session_turn_leases`. Openness alone is not enough, since a desktop session
stays open for hours. The lease table is probed through `sqlite_master` first,
so an older schema without it still reports by recency.

Both databases are opened read-only through the existing `SQLiteStore`
(`mode=ro`, then `immutable=1`), and any missing file or query error reads as
no sessions rather than throwing.

## Limits

None of the three tools persists a "waiting for the user" state on disk, so
this provider reports busy or nothing, like Cursor and Antigravity rather than
Claude. OpenCode exposes that state only on its password-protected local
server's SSE stream. Gemini CLI sessions driven through `--acp` remain
invisible while working, because those processes never touch the chat files.

## Tests

New: `OpenCodeGeminiActivityTests`, `HermesGeminiActivityTests`,
`GeminiAPIActivityMonitorTests`. `GeminiCLIActivityMonitorTests` is renamed to
`GeminiCLIActivityTests` and points at the reduced `GeminiCLIActivity`. Both
new readers are tested against throwaway SQLite files built with the sqlite3 C
API against a fixed clock. Full bundle green: 1128 tests, 1 skipped, 0
failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CjnC14aSCnDai346KwPAVs
