### PR TITLE
Take the Apple Development team from the certificate's OU

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,8 +34,15 @@ HAS_DEVELOPER_ID := $(shell security find-identity -v -p codesigning 2>/dev/null
 # build. Read its team from a valid signing identity: a certificate can remain
 # in the keychain without its private key, and choosing it would fail the
 # build. With nothing parsed, ad-hoc is the fallback and needs no Apple account.
-DEV_TEAM := $(shell security find-identity -v -p codesigning 2>/dev/null \
-	| sed -n 's/.*"Apple Development: .* (\([A-Z0-9]*\))".*/\1/p' | head -1)
+# The team is the certificate subject's OU, not the bracketed value in the CN
+# — that bracketed value is the developer's own id, which only coincides with
+# the Team ID on some accounts. On a personal team it does not, so reading it
+# had Xcode look for a certificate of a team that does not exist.
+DEV_IDENTITY := $(shell security find-identity -v -p codesigning 2>/dev/null \
+	| sed -n 's/.*"\(Apple Development: [^"]*\)".*/\1/p' | head -1)
+DEV_TEAM := $(if $(DEV_IDENTITY),$(shell security find-certificate -c "$(DEV_IDENTITY)" -p 2>/dev/null \
+	| openssl x509 -noout -subject -nameopt sep_multiline 2>/dev/null \
+	| sed -n 's/^ *OU=\([A-Z0-9]*\)$$/\1/p' | head -1))
 
 ifeq (,$(HAS_DEVELOPER_ID))
 ifeq (,$(DEV_TEAM))


### PR DESCRIPTION
## Problem

The Makefile picked the signing team out of the bracketed value in the Apple Development identity's common name. That value is the developer's own id, and it equals the Team ID only on some accounts. On a personal team the two differ, so Xcode was handed a team that does not exist and `make build` / `make test` failed with "no signing certificate matching team ID".

## Fix

Read the Team ID from the OU of the subject of the same certificate, via `security find-certificate` piped through `openssl x509 -subject`. The identity is still chosen with the existing "valid identity only" guard, so a certificate whose private key is missing is never picked.

## Relation to other PRs

- This commit is also part of #109 and will drop out of it once this is merged.
- #116 fixes a different bug in the same file, the `grep -c` guard for the ad-hoc signing fallback. The two changes are independent.
- #127 had to be tested with manual `CODE_SIGN_*` overrides, because upstream `main` still lacks this fix.

## Verified

`make build` on an Apple Silicon machine with a personal-team Apple Development certificate, with no `CODE_SIGN_*` or `DEVELOPMENT_TEAM` overrides on the command line. Ends in `** BUILD SUCCEEDED **`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CjnC14aSCnDai346KwPAVs
