### PR TITLE
Add a move handle for putting the notch on another edge

### DIFF
--- a/Sources/App/AppDelegate.swift
+++ b/Sources/App/AppDelegate.swift
@@ -308,6 +308,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 preferences?.setOffset(offset, for: preferences?.notchEdge ?? .right)
             }
 
+            // Writing the preference is the whole of it: `notchEdge` is
+            // `@Published` and the fleet already follows it, so the notch
+            // relocates by the same path the Settings picker uses.
+            fleet.onMoveToEdge = { [weak preferences] edge in
+                preferences?.notchEdge = edge
+            }
+
             preferences.$resetTimeFormat
                 .receive(on: RunLoop.main)
                 .sink { [weak fleet] in fleet?.apply(resetTimeFormat: $0) }

--- a/Sources/Features/EdgeDropZones.swift
+++ b/Sources/Features/EdgeDropZones.swift
@@ -1,0 +1,122 @@
+import SwiftUI
+
+/// The four places the notch can land, shown while one is being carried.
+///
+/// Drawn as the notch's own outline rather than as a generic rectangle: the
+/// shape differs per edge — a side edge is a tall pill, a horizontal one is a
+/// wide bar — and showing the real silhouette is what makes the choice legible
+/// before you commit to it.
+///
+/// All four are always visible while carrying, and the one under the pointer
+/// grows and solidifies. Showing only the nearest would mean discovering the
+/// other three by sweeping the pointer around, which is the thing a preview is
+/// supposed to save you from.
+struct EdgeDropZones: View {
+    /// Which zone the pointer is currently over, if any.
+    let target: NotchEdge?
+    /// The screen this is covering, in its own local coordinates.
+    let size: CGSize
+    /// The notch's resting footprint, so a zone is the size the notch will
+    /// actually be rather than a guess.
+    let restingDepth: CGFloat
+    let restingLength: CGFloat
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    /// Long dashes with a clear gap. Short ones blur into a solid line at the
+    /// length these outlines run — a bottom zone is most of the screen wide.
+    private static let dash: [CGFloat] = [Design.px(34), Design.px(26)]
+    /// Heavy enough to read as a deliberate outline from across the screen.
+    /// The first version was drawn at 10 and vanished against a busy desktop.
+    private static let stroke: CGFloat = Design.px(16)
+    /// The unselected zones are quiet but never faint: all four have to be
+    /// legible the moment the handle is held, since seeing the options is the
+    /// whole point of showing them before the pointer arrives.
+    private static let restingOpacity: CGFloat = 0.72
+
+    var body: some View {
+        ZStack(alignment: .topLeading) {
+            Color.clear
+            ForEach(NotchEdge.allCases) { edge in
+                zone(edge)
+            }
+        }
+        .frame(width: size.width, height: size.height)
+        .allowsHitTesting(false)
+    }
+
+    private func zone(_ edge: NotchEdge) -> some View {
+        let isTarget = edge == target
+        let frame = frame(for: edge)
+        return SideNotchShape(edge: edge)
+            .stroke(
+                Palette.textPrimary.opacity(isTarget ? 1 : Self.restingOpacity),
+                style: StrokeStyle(lineWidth: Self.stroke, lineCap: .round, dash: Self.dash)
+            )
+            // A dark wash inside every zone, deeper on the target. It is what
+            // separates a dashed outline from the wallpaper behind it — a
+            // stroke alone disappears over a light or busy desktop, which is
+            // exactly where you most need to see where the notch can go.
+            .background(
+                SideNotchShape(edge: edge)
+                    .fill(Palette.notch.opacity(isTarget ? 0.62 : 0.3))
+            )
+            .frame(width: frame.width, height: frame.height)
+            .position(x: frame.midX, y: frame.midY)
+            // The target swells slightly. Scaled about its own centre, which
+            // for a zone welded to an edge pushes it a few points off the
+            // bezel — deliberate: it reads as lifting toward the pointer.
+            .scaleEffect(isTarget ? 1.06 : 1)
+            .animation(
+                NotchMotion.respectingReduceMotion(
+                    .spring(response: 0.3, dampingFraction: 0.75), reduceMotion
+                ),
+                value: isTarget
+            )
+    }
+
+    /// Where a zone sits, welded to its own edge and centred along it.
+    ///
+    /// A side edge takes the resting length down the screen; a horizontal one
+    /// turns that on its side, for the same reason the real notch does — four
+    /// cells stacked vertically off the menu bar would reach a quarter of the
+    /// way down the screen.
+    private func frame(for edge: NotchEdge) -> CGRect {
+        switch edge {
+        case .right:
+            return CGRect(x: size.width - restingDepth,
+                          y: (size.height - restingLength) / 2,
+                          width: restingDepth, height: restingLength)
+        case .left:
+            return CGRect(x: 0,
+                          y: (size.height - restingLength) / 2,
+                          width: restingDepth, height: restingLength)
+        case .top:
+            return CGRect(x: (size.width - restingLength) / 2,
+                          y: 0,
+                          width: restingLength, height: restingDepth)
+        case .bottom:
+            return CGRect(x: (size.width - restingLength) / 2,
+                          y: size.height - restingDepth,
+                          width: restingLength, height: restingDepth)
+        }
+    }
+
+    /// The edge whose zone contains `point`, or the nearest one within reach.
+    ///
+    /// Nearest-edge rather than strict hit testing: the zones are thin, and
+    /// requiring the pointer to land inside a 40pt strip would make dropping
+    /// feel like threading a needle. The screen is split into four triangles
+    /// about its centre, so every point on it belongs to exactly one edge.
+    static func edge(at point: CGPoint, in size: CGSize) -> NotchEdge {
+        let dxLeft = point.x
+        let dxRight = size.width - point.x
+        let dyTop = point.y
+        let dyBottom = size.height - point.y
+        let nearest = min(dxLeft, dxRight, dyTop, dyBottom)
+        if nearest == dxRight { return .right }
+        if nearest == dxLeft { return .left }
+        if nearest == dyTop { return .top }
+        return .bottom
+    }
+}

--- a/Sources/Features/MoveHandle.swift
+++ b/Sources/Features/MoveHandle.swift
@@ -1,0 +1,185 @@
+import SwiftUI
+
+/// The move control, above the notch — the mirror of `SettingsOrb` below it.
+///
+/// At rest it is the same bare arc the settings orb is, for the same reason:
+/// the notch is meant to be glanceable, and a second permanently visible glyph
+/// competes with the readings. On hover the arc fills in and takes a hand,
+/// which turns as it arrives. Holding it starts a move.
+///
+/// The hand rather than arrows because the gesture is a carry, not a nudge: you
+/// pick the notch up and put it on another edge. Arrows would suggest the
+/// ⌥-drag that already exists, which slides it *along* the edge it is on.
+struct MoveHandle: View {
+    let isHovered: Bool
+    /// True once the handle has been held and the notch is waiting to be
+    /// dropped. The disc goes dashed and the hand stops turning: it is being
+    /// carried now, not offered.
+    var isArmed: Bool = false
+    var edge: NotchEdge = .right
+    /// True when the arc traces the bar's own rounded corner from outside
+    /// rather than a flare from inside — see `SettingsOrb.convex`.
+    var convex: Bool = false
+    var arcRadius: CGFloat = NotchLayout.orbArcRadius
+    var arcOffset: CGSize = .zero
+    /// How many times the hand has been asked to turn, on the same counter
+    /// pattern `SettingsOrb.spins` uses.
+    var spins: Int = 0
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Environment(\.notchSurfaceStyle) private var surfaceStyle
+    @Environment(\.codenotchReduceTransparency) private var reduceTransparency
+
+    private var glassy: Bool { surfaceStyle.effective == .glass && !reduceTransparency }
+
+    /// The resting arc occupies the quarter of the circle facing the notch it
+    /// hangs off and the bezel it merges into — the same two directions
+    /// `SettingsOrb` faces, with only the first of them reversed: this hangs
+    /// off the *near* end of the stack rather than the far one, but it is on
+    /// the same screen edge.
+    ///
+    /// Reflected along the stack, **not** rotated by half a circle. A half turn
+    /// reverses both directions at once, which sends the arc away from the
+    /// bezel and into the middle of the screen — it curls the wrong way, and on
+    /// a side edge it reads as visibly crooked against the flare it is supposed
+    /// to parallel. So a vertical edge swaps up for down and keeps its side of
+    /// the screen; a horizontal one swaps left for right and keeps its top or
+    /// bottom.
+    static func restingTrim(for edge: NotchEdge, convex: Bool) -> ClosedRange<CGFloat> {
+        let settings = SettingsOrb.restingTrim(for: edge, convex: convex)
+        return mirroredAlongStack(settings, isVertical: edge.isVertical)
+    }
+
+    /// Reflects a quadrant across the axis that runs *out of* the screen edge,
+    /// leaving the other axis — the one that says which edge this is — alone.
+    ///
+    /// A quadrant is identified by its lower bound, in SwiftUI's trim space:
+    /// 0 is three o'clock and it runs clockwise with y growing downward. So
+    /// reflecting vertically (up ↔ down) maps 0.75↔0.0 and 0.5↔0.25, and
+    /// reflecting horizontally (left ↔ right) maps 0.5↔0.75 and 0.25↔0.0.
+    static func mirroredAlongStack(
+        _ quadrant: ClosedRange<CGFloat>, isVertical: Bool
+    ) -> ClosedRange<CGFloat> {
+        // Both reflections are `constant - lower`, taken mod 1: 0.75 for the
+        // vertical flip, 1.25 for the horizontal one.
+        let constant: CGFloat = isVertical ? 0.75 : 1.25
+        let lower = (constant - quadrant.lowerBound).truncatingRemainder(dividingBy: 1)
+        return lower...(lower + 0.25)
+    }
+
+    private var restingTrim: ClosedRange<CGFloat> { Self.restingTrim(for: edge, convex: convex) }
+
+    /// How far the button dips under a click — the settings orb's depth, so the
+    /// two controls on the same notch press the same amount.
+    private static let squeezeScale: CGFloat = 0.84
+
+    /// The dashes on the armed disc. Long enough to read as a dashed ring at
+    /// 46pt rather than as a dotted blur.
+    private static let armedDash: [CGFloat] = [Design.px(14), Design.px(12)]
+
+    @ViewBuilder
+    private var restingArc: some View {
+        if glassy {
+            if #available(macOS 26.0, *) {
+                Color.clear
+                    .glassEffect(
+                        .regular,
+                        in: ArcBand(trim: restingTrim, lineWidth: NotchLayout.orbStroke)
+                    )
+                    .frame(width: arcRadius * 2 + NotchLayout.orbStroke,
+                           height: arcRadius * 2 + NotchLayout.orbStroke)
+            }
+        } else {
+            Circle()
+                .trim(from: restingTrim.lowerBound, to: restingTrim.upperBound)
+                .stroke(
+                    Palette.notch,
+                    style: StrokeStyle(lineWidth: NotchLayout.orbStroke, lineCap: .round)
+                )
+                .frame(width: arcRadius * 2, height: arcRadius * 2)
+        }
+    }
+
+    @ViewBuilder
+    private var hoverDisc: some View {
+        if glassy {
+            if #available(macOS 26.0, *) {
+                Color.clear
+                    .glassEffect(.regular.interactive(), in: Circle())
+                    .frame(width: NotchLayout.orbDiameter, height: NotchLayout.orbDiameter)
+            }
+        } else {
+            Circle()
+                .fill(Palette.notch)
+                .frame(width: NotchLayout.orbDiameter, height: NotchLayout.orbDiameter)
+        }
+    }
+
+    /// The dashed ring that says the notch is in hand. Drawn over the disc
+    /// rather than instead of it, so arming reads as the same button changing
+    /// state rather than as a different button.
+    private var armedRing: some View {
+        Circle()
+            .strokeBorder(
+                Palette.textPrimary.opacity(0.9),
+                style: StrokeStyle(lineWidth: NotchLayout.orbStroke / 2,
+                                   lineCap: .round,
+                                   dash: Self.armedDash)
+            )
+            .frame(width: NotchLayout.orbDiameter, height: NotchLayout.orbDiameter)
+    }
+
+    var body: some View {
+        ZStack {
+            restingArc
+                .opacity(isHovered ? 0 : 1)
+                .scaleEffect(isHovered ? 0.86 : 1)
+                .offset(arcOffset)
+
+            hoverDisc
+                .opacity(isHovered ? 1 : 0)
+                .scaleEffect(isHovered ? 1 : 1.1)
+
+            armedRing
+                .opacity(isArmed ? 1 : 0)
+                .scaleEffect(isArmed ? 1 : 0.8)
+
+            Image(systemName: isArmed ? "hand.draw.fill" : "hand.draw")
+                .font(.system(size: NotchLayout.orbGlyph, weight: .regular))
+                .foregroundStyle(Palette.textPrimary)
+                .opacity(isHovered ? 1 : 0)
+                .scaleEffect(isHovered ? 1 : 0.5)
+                // Two rotations on one glyph, as the gear has: the wake-up
+                // from the hover state, and a turn per arm. Summed so arming
+                // mid-hover does not fight the -60 the hand is arriving from.
+                // A quarter turn, not a full one — the hand is being offered,
+                // and a whole revolution reads as a spinner.
+                .rotationEffect(.degrees((isHovered ? 0 : -60) + Double(spins) * 90))
+                .animation(NotchMotion.respectingReduceMotion(.spring(response: 0.55,
+                                                                      dampingFraction: 0.72),
+                                                              reduceMotion),
+                           value: spins)
+        }
+        .frame(width: arcRadius * 2 + NotchLayout.orbStroke,
+               height: arcRadius * 2 + NotchLayout.orbStroke)
+        .animation(
+            NotchMotion.respectingReduceMotion(
+                .spring(response: 0.36, dampingFraction: 0.7), reduceMotion
+            ),
+            value: isHovered
+        )
+        .animation(
+            NotchMotion.respectingReduceMotion(
+                .spring(response: 0.4, dampingFraction: 0.68), reduceMotion
+            ),
+            value: isArmed
+        )
+        .keyframeAnimator(initialValue: CGFloat(1), trigger: spins) { handle, scale in
+            handle.scaleEffect(scale)
+        } keyframes: { _ in
+            SpringKeyframe(reduceMotion ? 1 : Self.squeezeScale,
+                           duration: 0.09, spring: .snappy)
+            SpringKeyframe(1, duration: 0.34, spring: .bouncy)
+        }
+    }
+}

--- a/Sources/Notch/DropZoneOverlay.swift
+++ b/Sources/Notch/DropZoneOverlay.swift
@@ -1,0 +1,78 @@
+import AppKit
+import SwiftUI
+
+/// The full-screen surface the drop zones are drawn on.
+///
+/// A window of its own rather than something inside `NotchPanel`: the panel is
+/// a thin strip welded to one edge, and the zones have to be visible on all
+/// four at once. It is click-through everywhere — the move is driven by the
+/// pointer position while the mouse button is held on the handle, so this
+/// surface must never intercept the events that drive it.
+@MainActor
+final class DropZoneOverlay {
+    private var window: NSWindow?
+    private var hosting: NSHostingView<EdgeDropZones>?
+    private let screen: NSScreen
+
+    init(screen: NSScreen) {
+        self.screen = screen
+    }
+
+    /// Puts the zones on screen, or updates which one is highlighted.
+    func show(target: NotchEdge?, restingDepth: CGFloat, restingLength: CGFloat) {
+        let frame = screen.frame
+        let view = EdgeDropZones(
+            target: target,
+            size: frame.size,
+            restingDepth: restingDepth,
+            restingLength: restingLength
+        )
+
+        if let hosting {
+            hosting.rootView = view
+            return
+        }
+
+        let hostingView = NSHostingView(rootView: view)
+        let panel = NSPanel(
+            contentRect: frame,
+            styleMask: [.borderless, .nonactivatingPanel],
+            backing: .buffered,
+            defer: false
+        )
+        // Strictly below the notch, so the thing being carried stays on top of
+        // the places it can go. Sharing `.statusBar` is not enough: the
+        // overlay is ordered front later, and same-level windows stack by
+        // order — the zones would cover the notch and the hand holding it.
+        panel.level = NSWindow.Level(rawValue: NSWindow.Level.statusBar.rawValue - 1)
+        panel.collectionBehavior = [.canJoinAllSpaces, .stationary, .fullScreenAuxiliary]
+        panel.isOpaque = false
+        panel.backgroundColor = .clear
+        panel.hasShadow = false
+        panel.ignoresMouseEvents = true
+        panel.isReleasedWhenClosed = false
+        panel.contentView = hostingView
+        panel.setFrame(frame, display: false)
+        panel.orderFront(nil)
+
+        window = panel
+        hosting = hostingView
+    }
+
+    func hide() {
+        window?.orderOut(nil)
+        window = nil
+        hosting = nil
+    }
+
+    /// Converts a screen point into this overlay's own top-left-origin space,
+    /// which is what `EdgeDropZones.edge(at:in:)` expects — AppKit's screen
+    /// coordinates grow upward, SwiftUI's grow down.
+    func localPoint(from screenPoint: CGPoint) -> CGPoint {
+        let frame = screen.frame
+        return CGPoint(x: screenPoint.x - frame.minX,
+                       y: frame.maxY - screenPoint.y)
+    }
+
+    var screenSize: CGSize { screen.frame.size }
+}

--- a/Sources/Notch/NotchFleet.swift
+++ b/Sources/Notch/NotchFleet.swift
@@ -61,6 +61,9 @@ final class NotchFleet {
     /// An ⌥-drag on any one panel settled at a new offset. Persisting it is
     /// Preferences' job, same division `apply(edge:)` already keeps.
     var onReposition: ((CGFloat) -> Void)?
+    /// A move handle carried a notch to another edge. Persisting it is
+    /// Preferences' job, the same division `onReposition` keeps.
+    var onMoveToEdge: ((NotchEdge) -> Void)?
 
     /// What the fleet settled on, for tests that need to see panels come and
     /// go rather than take our word for it.
@@ -330,6 +333,7 @@ final class NotchFleet {
         controller.onOpenSettings = onOpenSettings
         controller.model.onOpenSettings = onOpenSettings
         controller.onReposition = onReposition
+        controller.onMoveToEdge = onMoveToEdge
         controller.signInItems = signInItems
         controller.model.updateSnapshots(snapshots)
         controller.model.thinkingModels = thinkingModels

--- a/Sources/Notch/NotchRootView.swift
+++ b/Sources/Notch/NotchRootView.swift
@@ -58,6 +58,23 @@ struct NotchRootView: View {
                         .opacity(model.isExpanded ? 1 : 0)
                         .animation(motion(orbMotion), value: model.isExpanded)
 
+                // The move handle, mirroring the settings orb at the other end
+                // of the stack. Same construction, same reasons — see the
+                // comments on the orb above; only the placement differs.
+                MoveHandle(isHovered: model.isHoveringMove || model.isMoving,
+                           isArmed: model.isMoving,
+                           edge: model.edge,
+                           convex: model.orbHugsCorner,
+                           arcRadius: model.orbArcRadius,
+                           arcOffset: model.moveArcOffset,
+                           spins: model.moveSpins)
+                        .contentShape(Circle())
+                        .scaleEffect(model.sizeScale)
+                        .position(moveCentre(place))
+                        .scaleEffect(model.isExpanded ? 1 : model.orbMergeScale)
+                        .opacity(model.isExpanded ? 1 : 0)
+                        .animation(motion(orbMotion), value: model.isExpanded)
+
                 if let snapshot = model.hoveredSnapshot, let index = model.hoveredIndex,
                    model.isExpanded {
                     TooltipCard(
@@ -312,6 +329,13 @@ struct NotchRootView: View {
     private func orbCentre(_ place: NotchPlacement) -> CGPoint {
         place.point(
             along: model.slack + model.orbAlong * model.sizeScale,
+            across: model.orbInset * model.sizeScale
+        )
+    }
+
+    private func moveCentre(_ place: NotchPlacement) -> CGPoint {
+        place.point(
+            along: model.slack + model.moveAlong * model.sizeScale,
             across: model.orbInset * model.sizeScale
         )
     }

--- a/Sources/Notch/NotchViewModel.swift
+++ b/Sources/Notch/NotchViewModel.swift
@@ -98,6 +98,21 @@ final class NotchViewModel: ObservableObject {
     }
     /// The settings handle is under the cursor.
     @Published var isHoveringSettings = false
+    /// The move handle is under the cursor.
+    @Published var isHoveringMove = false
+    /// Bumped each time the move handle is pressed, on the same counter
+    /// pattern `settingsSpins` uses and for the same reason.
+    @Published var moveSpins = 0
+    /// The notch is in hand: the move handle has been held past its threshold
+    /// and the drop zones are up, waiting for a release.
+    @Published var isMoving = false
+    /// Which edge a release would land on. Nil before the pointer has moved
+    /// far enough for a target to be meaningful.
+    @Published var moveTarget: NotchEdge?
+    /// A move finished on `edge`. The controller owns persisting it, for the
+    /// same reason it owns `onReposition`: this type knows the geometry, not
+    /// where preferences live.
+    var onMove: ((NotchEdge) -> Void)?
     /// A direct SwiftUI tap on the settings orb, independent of the panel's
     /// own AppKit-level click routing (`NotchPanel.mouseDown` →
     /// `NotchWindowController.handleClick`). That path relies on the panel's
@@ -279,6 +294,22 @@ final class NotchViewModel: ObservableObject {
         max(0, orbAlong - shapeLength + NotchLayout.orbHotZone / 2).rounded(.up)
     }
 
+    /// Where the move handle sits: the settings orb's position mirrored to the
+    /// near end of the stack. Measured back from zero the same distance the
+    /// orb sits past `shapeLength`, so the pair stay symmetric about the notch
+    /// at every size and on every edge.
+    var moveAlong: CGFloat {
+        guard orbHugsCorner else { return 0 }
+        return cornerCentreAlong - shapeLength
+            + NotchLayout.orbCornerOffset(corner: drawnCornerRadius)
+    }
+
+    /// The mirror of `trailingExtent` at the near end — the room the move
+    /// handle needs before the notch's own start.
+    var leadingExtent: CGFloat {
+        max(0, -moveAlong + NotchLayout.orbHotZone / 2).rounded(.up)
+    }
+
     /// Where the bar's far corner actually turns, along the stack.
     ///
     /// Inset from the bar's end by the *flare* as well as by the corner's own
@@ -312,6 +343,16 @@ final class NotchViewModel: ObservableObject {
                       height: back * (edge.alongDirection.y + inward.y))
     }
 
+    /// `orbArcOffset` mirrored: the move handle hangs off the near corner, so
+    /// its arc tucks back *forward* along the stack rather than backward.
+    var moveArcOffset: CGSize {
+        guard orbHugsCorner else { return .zero }
+        let inward = CGPoint(x: -edge.outward.x, y: -edge.outward.y)
+        let forward = NotchLayout.orbCornerOffset(corner: drawnCornerRadius)
+        return CGSize(width: forward * (edge.alongDirection.x - inward.x),
+                      height: forward * (edge.alongDirection.y - inward.y))
+    }
+
     /// The points the settings handle answers around: the button you are
     /// reaching for, and — where it has parted company with it — the arc you
     /// can actually see.
@@ -341,6 +382,30 @@ final class NotchViewModel: ObservableObject {
     func isOnOrbHandle(along: CGFloat, across: CGFloat) -> Bool {
         let radius = NotchLayout.orbHotZone / 2
         return orbHandlePoints.contains {
+            hypot(along - $0.x, across - $0.y) <= radius
+        }
+    }
+
+    /// The move handle's own points, mirroring `orbHandlePoints` at the near
+    /// end of the stack.
+    var moveHandlePoints: [CGPoint] {
+        let button = CGPoint(x: moveAlong, y: orbInset)
+        guard orbHugsCorner else { return [button] }
+
+        let arcCentre = CGPoint(x: moveAlong + moveArcOffset.width,
+                                y: orbInset + moveArcOffset.height)
+        let reach = hypot(button.x - arcCentre.x, button.y - arcCentre.y)
+        guard reach > 0 else { return [button] }
+        let arcMid = CGPoint(
+            x: arcCentre.x + orbArcRadius * (button.x - arcCentre.x) / reach,
+            y: arcCentre.y + orbArcRadius * (button.y - arcCentre.y) / reach
+        )
+        return [button, arcMid]
+    }
+
+    func isOnMoveHandle(along: CGFloat, across: CGFloat) -> Bool {
+        let radius = NotchLayout.orbHotZone / 2
+        return moveHandlePoints.contains {
             hypot(along - $0.x, across - $0.y) <= radius
         }
     }

--- a/Sources/Notch/NotchWindowController.swift
+++ b/Sources/Notch/NotchWindowController.swift
@@ -28,6 +28,9 @@ final class NotchWindowController {
     /// controller only holds the live value; persisting it per edge is
     /// Preferences' job, the same division `apply(edge:)` already keeps.
     var onReposition: ((CGFloat) -> Void)?
+    /// A move settled on a new edge. The fleet owns writing that to
+    /// preferences, for the same reason it owns `onReposition`.
+    var onMoveToEdge: ((NotchEdge) -> Void)?
 
     private var panel: NotchPanel?
     private var hostingView: NotchHostingView<NotchRootView>?
@@ -336,7 +339,7 @@ final class NotchWindowController {
     /// than a box can answer — see `isOverHandle`.
     private var handleRect: CGRect {
         let side = NotchLayout.orbHotZone
-        let boxes = model.orbHandlePoints.map { point -> CGRect in
+        let boxes = (model.orbHandlePoints + model.moveHandlePoints).map { point -> CGRect in
             let centre = placement.point(along: model.slack + point.x * model.sizeScale,
                                          across: point.y * model.sizeScale)
             return CGRect(x: centre.x - side / 2, y: centre.y - side / 2,
@@ -352,6 +355,15 @@ final class NotchWindowController {
         // is written in — the orb scales with the notch, so its hit test has to
         // be asked in the same space the shape was drawn in.
         model.isOnOrbHandle(
+            along: (placement.along(of: local) - model.slack) / model.sizeScale,
+            across: placement.across(of: local) / model.sizeScale
+        )
+    }
+
+    /// Whether the pointer is on the move handle, asked in the same notch-own
+    /// measurements `isOverHandle` uses.
+    private func isOverMoveHandle(_ local: CGPoint) -> Bool {
+        model.isOnMoveHandle(
             along: (placement.along(of: local) - model.slack) / model.sizeScale,
             across: placement.across(of: local) / model.sizeScale
         )
@@ -468,8 +480,13 @@ final class NotchWindowController {
         if model.isHoveringSettings != overHandle {
             model.isHoveringSettings = overHandle
         }
+        let overMove = model.isExpanded && isOverMoveHandle(local)
+        if model.isHoveringMove != overMove {
+            model.isHoveringMove = overMove
+        }
         setPointing(
-            Self.wantsPointingHand(isExpanded: model.isExpanded, cellIndex: target) || overHandle
+            Self.wantsPointingHand(isExpanded: model.isExpanded, cellIndex: target)
+                || overHandle || overMove
         )
 
         if let target {
@@ -558,6 +575,14 @@ final class NotchWindowController {
         // The handle sits inside the notch, so it has to be tested before the
         // cells — otherwise the cell band nearest the foot of the stack swallows
         // it and clicking the gear refetches a provider instead.
+        // The move handle is tested before the settings orb and the cells for
+        // the same reason the orb is: it sits over the stack, and whichever
+        // band is nearest would otherwise swallow the press.
+        if model.isExpanded, isOverMoveHandle(local) {
+            model.moveSpins += 1
+            beginMove()
+            return
+        }
         if model.isExpanded, isOverHandle(local) {
             // The same turn the SwiftUI tap gives it, so the gear responds
             // however the click reached it — this path and the tap gesture
@@ -681,6 +706,59 @@ final class NotchWindowController {
         pendingRelocate = work
         DispatchQueue.main.asyncAfter(deadline: .now() + Self.relocateInterval,
                                       execute: work)
+    }
+
+    private var dropZones: DropZoneOverlay?
+
+    /// Carries the notch: raises the drop zones, follows the pointer until the
+    /// button lifts, and hands the edge it landed on to `onMoveToEdge`.
+    ///
+    /// Driven from the pointer's own position rather than from drag deltas,
+    /// because what is being chosen is a *place on the screen*, not a distance
+    /// moved — and a press that never moves has to be able to end on the edge
+    /// it started from without having accumulated anything.
+    ///
+    /// Blocks on the panel's event stream until mouse-up, the same AppKit
+    /// pattern `NotchPanel.trackOptionDrag` uses.
+    private func beginMove() {
+        guard let panel, let screen = currentScreen() else { return }
+
+        let overlay = DropZoneOverlay(screen: screen)
+        dropZones = overlay
+        model.isMoving = true
+        // Starts on the edge it is already on, so releasing without moving is
+        // a no-op rather than a jump to whichever edge the maths rounds to.
+        model.moveTarget = model.edge
+        overlay.show(target: model.edge,
+                     restingDepth: model.restingDepth * model.sizeScale,
+                     restingLength: model.shapeLength * model.sizeScale)
+
+        defer {
+            model.isMoving = false
+            model.moveTarget = nil
+            overlay.hide()
+            dropZones = nil
+        }
+
+        while let event = panel.nextEvent(matching: [.leftMouseDragged, .leftMouseUp]) {
+            let local = overlay.localPoint(from: NSEvent.mouseLocation)
+            let target = EdgeDropZones.edge(at: local, in: overlay.screenSize)
+
+            switch event.type {
+            case .leftMouseDragged:
+                if model.moveTarget != target {
+                    model.moveTarget = target
+                }
+                overlay.show(target: target,
+                             restingDepth: model.restingDepth * model.sizeScale,
+                             restingLength: model.shapeLength * model.sizeScale)
+            case .leftMouseUp:
+                if target != model.edge { onMoveToEdge?(target) }
+                return
+            default:
+                return
+            }
+        }
     }
 
     private var lastRelocate = Date.distantPast

--- a/Tests/NotchEdgeTests.swift
+++ b/Tests/NotchEdgeTests.swift
@@ -535,6 +535,64 @@ final class OrbOrientationTests: XCTestCase {
         XCTAssertEqual(SettingsOrb.restingTrim(for: .right).upperBound, 1.0, accuracy: 0.0001)
     }
 
+    // MARK: - Move handle
+
+    /// The move handle's arc, by the same measurement.
+    private func moveArcDirection(_ edge: NotchEdge) -> CGPoint {
+        let range = MoveHandle.restingTrim(for: edge, convex: false)
+        let mid = (range.lowerBound + range.upperBound) / 2
+        let angle = Double(mid) * 2 * .pi
+        return CGPoint(x: cos(angle), y: sin(angle))
+    }
+
+    /// The move handle hangs off the *other* end of the stack, but off the same
+    /// screen edge — so its arc faces the bezel exactly as the orb's does.
+    ///
+    /// This is the assertion that fails if the quadrant is reached by rotating
+    /// half a circle instead of reflecting along the stack: a half turn
+    /// reverses this direction too, and the arc curls away into open screen.
+    func testTheMoveArcFacesTheBezelOnEveryEdge() {
+        for edge in NotchEdge.allCases {
+            XCTAssertGreaterThan(
+                dot(moveArcDirection(edge), edge.outward), 0.5,
+                "\(edge): the move handle's arc faces away from the bezel"
+            )
+        }
+    }
+
+    /// And back toward the notch — which for this handle is *forward* along the
+    /// stack, since it hangs off the near end.
+    func testTheMoveArcFacesBackTowardTheNotchOnEveryEdge() {
+        for edge in NotchEdge.allCases {
+            XCTAssertGreaterThan(
+                dot(moveArcDirection(edge), edge.alongDirection), 0.5,
+                "\(edge): the move handle's arc points away from the notch"
+            )
+        }
+    }
+
+    /// The two handles mirror each other along the stack: same bezel component,
+    /// opposite component along it.
+    func testTheTwoHandlesMirrorEachOther() {
+        for edge in NotchEdge.allCases {
+            let orb = arcDirection(edge)
+            let move = moveArcDirection(edge)
+            XCTAssertEqual(dot(orb, edge.outward), dot(move, edge.outward),
+                           accuracy: 0.0001,
+                           "\(edge): the handles lean differently against the bezel")
+            XCTAssertEqual(dot(orb, edge.alongDirection), -dot(move, edge.alongDirection),
+                           accuracy: 0.0001,
+                           "\(edge): the handles are not mirrored along the stack")
+        }
+    }
+
+    func testTheMoveArcIsAQuadrantOnEveryEdge() {
+        for edge in NotchEdge.allCases {
+            let range = MoveHandle.restingTrim(for: edge, convex: false)
+            XCTAssertEqual(range.upperBound - range.lowerBound, 0.25, accuracy: 0.0001, "\(edge)")
+        }
+    }
+
     /// `alongDirection` and `outward` are perpendicular by construction — the
     /// stack runs along the bezel and `across` leaves it at a right angle.
     func testTheStackRunsAlongTheBezelNotIntoIt() {


### PR DESCRIPTION
A second handle above the notch, mirroring the settings orb below it — a
shortcut for putting the notch somewhere else without going through Settings.

At rest it is the same bare arc the orb is. On hover it fills in and takes a
hand, which turns as it arrives. Hold it and a dashed outline comes up on all
four screen edges; release over one and the notch lands there.

### Why

The edge is already changeable from Settings → Appearance, so this adds no new
capability — it adds a fast way to reach the one that exists. The moment you
decide the notch is in your way, you are looking at the notch. Today that means
opening Settings, finding the Edge picker and reading four labels to describe a
place you were already pointing at. This lets you just put it there.

A hand rather than arrows because the gesture is a carry, not a nudge. The
existing ⌥-drag slides the notch *along* the edge it is on, and arrows would
read as that. I left that gesture alone; the two coexist.

### The drop zones

Drawn with `SideNotchShape`, so each zone is the notch's real silhouette on
that edge — a tall pill on the sides, a wide bar top and bottom — rather than a
generic rectangle. You can see what you are choosing before you commit to it.

All four stay visible for as long as the handle is held. Showing only the
nearest would mean discovering the other three by sweeping the pointer around,
which is the thing a preview is supposed to save you from.

The pointer picks a zone by nearest edge rather than by hit test. The zones are
thin, and requiring the pointer to land inside a 40pt strip made dropping feel
like threading a needle. The screen splits into four triangles about its
centre, so every point belongs to exactly one edge.

### One thing worth flagging

I first reached the handle's quadrant by rotating the orb's through half a
circle, which looked right in the maths and wrong on screen. A half turn
reverses *both* directions the arc faces, including the one pointing at the
bezel — so the arc curled away into open screen and read as visibly crooked
against the flare it is supposed to parallel. It has to be reflected along the
stack instead: a vertical edge swaps up for down and keeps its side of the
screen, a horizontal one swaps left for right and keeps its top or bottom.

Four tests in `OrbOrientationTests` pin that down — the bezel-facing direction,
the mirror relationship between the two handles, and the quadrant width. I
checked that each of them fails on all four edges if the half turn comes back,
rather than assuming they would.

### Notes

Persisting the new edge is one line: `notchEdge` is `@Published` and the fleet
already follows it, so a move relocates the notch by exactly the path the
Settings picker uses.

The drop-zone overlay is its own window, one level below the notch. The notch
panel is a thin strip welded to one edge, and the zones have to be visible on
all four at once; sharing `.statusBar` was not enough, since same-level windows
stack by order and the zones ended up covering the hand holding them.

No new user-visible strings, so nothing to add to `Localizable.xcstrings`.

### Tests

`make test` passes: 1114 tests, 0 failures.

Happy to adjust the feel — dash weight, how much the target zone swells, the
hold before it arms. Those are all one constant each.