### PR TITLE
Add a Japanese localization

### DIFF
--- a/Sources/Info.plist
+++ b/Sources/Info.plist
@@ -16,6 +16,7 @@
 	<array>
 		<string>en</string>
 		<string>fr</string>
+		<string>ja</string>
 		<string>pt-BR</string>
 		<string>zh-Hans</string>
 	</array>

--- a/Sources/Localizable.xcstrings
+++ b/Sources/Localizable.xcstrings
@@ -12,8 +12,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "just now"
+            "state": "translated",
+            "value": "たった今"
           }
         },
         "pt-BR": {
@@ -41,8 +41,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "%lld min"
+            "state": "translated",
+            "value": "%lld 分"
           }
         },
         "pt-BR": {
@@ -70,8 +70,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "%lld hr"
+            "state": "translated",
+            "value": "%lld 時間"
           }
         },
         "pt-BR": {
@@ -99,8 +99,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "%lld hr %lld min"
+            "state": "translated",
+            "value": "%lld 時間 %lld 分"
           }
         },
         "pt-BR": {
@@ -128,8 +128,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "%@ ago"
+            "state": "translated",
+            "value": "%@前"
           }
         },
         "pt-BR": {
@@ -157,8 +157,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Resetting…"
+            "state": "translated",
+            "value": "リセット中…"
           }
         },
         "pt-BR": {
@@ -186,8 +186,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Resets in %lld min"
+            "state": "translated",
+            "value": "%lld 分後にリセット"
           }
         },
         "pt-BR": {
@@ -215,8 +215,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Resets %@"
+            "state": "translated",
+            "value": "%@ にリセット"
           }
         },
         "pt-BR": {
@@ -244,8 +244,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "%lld%% Used · %lld%% left"
+            "state": "translated",
+            "value": "%lld%% 使用 · 残り %lld%%"
           }
         },
         "pt-BR": {
@@ -273,8 +273,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "1 left"
+            "state": "translated",
+            "value": "残り 1"
           }
         },
         "pt-BR": {
@@ -302,8 +302,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "%lld left"
+            "state": "translated",
+            "value": "残り %lld"
           }
         },
         "pt-BR": {
@@ -331,8 +331,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "1 used"
+            "state": "translated",
+            "value": "1 使用"
           }
         },
         "pt-BR": {
@@ -360,8 +360,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "%lld used"
+            "state": "translated",
+            "value": "%lld 使用"
           }
         },
         "pt-BR": {
@@ -389,8 +389,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "No reading"
+            "state": "translated",
+            "value": "読み取りなし"
           }
         },
         "pt-BR": {
@@ -418,8 +418,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "%@ until %@"
+            "state": "translated",
+            "value": "%@（%@ まで）"
           }
         },
         "pt-BR": {
@@ -447,8 +447,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Sign in to Claude Code to read your usage"
+            "state": "translated",
+            "value": "使用量を読み取るには Claude Code にサインイン"
           }
         },
         "pt-BR": {
@@ -476,8 +476,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Sign in to Claude Code in ~/.claude-%@ to read your usage"
+            "state": "translated",
+            "value": "使用量を読み取るには ~/.claude-%@ で Claude Code にサインイン"
           }
         },
         "pt-BR": {
@@ -505,8 +505,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Sign in to Cursor in the editor"
+            "state": "translated",
+            "value": "エディタで Cursor にサインイン"
           }
         },
         "pt-BR": {
@@ -534,8 +534,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Sign in to Codex to read your usage"
+            "state": "translated",
+            "value": "使用量を読み取るには Codex にサインイン"
           }
         },
         "pt-BR": {
@@ -563,8 +563,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Sign in to Antigravity to read your usage"
+            "state": "translated",
+            "value": "使用量を読み取るには Antigravity にサインイン"
           }
         },
         "pt-BR": {
@@ -592,8 +592,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Set up a GLM Coding Plan key for a coding tool to read your usage"
+            "state": "translated",
+            "value": "使用量を読み取るには、コーディングツールに GLM Coding Plan のキーを設定"
           }
         },
         "pt-BR": {
@@ -621,8 +621,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Connect the Go plan in OpenCode to read your usage"
+            "state": "translated",
+            "value": "使用量を読み取るには OpenCode で Go プランを接続"
           }
         },
         "pt-BR": {
@@ -650,8 +650,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Sign in to %@ to read your usage"
+            "state": "translated",
+            "value": "使用量を読み取るには %@ にサインイン"
           }
         },
         "pt-BR": {
@@ -679,8 +679,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Codenotch was refused access to %@'s saved login. Click this ring to ask again, and choose Always Allow."
+            "state": "translated",
+            "value": "Codenotch は %@ の保存済みログインへのアクセスを拒否されました。このリングをクリックして再度要求し、「常に許可」を選んでください。"
           }
         },
         "pt-BR": {
@@ -708,8 +708,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Couldn't read usage — %@"
+            "state": "translated",
+            "value": "使用量を読み取れませんでした — %@"
           }
         },
         "pt-BR": {
@@ -737,8 +737,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Waiting for the first reading…"
+            "state": "translated",
+            "value": "最初の読み取りを待っています…"
           }
         },
         "pt-BR": {
@@ -766,8 +766,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Current session"
+            "state": "translated",
+            "value": "現在のセッション"
           }
         },
         "pt-BR": {
@@ -795,8 +795,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "All models"
+            "state": "translated",
+            "value": "全モデル"
           }
         },
         "pt-BR": {
@@ -824,7 +824,7 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
+            "state": "translated",
             "value": "Opus"
           }
         },
@@ -853,7 +853,7 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
+            "state": "translated",
             "value": "Sonnet"
           }
         },
@@ -882,8 +882,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Included usage"
+            "state": "translated",
+            "value": "プラン内の使用量"
           }
         },
         "pt-BR": {
@@ -911,8 +911,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "API usage"
+            "state": "translated",
+            "value": "API 使用量"
           }
         },
         "pt-BR": {
@@ -940,8 +940,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "On demand"
+            "state": "translated",
+            "value": "従量課金"
           }
         },
         "pt-BR": {
@@ -969,8 +969,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "5h limit"
+            "state": "translated",
+            "value": "5 時間の上限"
           }
         },
         "pt-BR": {
@@ -998,8 +998,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Weekly limit"
+            "state": "translated",
+            "value": "週間の上限"
           }
         },
         "pt-BR": {
@@ -1027,8 +1027,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Monthly limit"
+            "state": "translated",
+            "value": "月間の上限"
           }
         },
         "pt-BR": {
@@ -1056,8 +1056,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Daily quota"
+            "state": "translated",
+            "value": "1 日の割り当て"
           }
         },
         "pt-BR": {
@@ -1085,8 +1085,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Longer window"
+            "state": "translated",
+            "value": "長期の枠"
           }
         },
         "pt-BR": {
@@ -1114,8 +1114,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "%lldm limit"
+            "state": "translated",
+            "value": "%lld 分の上限"
           }
         },
         "pt-BR": {
@@ -1143,8 +1143,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "%lldh limit"
+            "state": "translated",
+            "value": "%lld 時間の上限"
           }
         },
         "pt-BR": {
@@ -1172,8 +1172,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "%lldd limit"
+            "state": "translated",
+            "value": "%lld 日の上限"
           }
         },
         "pt-BR": {
@@ -1201,8 +1201,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Weekly"
+            "state": "translated",
+            "value": "週間"
           }
         },
         "pt-BR": {
@@ -1230,8 +1230,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "MCP (1 month)"
+            "state": "translated",
+            "value": "MCP（1 か月）"
           }
         },
         "pt-BR": {
@@ -1259,8 +1259,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Usage (%lld h)"
+            "state": "translated",
+            "value": "使用量（%lld 時間）"
           }
         },
         "pt-BR": {
@@ -1288,8 +1288,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Usage (%lld wk)"
+            "state": "translated",
+            "value": "使用量（%lld 週）"
           }
         },
         "pt-BR": {
@@ -1317,8 +1317,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Usage"
+            "state": "translated",
+            "value": "使用量"
           }
         },
         "pt-BR": {
@@ -1346,8 +1346,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Pro searches"
+            "state": "translated",
+            "value": "Pro 検索"
           }
         },
         "pt-BR": {
@@ -1375,8 +1375,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Research"
+            "state": "translated",
+            "value": "リサーチ"
           }
         },
         "pt-BR": {
@@ -1404,8 +1404,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Agentic research"
+            "state": "translated",
+            "value": "エージェントリサーチ"
           }
         },
         "pt-BR": {
@@ -1433,7 +1433,7 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
+            "state": "translated",
             "value": "Labs"
           }
         },
@@ -1462,8 +1462,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Free queries"
+            "state": "translated",
+            "value": "無料クエリ"
           }
         },
         "pt-BR": {
@@ -1491,8 +1491,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Requests today · no limit published"
+            "state": "translated",
+            "value": "本日のリクエスト · 上限の公表なし"
           }
         },
         "pt-BR": {
@@ -1520,8 +1520,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "no requests today"
+            "state": "translated",
+            "value": "本日のリクエストなし"
           }
         },
         "pt-BR": {
@@ -1549,8 +1549,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "~%lld request today"
+            "state": "translated",
+            "value": "本日 約 %lld リクエスト"
           }
         },
         "pt-BR": {
@@ -1578,8 +1578,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "~%lld requests today"
+            "state": "translated",
+            "value": "本日 約 %lld リクエスト"
           }
         },
         "pt-BR": {
@@ -1607,7 +1607,7 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
+            "state": "translated",
             "value": "Grok Build"
           }
         },
@@ -1636,8 +1636,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "%@ Usage"
+            "state": "translated",
+            "value": "%@ の使用量"
           }
         },
         "pt-BR": {
@@ -1665,8 +1665,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "and %lld more"
+            "state": "translated",
+            "value": "ほか %lld 件"
           }
         },
         "pt-BR": {
@@ -1694,8 +1694,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "working"
+            "state": "translated",
+            "value": "作業中"
           }
         },
         "pt-BR": {
@@ -1723,8 +1723,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "waiting"
+            "state": "translated",
+            "value": "待機中"
           }
         },
         "pt-BR": {
@@ -1752,8 +1752,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "idle"
+            "state": "translated",
+            "value": "アイドル"
           }
         },
         "pt-BR": {
@@ -1781,8 +1781,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Working"
+            "state": "translated",
+            "value": "作業中"
           }
         },
         "pt-BR": {
@@ -1810,8 +1810,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Desktop"
+            "state": "translated",
+            "value": "デスクトップ"
           }
         },
         "pt-BR": {
@@ -1839,7 +1839,7 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
+            "state": "translated",
             "value": "VS Code"
           }
         },
@@ -1868,8 +1868,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Agent"
+            "state": "translated",
+            "value": "エージェント"
           }
         },
         "pt-BR": {
@@ -1897,8 +1897,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Terminal"
+            "state": "translated",
+            "value": "ターミナル"
           }
         },
         "pt-BR": {
@@ -1926,8 +1926,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Untitled chat"
+            "state": "translated",
+            "value": "無題のチャット"
           }
         },
         "pt-BR": {
@@ -1955,8 +1955,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Always show"
+            "state": "translated",
+            "value": "常に表示"
           }
         },
         "pt-BR": {
@@ -1984,8 +1984,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Show on hover"
+            "state": "translated",
+            "value": "ホバー時に表示"
           }
         },
         "pt-BR": {
@@ -2013,8 +2013,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Hide"
+            "state": "translated",
+            "value": "非表示"
           }
         },
         "pt-BR": {
@@ -2042,8 +2042,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "The notch stays open with every reading visible."
+            "state": "translated",
+            "value": "ノッチは開いたままで、すべての読み取りが見えます。"
           }
         },
         "pt-BR": {
@@ -2071,8 +2071,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "A small pill at the screen edge that opens when you reach it."
+            "state": "translated",
+            "value": "画面の端に小さなピル。ポインタを近づけると開きます。"
           }
         },
         "pt-BR": {
@@ -2100,8 +2100,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Nothing on screen. Open Codenotch again from Applications to bring these settings back."
+            "state": "translated",
+            "value": "画面には何も出ません。この設定に戻るには、アプリケーションから Codenotch をもう一度開いてください。"
           }
         },
         "pt-BR": {
@@ -2129,7 +2129,7 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
+            "state": "translated",
             "value": "Dock"
           }
         },
@@ -2158,8 +2158,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Menu bar"
+            "state": "translated",
+            "value": "メニューバー"
           }
         },
         "pt-BR": {
@@ -2187,8 +2187,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Neither"
+            "state": "translated",
+            "value": "どちらにも出さない"
           }
         },
         "pt-BR": {
@@ -2216,8 +2216,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "A normal app icon in the Dock while Codenotch is running."
+            "state": "translated",
+            "value": "Codenotch の実行中、Dock に通常のアプリアイコンが出ます。"
           }
         },
         "pt-BR": {
@@ -2245,8 +2245,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "A small icon in the menu bar instead, and nothing in the Dock."
+            "state": "translated",
+            "value": "代わりにメニューバーへ小さなアイコン。Dock には出ません。"
           }
         },
         "pt-BR": {
@@ -2274,8 +2274,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "No icon anywhere. Open Codenotch again from Applications to bring these settings back."
+            "state": "translated",
+            "value": "どこにもアイコンが出ません。この設定に戻るには、アプリケーションから Codenotch をもう一度開いてください。"
           }
         },
         "pt-BR": {
@@ -2303,8 +2303,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Right"
+            "state": "translated",
+            "value": "右"
           }
         },
         "pt-BR": {
@@ -2332,8 +2332,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Left"
+            "state": "translated",
+            "value": "左"
           }
         },
         "pt-BR": {
@@ -2361,8 +2361,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Top"
+            "state": "translated",
+            "value": "上"
           }
         },
         "pt-BR": {
@@ -2390,8 +2390,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Bottom"
+            "state": "translated",
+            "value": "下"
           }
         },
         "pt-BR": {
@@ -2419,8 +2419,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Down the right-hand edge, clear of a Dock on that side."
+            "state": "translated",
+            "value": "右端に沿って。その側の Dock は避けます。"
           }
         },
         "pt-BR": {
@@ -2448,8 +2448,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Down the left-hand edge, clear of a Dock on that side."
+            "state": "translated",
+            "value": "左端に沿って。その側の Dock は避けます。"
           }
         },
         "pt-BR": {
@@ -2477,8 +2477,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "A wide bar across the top, readings side by side. On a Mac with a notch of its own it runs up to meet it, so the two read as one shape."
+            "state": "translated",
+            "value": "上端を横切る幅広のバー。読み取りが横並びになります。ノッチのある Mac ではそこまで伸びて、ひと続きの形に見えます。"
           }
         },
         "pt-BR": {
@@ -2506,8 +2506,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "A wide bar resting on top of the Dock, readings side by side."
+            "state": "translated",
+            "value": "Dock の上に載る幅広のバー。読み取りが横並びになります。"
           }
         },
         "pt-BR": {
@@ -2535,8 +2535,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Integrations"
+            "state": "translated",
+            "value": "連携"
           }
         },
         "pt-BR": {
@@ -2564,8 +2564,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Appearance"
+            "state": "translated",
+            "value": "外観"
           }
         },
         "pt-BR": {
@@ -2593,8 +2593,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "General"
+            "state": "translated",
+            "value": "一般"
           }
         },
         "pt-BR": {
@@ -2622,8 +2622,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Show"
+            "state": "translated",
+            "value": "表示"
           }
         },
         "pt-BR": {
@@ -2651,8 +2651,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Edge"
+            "state": "translated",
+            "value": "配置する辺"
           }
         },
         "pt-BR": {
@@ -2680,8 +2680,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "App icon"
+            "state": "translated",
+            "value": "アプリアイコン"
           }
         },
         "pt-BR": {
@@ -2709,8 +2709,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Open Codenotch at login"
+            "state": "translated",
+            "value": "ログイン時に Codenotch を開く"
           }
         },
         "pt-BR": {
@@ -2738,8 +2738,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Install updates automatically"
+            "state": "translated",
+            "value": "アップデートを自動的にインストール"
           }
         },
         "pt-BR": {
@@ -2767,8 +2767,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Check now"
+            "state": "translated",
+            "value": "今すぐ確認"
           }
         },
         "pt-BR": {
@@ -2796,8 +2796,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "App designed and developed by"
+            "state": "translated",
+            "value": "デザインと開発"
           }
         },
         "pt-BR": {
@@ -2825,8 +2825,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Connect an assistant to get started"
+            "state": "translated",
+            "value": "アシスタントを接続して始めましょう"
           }
         },
         "pt-BR": {
@@ -2854,8 +2854,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Codenotch never signs in — each reading is borrowed from the tool that already holds the account. Signing out here stops the credential being read and forgets the numbers, but leaves you signed in to that tool. macOS asks once per tool the first time, and again whenever you sign in to a different account; Always Allow keeps it quiet."
+            "state": "translated",
+            "value": "Codenotch がサインインすることはありません。読み取りはすべて、すでにアカウントを保持しているツールから借りたものです。ここでサインアウトすると資格情報の読み取りが止まり、数値も忘れられますが、そのツールへのサインインはそのまま残ります。macOS はツールごとに初回の一度、そして別のアカウントにサインインするたびに確認します。「常に許可」を選べば以後は尋ねられません。"
           }
         },
         "pt-BR": {
@@ -2883,8 +2883,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Codenotch reads usage from tools already signed in on this Mac — it never asks for your password. Install and sign in to any of Claude Code (the terminal tool, not the Claude app), Cursor, Codex, Antigravity, GLM, Grok or OpenCode, and its ring appears in the notch."
+            "state": "translated",
+            "value": "Codenotch は、この Mac ですでにサインイン済みのツールから使用量を読み取ります。パスワードを尋ねることはありません。Claude Code（Claude アプリではなくターミナルのツール）、Cursor、Codex、Antigravity、GLM、Grok、OpenCode のいずれかをインストールしてサインインすると、そのリングがノッチに現れます。"
           }
         },
         "pt-BR": {
@@ -2912,8 +2912,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "macOS will ask once for permission to read Claude Code's and Antigravity's saved logins. Choose Always Allow — plain Allow makes it ask again every time."
+            "state": "translated",
+            "value": "macOS は Claude Code と Antigravity の保存済みログインを読み取る許可を一度だけ尋ねます。「常に許可」を選んでください。「許可」だけでは毎回尋ねられます。"
           }
         },
         "pt-BR": {
@@ -2941,8 +2941,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Version %@. Updates install in the background and apply next time Codenotch starts."
+            "state": "translated",
+            "value": "バージョン %@。アップデートはバックグラウンドでインストールされ、次回 Codenotch を起動したときに適用されます。"
           }
         },
         "pt-BR": {
@@ -2970,8 +2970,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Signed out — nothing is read, and no readings are kept."
+            "state": "translated",
+            "value": "サインアウト済み — 読み取りも行わず、読み取りの保存もしません。"
           }
         },
         "pt-BR": {
@@ -2999,8 +2999,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Allow access…"
+            "state": "translated",
+            "value": "アクセスを許可…"
           }
         },
         "pt-BR": {
@@ -3028,8 +3028,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Switch…"
+            "state": "translated",
+            "value": "切り替え…"
           }
         },
         "pt-BR": {
@@ -3057,8 +3057,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Asks macOS for %@'s saved login again. Choose Always Allow and it will stop asking."
+            "state": "translated",
+            "value": "%@ の保存済みログインを macOS に再度要求します。「常に許可」を選べば以後は尋ねられません。"
           }
         },
         "pt-BR": {
@@ -3086,8 +3086,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Switch off to stop reading %@ and forget its readings. %@"
+            "state": "translated",
+            "value": "オフにすると %@ の読み取りを止め、その読み取りを忘れます。%@"
           }
         },
         "pt-BR": {
@@ -3115,8 +3115,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Switch on to sign in and read %@ again."
+            "state": "translated",
+            "value": "オンにすると再びサインインして %@ を読み取ります。"
           }
         },
         "pt-BR": {
@@ -3144,8 +3144,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "macOS is not letting Codenotch read %@'s saved login. Choose Allow access… above, then Always Allow."
+            "state": "translated",
+            "value": "macOS が %@ の保存済みログインの読み取りを許可していません。上の「アクセスを許可…」を選び、「常に許可」を選んでください。"
           }
         },
         "pt-BR": {
@@ -3173,8 +3173,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Open %@"
+            "state": "translated",
+            "value": "%@ を開く"
           }
         },
         "pt-BR": {
@@ -3202,8 +3202,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Opens %@, which is where this account is signed in."
+            "state": "translated",
+            "value": "このアカウントがサインインしている %@ を開きます。"
           }
         },
         "pt-BR": {
@@ -3231,8 +3231,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Opens %@ in your browser. That site has its own sign-in, separate from the credential read here."
+            "state": "translated",
+            "value": "ブラウザで %@ を開きます。このサイトには独自のサインインがあり、ここで読み取っている資格情報とは別のものです。"
           }
         },
         "pt-BR": {
@@ -3260,8 +3260,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Codenotch Settings"
+            "state": "translated",
+            "value": "Codenotch 設定"
           }
         },
         "pt-BR": {
@@ -3289,8 +3289,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "What's New"
+            "state": "translated",
+            "value": "新機能"
           }
         },
         "pt-BR": {
@@ -3318,8 +3318,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "What's new in Codenotch"
+            "state": "translated",
+            "value": "Codenotch の新機能"
           }
         },
         "pt-BR": {
@@ -3347,8 +3347,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Version %@"
+            "state": "translated",
+            "value": "バージョン %@"
           }
         },
         "pt-BR": {
@@ -3376,8 +3376,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Continue"
+            "state": "translated",
+            "value": "続ける"
           }
         },
         "pt-BR": {
@@ -3405,8 +3405,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "macOS refused this — try moving Codenotch to /Applications."
+            "state": "translated",
+            "value": "macOS に拒否されました — Codenotch を /Applications に移動してみてください。"
           }
         },
         "pt-BR": {
@@ -3434,8 +3434,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "via %@"
+            "state": "translated",
+            "value": "%@ 経由"
           }
         },
         "pt-BR": {
@@ -3463,8 +3463,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Sign in to %@"
+            "state": "translated",
+            "value": "%@ にサインイン"
           }
         },
         "pt-BR": {
@@ -3492,8 +3492,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Sign in to %@ to read this account."
+            "state": "translated",
+            "value": "このアカウントを読み取るには %@ にサインインしてください。"
           }
         },
         "pt-BR": {
@@ -3521,8 +3521,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Sign in with %@ to read this account."
+            "state": "translated",
+            "value": "このアカウントを読み取るには %@ でサインインしてください。"
           }
         },
         "pt-BR": {
@@ -3550,8 +3550,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Sign out in the %@ window to use another account."
+            "state": "translated",
+            "value": "別のアカウントを使うには、%@ のウインドウでサインアウトしてください。"
           }
         },
         "pt-BR": {
@@ -3579,8 +3579,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Switch accounts in %@; the notch follows."
+            "state": "translated",
+            "value": "%@ でアカウントを切り替えると、ノッチもそれに従います。"
           }
         },
         "pt-BR": {
@@ -3608,8 +3608,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Switch accounts in the tool that owns it; the notch follows."
+            "state": "translated",
+            "value": "そのアカウントを持つツールで切り替えると、ノッチもそれに従います。"
           }
         },
         "pt-BR": {
@@ -3637,8 +3637,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Signs out of %@ — the session belongs to Codenotch."
+            "state": "translated",
+            "value": "%@ からサインアウトします — このセッションは Codenotch のものです。"
           }
         },
         "pt-BR": {
@@ -3666,8 +3666,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "You stay signed in to %@ — end that session in %@ itself."
+            "state": "translated",
+            "value": "%@ にはサインインしたままです — そのセッションを終えるには %@ 側で操作してください。"
           }
         },
         "pt-BR": {
@@ -3695,8 +3695,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "You stay signed in to the tool that owns the account."
+            "state": "translated",
+            "value": "そのアカウントを持つツールにはサインインしたままです。"
           }
         },
         "pt-BR": {
@@ -3724,8 +3724,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Sign in with the tool that owns this account."
+            "state": "translated",
+            "value": "このアカウントを持つツールでサインインしてください。"
           }
         },
         "pt-BR": {
@@ -3753,8 +3753,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Sign in to %@…"
+            "state": "translated",
+            "value": "%@ にサインイン…"
           }
         },
         "pt-BR": {
@@ -3782,8 +3782,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Run grok login — it signs in and refreshes the token this reads."
+            "state": "translated",
+            "value": "grok login を実行してください。サインインし、ここで読み取るトークンを更新します。"
           }
         },
         "pt-BR": {
@@ -3811,8 +3811,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Usage rides on the opencode-go key OpenCode stores on sign-in — connect Go inside OpenCode (`opencode auth login`) and the notch reads it."
+            "state": "translated",
+            "value": "使用量は、OpenCode がサインイン時に保存する opencode-go キーを使います。OpenCode 内で Go を接続（`opencode auth login`）すれば、ノッチが読み取ります。"
           }
         },
         "pt-BR": {
@@ -3840,8 +3840,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Usage rides on a Z.ai GLM Coding Plan key held by a coding tool — Claude Code's settings.json, ZCode or OpenCode. Set one up there and the notch reads it."
+            "state": "translated",
+            "value": "使用量は、コーディングツールが持つ Z.ai GLM Coding Plan のキーを使います。Claude Code の settings.json、ZCode、OpenCode のいずれかです。そこで設定すれば、ノッチが読み取ります。"
           }
         },
         "pt-BR": {
@@ -3869,8 +3869,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Run `%@` once — it signs in and refreshes the token this reads. Use /login there to change account."
+            "state": "translated",
+            "value": "`%@` を一度実行してください。サインインし、ここで読み取るトークンを更新します。アカウントを変えるには、そこで /login を使います。"
           }
         },
         "pt-BR": {
@@ -3898,8 +3898,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Unlimited on the %@ plan — nothing to meter"
+            "state": "translated",
+            "value": "%@ プランでは無制限 — 計測する対象がありません"
           }
         },
         "pt-BR": {
@@ -3927,8 +3927,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "The %@ plan has nothing for Cursor to meter yet"
+            "state": "translated",
+            "value": "%@ プランには、Cursor が計測できる対象がまだありません"
           }
         },
         "pt-BR": {
@@ -3956,8 +3956,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Codex reported no usage windows"
+            "state": "translated",
+            "value": "Codex は使用量の枠を返しませんでした"
           }
         },
         "pt-BR": {
@@ -3985,8 +3985,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "No OpenCode Go subscription on this key"
+            "state": "translated",
+            "value": "このキーに OpenCode Go のサブスクリプションがありません"
           }
         },
         "pt-BR": {
@@ -4014,8 +4014,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Grok has nothing metered on this account yet"
+            "state": "translated",
+            "value": "このアカウントには、Grok が計測する対象がまだありません"
           }
         },
         "pt-BR": {
@@ -4043,8 +4043,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Settings…"
+            "state": "translated",
+            "value": "設定…"
           }
         },
         "pt-BR": {
@@ -4072,8 +4072,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Quit Codenotch"
+            "state": "translated",
+            "value": "Codenotch を終了"
           }
         },
         "pt-BR": {
@@ -4101,8 +4101,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Keep open"
+            "state": "translated",
+            "value": "開いたままにする"
           }
         },
         "pt-BR": {
@@ -4130,8 +4130,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Refresh now"
+            "state": "translated",
+            "value": "今すぐ更新"
           }
         },
         "pt-BR": {
@@ -4159,8 +4159,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Codenotch is set to Always show. Change it in Settings."
+            "state": "translated",
+            "value": "Codenotch は「常に表示」に設定されています。設定で変更してください。"
           }
         },
         "pt-BR": {
@@ -4188,8 +4188,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Checking…"
+            "state": "translated",
+            "value": "確認中…"
           }
         },
         "pt-BR": {
@@ -4217,8 +4217,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Codenotch is up to date."
+            "state": "translated",
+            "value": "Codenotch は最新です。"
           }
         },
         "pt-BR": {
@@ -4246,8 +4246,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Version %@ is available and will install shortly."
+            "state": "translated",
+            "value": "バージョン %@ が利用可能です。まもなくインストールされます。"
           }
         },
         "pt-BR": {
@@ -4275,8 +4275,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Couldn't reach the update server. Codenotch will try again on its own — nothing is wrong with this copy."
+            "state": "translated",
+            "value": "アップデートサーバーに接続できませんでした。Codenotch が自動で再試行します — このコピーに問題はありません。"
           }
         },
         "pt-BR": {
@@ -4304,8 +4304,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Two more providers, and a live account plan that was silently dropped."
+            "state": "translated",
+            "value": "サービスが 2 つ増え、黙って抜け落ちていた実アカウントのプランに対応。"
           }
         },
         "pt-BR": {
@@ -4333,8 +4333,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Grok is a new ring"
+            "state": "translated",
+            "value": "Grok が新しいリングに"
           }
         },
         "pt-BR": {
@@ -4362,8 +4362,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "SuperGrok's weekly Grok Build allowance, read from the same billing endpoint the CLI uses, with the session in ~/.grok/auth.json."
+            "state": "translated",
+            "value": "SuperGrok の週間 Grok Build 枠を、CLI と同じ課金エンドポイントから読み取ります。セッションは ~/.grok/auth.json のものを使います。"
           }
         },
         "pt-BR": {
@@ -4391,8 +4391,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "OpenCode's Go plan is a new ring"
+            "state": "translated",
+            "value": "OpenCode の Go プランが新しいリングに"
           }
         },
         "pt-BR": {
@@ -4420,8 +4420,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Reads the Go plan's official usage endpoint with the key OpenCode itself stores on sign-in — no second sign-in."
+            "state": "translated",
+            "value": "OpenCode 自身がサインイン時に保存するキーで、Go プランの公式な使用量エンドポイントを読み取ります。二度目のサインインは不要です。"
           }
         },
         "pt-BR": {
@@ -4449,8 +4449,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "A real Codex account went unmetered"
+            "state": "translated",
+            "value": "実在の Codex アカウントが未計測になっていた"
           }
         },
         "pt-BR": {
@@ -4478,8 +4478,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Codex's live reading only recognised a 5-hour and a 7-day window. A free-plan account's real limit was a 30-day one, which fell through unnoticed and showed as nothing metered on an account that was genuinely tracked."
+            "state": "translated",
+            "value": "Codex のライブ読み取りは 5 時間と 7 日間の枠しか認識していませんでした。無料プランのアカウントの実際の上限は 30 日間で、これが見落とされ、本当は計測されているアカウントが「計測対象なし」と表示されていました。"
           }
         },
         "pt-BR": {
@@ -4507,8 +4507,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Switching a provider off now really stops it"
+            "state": "translated",
+            "value": "サービスをオフにすると本当に止まるように"
           }
         },
         "pt-BR": {
@@ -4536,8 +4536,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Opening Settings could still read a switched-off provider's account, and a reply already in flight could restore a reading you had just asked it to forget."
+            "state": "translated",
+            "value": "設定を開くと、オフにしたサービスのアカウントを読み取ってしまうことがありました。また、すでに送信済みの応答が、忘れるよう指示したばかりの読み取りを復活させることがありました。"
           }
         },
         "pt-BR": {
@@ -4565,8 +4565,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Contributors can build without a certificate"
+            "state": "translated",
+            "value": "証明書なしでコントリビューターがビルドできるように"
           }
         },
         "pt-BR": {
@@ -4594,8 +4594,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "make build and make test now sign themselves automatically when the maintainer's Developer ID isn't present — no Apple account needed to work on this."
+            "state": "translated",
+            "value": "メンテナの Developer ID がない場合、make build と make test が自動的に自己署名するようになりました。作業に Apple アカウントは要りません。"
           }
         },
         "pt-BR": {
@@ -4623,8 +4623,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Waking from sleep no longer erases a reading."
+            "state": "translated",
+            "value": "スリープからの復帰で読み取りが消えなくなりました。"
           }
         },
         "pt-BR": {
@@ -4652,8 +4652,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "A ring survives waking your Mac"
+            "state": "translated",
+            "value": "Mac の復帰後もリングが残るように"
           }
         },
         "pt-BR": {
@@ -4681,8 +4681,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "A brief window right after sleep, where macOS won't allow a keychain prompt yet, was mistaken for being signed out — which erased the reading and left \"waiting for the first reading\" on screen. It now ages the number instead of throwing it away, and picks back up on its own."
+            "state": "translated",
+            "value": "スリープ直後の、macOS がまだキーチェーンの確認を許可しないわずかな時間が、サインアウトと誤認されていました。その結果、読み取りが消えて「最初の読み取りを待っています」が表示されたままになっていました。今は数値を破棄せず古いものとして扱い、自動で復帰します。"
           }
         },
         "pt-BR": {
@@ -4710,8 +4710,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Two more accounts, four community fixes, and honest duplicates."
+            "state": "translated",
+            "value": "アカウントが 2 つ増え、コミュニティからの修正が 4 件、そして重複の扱いを正直に。"
           }
         },
         "pt-BR": {
@@ -4739,8 +4739,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Multiple Claude Code accounts"
+            "state": "translated",
+            "value": "複数の Claude Code アカウント"
           }
         },
         "pt-BR": {
@@ -4768,8 +4768,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Keep a work login apart with CLAUDE_CONFIG_DIR? It now gets its own ring, its own limits, and its own row in Settings, beside your personal one."
+            "state": "translated",
+            "value": "CLAUDE_CONFIG_DIR で仕事用のログインを分けていますか。個人用のものと並んで、独自のリング、独自の上限、設定の独自の行を持つようになりました。"
           }
         },
         "pt-BR": {
@@ -4797,8 +4797,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "GLM added"
+            "state": "translated",
+            "value": "GLM に対応"
           }
         },
         "pt-BR": {
@@ -4826,8 +4826,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Z.ai's Coding Plan reads live now too, with a key borrowed from whichever tool already holds one."
+            "state": "translated",
+            "value": "Z.ai の Coding Plan もライブで読み取れるようになりました。キーは、すでにそれを持っているツールから借ります。"
           }
         },
         "pt-BR": {
@@ -4855,8 +4855,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "A stuck Claude ring recovers on its own"
+            "state": "translated",
+            "value": "固まった Claude のリングが自動で復帰"
           }
         },
         "pt-BR": {
@@ -4884,8 +4884,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "One momentary failure — the Mac waking from sleep, most often — used to lock the ring until the app restarted. It now clears itself on the next check."
+            "state": "translated",
+            "value": "一度の瞬間的な失敗 — 多くは Mac のスリープ復帰時です — でリングがロックされ、アプリを再起動するまで戻りませんでした。今は次回の確認で自動的に解消されます。"
           }
         },
         "pt-BR": {
@@ -4913,8 +4913,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Cursor sessions stop reporting work that already ended"
+            "state": "translated",
+            "value": "Cursor のセッションが、終わった作業を報告し続けないように"
           }
         },
         "pt-BR": {
@@ -4942,8 +4942,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "A crashed or abandoned chat could read as \"still working\" for a day or more. It now notices when the writing has actually stopped."
+            "state": "translated",
+            "value": "クラッシュしたり放置されたチャットが、1 日以上「まだ作業中」と表示されることがありました。今は書き込みが実際に止まったことを検知します。"
           }
         },
         "pt-BR": {
@@ -4971,8 +4971,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "A months-old duplicate can no longer win"
+            "state": "translated",
+            "value": "数か月前の重複が勝たないように"
           }
         },
         "pt-BR": {
@@ -5000,8 +5000,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Claude Code files a new keychain entry on every token rotation. An account signed in for a while could pick an old, expired one at random and show \"waiting for the first reading\" forever."
+            "state": "translated",
+            "value": "Claude Code はトークンをローテーションするたびに新しいキーチェーン項目を作ります。しばらくサインインしたままのアカウントでは、古い期限切れの項目がランダムに選ばれ、「最初の読み取りを待っています」がいつまでも表示されることがありました。"
           }
         },
         "pt-BR": {
@@ -5029,8 +5029,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "A stray click no longer pins the notch open"
+            "state": "translated",
+            "value": "誤クリックでノッチが開いたままにならないように"
           }
         },
         "pt-BR": {
@@ -5058,8 +5058,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Clicking near the screen edge before the notch had even opened could leave it stuck open with nothing on screen explaining why."
+            "state": "translated",
+            "value": "ノッチが開く前に画面の端の近くをクリックすると、理由が画面に出ないまま開いた状態で固まることがありました。"
           }
         },
         "pt-BR": {
@@ -5087,8 +5087,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Codex reads live, and Always show stays on."
+            "state": "translated",
+            "value": "Codex をライブ読み取りに。「常に表示」もオフになりません。"
           }
         },
         "pt-BR": {
@@ -5116,8 +5116,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Codex is read live instead of from a log"
+            "state": "translated",
+            "value": "Codex をログではなくライブで読み取るように"
           }
         },
         "pt-BR": {
@@ -5145,8 +5145,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "The figure came from a file Codex writes during a turn, so it was as old as the last time you used it — three days stale in one case. Codenotch now asks Codex itself, and matches its own panel."
+            "state": "translated",
+            "value": "数値はターンの途中で Codex が書き出すファイルから取っていたため、最後に使った時点のまま古くなっていました。3 日前の値だったこともあります。今は Codex 自身に問い合わせるので、Codex のパネルと一致します。"
           }
         },
         "pt-BR": {
@@ -5174,8 +5174,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "The Codex ring notices the desktop app"
+            "state": "translated",
+            "value": "Codex のリングがデスクトップアプリを認識"
           }
         },
         "pt-BR": {
@@ -5203,8 +5203,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "It only ever watched the files the CLI and the VS Code extension write, so work done in the desktop app never made it spin."
+            "state": "translated",
+            "value": "以前は CLI と VS Code 拡張が書くファイルしか見ていなかったため、デスクトップアプリでの作業ではリングが動きませんでした。"
           }
         },
         "pt-BR": {
@@ -5232,8 +5232,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Always show no longer turns itself off"
+            "state": "translated",
+            "value": "「常に表示」が勝手にオフにならないように"
           }
         },
         "pt-BR": {
@@ -5261,8 +5261,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Clicking the notch toggled the same flag the setting used, so a stray click quietly put it back to showing on hover."
+            "state": "translated",
+            "value": "ノッチをクリックすると設定と同じフラグが切り替わっていたため、誤クリックで静かに「ホバー時に表示」へ戻っていました。"
           }
         },
         "pt-BR": {
@@ -5290,8 +5290,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Far fewer keychain prompts"
+            "state": "translated",
+            "value": "キーチェーンの確認が大幅に減少"
           }
         },
         "pt-BR": {
@@ -5319,8 +5319,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Once a token expired, every check went back to the keychain — a prompt a minute. It now reads the secret only when the owning app has changed it, and never retries a refusal on a timer."
+            "state": "translated",
+            "value": "トークンが期限切れになると、確認のたびにキーチェーンへ戻っていました。1 分に 1 回の確認です。今は、持ち主のアプリが秘密情報を変更したときにだけ読み取り、拒否をタイマーで再試行することもありません。"
           }
         },
         "pt-BR": {
@@ -5348,8 +5348,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "A paused limit is shown as paused"
+            "state": "translated",
+            "value": "一時停止中の上限を、そのように表示"
           }
         },
         "pt-BR": {
@@ -5377,8 +5377,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Some limits are reached while the headline still shows room. The ring reads as spent and says when it lifts."
+            "state": "translated",
+            "value": "見出しにはまだ余裕があるのに達している上限があります。リングは使い切りとして表示し、いつ解除されるかを示します。"
           }
         },
         "pt-BR": {
@@ -5406,8 +5406,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Long messages are no longer cut off"
+            "state": "translated",
+            "value": "長いメッセージが切れないように"
           }
         },
         "pt-BR": {
@@ -5435,8 +5435,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "A tooltip with something to explain reserved one line for it however much it said."
+            "state": "translated",
+            "value": "説明のあるツールチップは、内容の量にかかわらず 1 行しか確保していませんでした。"
           }
         },
         "pt-BR": {
@@ -5464,8 +5464,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Every session, and a tooltip that fits on the screen."
+            "state": "translated",
+            "value": "すべてのセッションと、画面に収まるツールチップ。"
           }
         },
         "pt-BR": {
@@ -5493,8 +5493,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Tooltips are no longer cut off"
+            "state": "translated",
+            "value": "ツールチップが切れないように"
           }
         },
         "pt-BR": {
@@ -5522,8 +5522,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "A card is centred on the ring it belongs to, so the first and last providers threw half of it past the end of the panel — and what fell off was the title. The panel now keeps room for it."
+            "state": "translated",
+            "value": "カードは対応するリングを中心に配置されるため、最初と最後のサービスではその半分がパネルの外へはみ出し、はみ出すのはタイトルでした。今はパネルがその分の余白を確保します。"
           }
         },
         "pt-BR": {
@@ -5551,8 +5551,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "As many sessions as your screen can hold"
+            "state": "translated",
+            "value": "画面に収まるだけのセッションを表示"
           }
         },
         "pt-BR": {
@@ -5580,8 +5580,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "The list was capped at four whatever you were running on. It is now solved for the display: ten on a large one, and \"and N more\" only when there is genuinely no room for the rest."
+            "state": "translated",
+            "value": "一覧は実行環境にかかわらず 4 件に固定されていました。今はディスプレイに合わせて決まります。大きな画面なら 10 件、「ほか N 件」は本当に余地がないときだけ出ます。"
           }
         },
         "pt-BR": {
@@ -5609,8 +5609,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "The ones that need you come first"
+            "state": "translated",
+            "value": "あなたを待っているものが先頭に"
           }
         },
         "pt-BR": {
@@ -5638,8 +5638,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Waiting, then busy, then idle — so if anything is summarised away, it is what matters least."
+            "state": "translated",
+            "value": "待機中、次に作業中、最後にアイドル。まとめて省略されるとしても、いちばん重要でないものから省かれます。"
           }
         },
         "pt-BR": {
@@ -5667,8 +5667,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Antigravity's real numbers, and a switch that stays off."
+            "state": "translated",
+            "value": "Antigravity の実際の数値と、オフのままになるスイッチ。"
           }
         },
         "pt-BR": {
@@ -5696,8 +5696,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Antigravity shows its actual quota"
+            "state": "translated",
+            "value": "Antigravity が実際の割り当てを表示"
           }
         },
         "pt-BR": {
@@ -5725,8 +5725,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Google will not answer Codenotch directly, so it asks Antigravity's own language server instead — the same place Antigravity's usage panel gets its figure."
+            "state": "translated",
+            "value": "Google は Codenotch に直接応答しないため、代わりに Antigravity 自身の言語サーバーに問い合わせます。Antigravity の使用量パネルが数値を得ているのと同じ場所です。"
           }
         },
         "pt-BR": {
@@ -5754,8 +5754,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Usage reads both ways"
+            "state": "translated",
+            "value": "使用量を両方の見方で表示"
           }
         },
         "pt-BR": {
@@ -5783,8 +5783,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "\"12% used · 88% left\", so a reading lines up with whichever end your vendor happens to show."
+            "state": "translated",
+            "value": "「12% 使用 · 残り 88%」。ベンダーがどちらの数値を示していても、読み取りが噛み合います。"
           }
         },
         "pt-BR": {
@@ -5812,8 +5812,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "A way back from a declined keychain prompt"
+            "state": "translated",
+            "value": "キーチェーンの確認を拒否したあとの戻り道"
           }
         },
         "pt-BR": {
@@ -5841,8 +5841,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Declining no longer looks like being signed out, and Allow access… asks macOS again."
+            "state": "translated",
+            "value": "拒否してもサインアウトには見えなくなり、「アクセスを許可…」で macOS に再度要求できます。"
           }
         },
         "pt-BR": {
@@ -5870,8 +5870,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Switching a provider off now sticks"
+            "state": "translated",
+            "value": "サービスをオフにした状態が保たれるように"
           }
         },
         "pt-BR": {
@@ -5899,8 +5899,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "It stopped being read but its last reading was kept, so the ring came back at the next launch."
+            "state": "translated",
+            "value": "読み取りは止まるものの最後の読み取りが保持されていたため、次回の起動でリングが戻ってきていました。"
           }
         },
         "pt-BR": {
@@ -5928,8 +5928,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Distant resets show a date"
+            "state": "translated",
+            "value": "先のリセットは日付で表示"
           }
         },
         "pt-BR": {
@@ -5957,8 +5957,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "A limit renewing in four weeks said \"Mon\", which read as this Monday. It says \"28 Sep\"."
+            "state": "translated",
+            "value": "4 週間後に更新される上限が「月」と表示され、今週の月曜日のように読めていました。今は「9月28日」と表示します。"
           }
         },
         "pt-BR": {
@@ -5986,8 +5986,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "The first release."
+            "state": "translated",
+            "value": "最初のリリース。"
           }
         },
         "pt-BR": {
@@ -6015,8 +6015,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Put the notch anywhere"
+            "state": "translated",
+            "value": "ノッチをどこにでも配置"
           }
         },
         "pt-BR": {
@@ -6044,8 +6044,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Right, left, top or bottom. It keeps clear of the Dock and the menu bar, and follows when the Dock moves."
+            "state": "translated",
+            "value": "右、左、上、下。Dock とメニューバーを避け、Dock が移動すれば追従します。"
           }
         },
         "pt-BR": {
@@ -6073,8 +6073,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "It joins your Mac's own notch"
+            "state": "translated",
+            "value": "Mac 自身のノッチと一体に"
           }
         },
         "pt-BR": {
@@ -6102,8 +6102,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "On the top edge it takes the hardware's shape, so the two read as one rather than as a bar parked underneath."
+            "state": "translated",
+            "value": "上端では実機のノッチの形を取り込むので、下にバーが置かれているようにではなく、ひと続きに見えます。"
           }
         },
         "pt-BR": {
@@ -6131,8 +6131,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Claude, Cursor, Codex and Gemini"
+            "state": "translated",
+            "value": "Claude、Cursor、Codex、Gemini"
           }
         },
         "pt-BR": {
@@ -6160,8 +6160,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Each read from the tool already signed in on this Mac. Codenotch never asks for a password."
+            "state": "translated",
+            "value": "いずれもこの Mac ですでにサインイン済みのツールから読み取ります。Codenotch がパスワードを尋ねることはありません。"
           }
         },
         "pt-BR": {
@@ -6189,8 +6189,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Choose where Codenotch appears"
+            "state": "translated",
+            "value": "Codenotch の表示場所を選択"
           }
         },
         "pt-BR": {
@@ -6218,8 +6218,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "In the Dock, in the menu bar, or nowhere at all."
+            "state": "translated",
+            "value": "Dock、メニューバー、またはどこにも出さない。"
           }
         },
         "pt-BR": {
@@ -6247,7 +6247,7 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
+            "state": "translated",
             "value": "Codenotch"
           }
         },
@@ -6276,8 +6276,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "%@%% Used · %@%% left"
+            "state": "translated",
+            "value": "%@%% 使用 · 残り %@%%"
           }
         },
         "pt-BR": {
@@ -6305,8 +6305,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "%@ left"
+            "state": "translated",
+            "value": "残り %@"
           }
         },
         "pt-BR": {
@@ -6334,8 +6334,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "%@ used"
+            "state": "translated",
+            "value": "%@ 使用"
           }
         },
         "pt-BR": {
@@ -6363,8 +6363,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Sign in with GitHub CLI to read your Copilot usage"
+            "state": "translated",
+            "value": "Copilot の使用量を読み取るには GitHub CLI でサインイン"
           }
         },
         "pt-BR": {
@@ -6392,8 +6392,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Sign in with GitHub CLI using `gh auth login`, then enable GitHub Copilot."
+            "state": "translated",
+            "value": "`gh auth login` で GitHub CLI にサインインし、GitHub Copilot を有効にしてください。"
           }
         },
         "pt-BR": {
@@ -6421,8 +6421,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "GitHub Copilot reported no metered quotas"
+            "state": "translated",
+            "value": "GitHub Copilot は計測対象の割り当てを返しませんでした"
           }
         },
         "pt-BR": {
@@ -6450,8 +6450,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "There is nothing to sign in to: the count is added up from what Gemini CLI, OpenCode and Hermes recorded about their own calls. Your API key is never read."
+            "state": "translated",
+            "value": "サインインする先はありません。この件数は、Gemini CLI、OpenCode、Hermes が自分の呼び出しについて記録した内容を合算したものです。API キーが読み取られることはありません。"
           }
         },
         "pt-BR": {
@@ -6479,8 +6479,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "No Gemini CLI, OpenCode or Hermes sessions found"
+            "state": "translated",
+            "value": "Gemini CLI、OpenCode、Hermes のセッションが見つかりません"
           }
         },
         "pt-BR": {
@@ -6508,8 +6508,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Run `%@` once — it signs in and is what these readings come from. Use /login there to change account."
+            "state": "translated",
+            "value": "`%@` を一度実行してください。サインインし、ここでの読み取りはそこから得られます。アカウントを変えるには、そこで /login を使います。"
           }
         },
         "pt-BR": {
@@ -6537,8 +6537,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Scoped"
+            "state": "translated",
+            "value": "スコープ付き"
           }
         },
         "pt-BR": {
@@ -6566,8 +6566,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Auto usage"
+            "state": "translated",
+            "value": "自動使用量"
           }
         },
         "pt-BR": {
@@ -6595,8 +6595,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Team on demand"
+            "state": "translated",
+            "value": "チームの従量課金"
           }
         },
         "pt-BR": {
@@ -6624,8 +6624,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Refresh all"
+            "state": "translated",
+            "value": "すべて更新"
           }
         },
         "pt-BR": {
@@ -6653,8 +6653,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Reset date"
+            "state": "translated",
+            "value": "リセット日"
           }
         },
         "pt-BR": {
@@ -6682,8 +6682,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Time remaining"
+            "state": "translated",
+            "value": "残り時間"
           }
         },
         "pt-BR": {
@@ -6711,8 +6711,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Minutes under an hour; otherwise the reset date and time."
+            "state": "translated",
+            "value": "1 時間未満なら分、それ以外はリセットの日時。"
           }
         },
         "pt-BR": {
@@ -6740,8 +6740,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Time until usage resets, such as 3 Days 3h or 3h 20m."
+            "state": "translated",
+            "value": "使用量がリセットされるまでの時間。「3 日 3 時間」「3 時間 20 分」など。"
           }
         },
         "pt-BR": {
@@ -6769,8 +6769,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Resets in %lld Day %lldh"
+            "state": "translated",
+            "value": "%lld 日 %lld 時間後にリセット"
           }
         },
         "pt-BR": {
@@ -6798,8 +6798,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Resets in %lld Days %lldh"
+            "state": "translated",
+            "value": "%lld 日 %lld 時間後にリセット"
           }
         },
         "pt-BR": {
@@ -6827,8 +6827,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Resets in %lldh %lldm"
+            "state": "translated",
+            "value": "%lld 時間 %lld 分後にリセット"
           }
         },
         "pt-BR": {
@@ -6856,8 +6856,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Nothing on screen. The readings stay in the menu bar menu when App icon is Menu bar. Otherwise, open Codenotch again from Applications to bring these settings back."
+            "state": "translated",
+            "value": "画面には何も出ません。「アプリアイコン」が「メニューバー」なら、読み取りはメニューバーのメニューに残ります。それ以外の場合、この設定に戻るには、アプリケーションから Codenotch をもう一度開いてください。"
           }
         },
         "pt-BR": {
@@ -6885,8 +6885,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Main display"
+            "state": "translated",
+            "value": "メインディスプレイ"
           }
         },
         "pt-BR": {
@@ -6914,8 +6914,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "All displays"
+            "state": "translated",
+            "value": "すべてのディスプレイ"
           }
         },
         "pt-BR": {
@@ -6943,8 +6943,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "The notch appears only on the display with the menu bar."
+            "state": "translated",
+            "value": "ノッチはメニューバーのあるディスプレイにだけ出ます。"
           }
         },
         "pt-BR": {
@@ -6972,8 +6972,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Each display gets its own notch, and hovering one opens only that one."
+            "state": "translated",
+            "value": "ディスプレイごとに独自のノッチが出ます。ホバーしたものだけが開きます。"
           }
         },
         "pt-BR": {
@@ -7001,8 +7001,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "3 seconds"
+            "state": "translated",
+            "value": "3 秒"
           }
         },
         "pt-BR": {
@@ -7030,8 +7030,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "5 seconds"
+            "state": "translated",
+            "value": "5 秒"
           }
         },
         "pt-BR": {
@@ -7059,8 +7059,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "10 seconds"
+            "state": "translated",
+            "value": "10 秒"
           }
         },
         "pt-BR": {
@@ -7088,8 +7088,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Long enough to notice, short enough to ignore."
+            "state": "translated",
+            "value": "気づく程度に長く、無視できる程度に短く。"
           }
         },
         "pt-BR": {
@@ -7117,8 +7117,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Long enough to read the session's name and reach for it."
+            "state": "translated",
+            "value": "セッション名を読んで手を伸ばせる程度の長さ。"
           }
         },
         "pt-BR": {
@@ -7146,8 +7146,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Stays until you have had a chance to look up."
+            "state": "translated",
+            "value": "顔を上げる余裕ができるまで残ります。"
           }
         },
         "pt-BR": {
@@ -7175,8 +7175,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Device accent color"
+            "state": "translated",
+            "value": "デバイスのアクセントカラー"
           }
         },
         "pt-BR": {
@@ -7204,8 +7204,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Connected"
+            "state": "translated",
+            "value": "接続済み"
           }
         },
         "pt-BR": {
@@ -7233,8 +7233,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Not connected"
+            "state": "translated",
+            "value": "未接続"
           }
         },
         "pt-BR": {
@@ -7262,8 +7262,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Accounts"
+            "state": "translated",
+            "value": "アカウント"
           }
         },
         "pt-BR": {
@@ -7291,8 +7291,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Notifications"
+            "state": "translated",
+            "value": "通知"
           }
         },
         "pt-BR": {
@@ -7320,8 +7320,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Nothing is connected, so the notch has no rings to draw."
+            "state": "translated",
+            "value": "何も接続されていないため、ノッチに描くリングがありません。"
           }
         },
         "pt-BR": {
@@ -7349,8 +7349,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "The notch draws these in this order. Drag one by its handle to move it."
+            "state": "translated",
+            "value": "ノッチはこの順にリングを描きます。ハンドルをドラッグして並べ替えられます。"
           }
         },
         "pt-BR": {
@@ -7378,8 +7378,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "These have no ring to place. Switch one on and it joins the end of the list above."
+            "state": "translated",
+            "value": "これらには配置するリングがありません。オンにすると、上の一覧の末尾に加わります。"
           }
         },
         "pt-BR": {
@@ -7407,8 +7407,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Notch"
+            "state": "translated",
+            "value": "ノッチ"
           }
         },
         "pt-BR": {
@@ -7436,8 +7436,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Reset time"
+            "state": "translated",
+            "value": "リセット時刻"
           }
         },
         "pt-BR": {
@@ -7465,8 +7465,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Displays"
+            "state": "translated",
+            "value": "ディスプレイ"
           }
         },
         "pt-BR": {
@@ -7494,8 +7494,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Display"
+            "state": "translated",
+            "value": "ディスプレイ"
           }
         },
         "pt-BR": {
@@ -7523,8 +7523,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Follow active window"
+            "state": "translated",
+            "value": "アクティブなウインドウに追従"
           }
         },
         "pt-BR": {
@@ -7552,8 +7552,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Unavailable display"
+            "state": "translated",
+            "value": "利用できないディスプレイ"
           }
         },
         "pt-BR": {
@@ -7581,8 +7581,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "App"
+            "state": "translated",
+            "value": "アプリ"
           }
         },
         "pt-BR": {
@@ -7610,8 +7610,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Accent color"
+            "state": "translated",
+            "value": "アクセントカラー"
           }
         },
         "pt-BR": {
@@ -7639,8 +7639,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "When a session ends"
+            "state": "translated",
+            "value": "セッションが終わったとき"
           }
         },
         "pt-BR": {
@@ -7668,8 +7668,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Open the notch for a moment"
+            "state": "translated",
+            "value": "ノッチを一瞬開く"
           }
         },
         "pt-BR": {
@@ -7697,8 +7697,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "For"
+            "state": "translated",
+            "value": "表示時間"
           }
         },
         "pt-BR": {
@@ -7726,8 +7726,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Play a sound"
+            "state": "translated",
+            "value": "サウンドを再生"
           }
         },
         "pt-BR": {
@@ -7755,8 +7755,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Finished"
+            "state": "translated",
+            "value": "完了"
           }
         },
         "pt-BR": {
@@ -7784,8 +7784,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Waiting on you"
+            "state": "translated",
+            "value": "あなたを待機中"
           }
         },
         "pt-BR": {
@@ -7813,8 +7813,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Threshold alerts"
+            "state": "translated",
+            "value": "しきい値の通知"
           }
         },
         "pt-BR": {
@@ -7842,8 +7842,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Hide Sidebar"
+            "state": "translated",
+            "value": "サイドバーを隠す"
           }
         },
         "pt-BR": {
@@ -7871,8 +7871,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Show Sidebar"
+            "state": "translated",
+            "value": "サイドバーを表示"
           }
         },
         "pt-BR": {
@@ -7900,8 +7900,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Selected"
+            "state": "translated",
+            "value": "選択中"
           }
         },
         "pt-BR": {
@@ -7929,8 +7929,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Not selected"
+            "state": "translated",
+            "value": "未選択"
           }
         },
         "pt-BR": {
@@ -7958,8 +7958,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "%@ (missing)"
+            "state": "translated",
+            "value": "%@（見つかりません）"
           }
         },
         "pt-BR": {
@@ -7987,8 +7987,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Play %@"
+            "state": "translated",
+            "value": "%@ を再生"
           }
         },
         "pt-BR": {
@@ -8016,8 +8016,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Monthly budget"
+            "state": "translated",
+            "value": "月間の予算"
           }
         },
         "pt-BR": {
@@ -8045,8 +8045,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "None"
+            "state": "translated",
+            "value": "なし"
           }
         },
         "pt-BR": {
@@ -8074,8 +8074,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "tokens"
+            "state": "translated",
+            "value": "トークン"
           }
         },
         "pt-BR": {
@@ -8103,8 +8103,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "%@ limit reached"
+            "state": "translated",
+            "value": "%@ の上限に到達"
           }
         },
         "pt-BR": {
@@ -8132,8 +8132,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "%@ is at %lld%%"
+            "state": "translated",
+            "value": "%@ が %lld%%"
           }
         },
         "pt-BR": {
@@ -8161,8 +8161,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Its %@ limit is spent."
+            "state": "translated",
+            "value": "%@ の上限を使い切りました。"
           }
         },
         "pt-BR": {
@@ -8190,8 +8190,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Its %@ limit is spent — resets %@"
+            "state": "translated",
+            "value": "%@ の上限を使い切りました — %@ にリセット"
           }
         },
         "pt-BR": {
@@ -8219,8 +8219,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "%lld%% of its %@ limit used."
+            "state": "translated",
+            "value": "%lld%% を使用（%@ の上限）。"
           }
         },
         "pt-BR": {
@@ -8248,8 +8248,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Moves to the display containing the window receiving keyboard input."
+            "state": "translated",
+            "value": "キーボード入力を受け取っているウインドウのあるディスプレイに移動します。"
           }
         },
         "pt-BR": {
@@ -8277,8 +8277,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Pinned to %@."
+            "state": "translated",
+            "value": "%@ に固定。"
           }
         },
         "pt-BR": {
@@ -8306,8 +8306,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "That display is disconnected. Codenotch follows the active window until it returns."
+            "state": "translated",
+            "value": "そのディスプレイは接続されていません。復帰するまで、Codenotch はアクティブなウインドウに追従します。"
           }
         },
         "pt-BR": {
@@ -8335,8 +8335,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Drag to reorder. The notch draws the rings in this order."
+            "state": "translated",
+            "value": "ドラッグして並べ替えます。ノッチはこの順にリングを描きます。"
           }
         },
         "pt-BR": {
@@ -8364,8 +8364,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Switch this on to give it a ring in the notch."
+            "state": "translated",
+            "value": "オンにすると、ノッチにリングが追加されます。"
           }
         },
         "pt-BR": {
@@ -8393,8 +8393,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Alerts for %@ are muted. Click to unmute."
+            "state": "translated",
+            "value": "%@ の通知はミュート中です。クリックで解除します。"
           }
         },
         "pt-BR": {
@@ -8422,8 +8422,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Alert when %@ crosses 80% and 100% of a limit."
+            "state": "translated",
+            "value": "%@ が上限の 80% と 100% を超えたときに通知します。"
           }
         },
         "pt-BR": {
@@ -8451,8 +8451,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Fills the ring against a ceiling you choose; Google publishes none for an API key."
+            "state": "translated",
+            "value": "自分で決めた上限に対してリングを満たします。API キーについて Google は上限を公表していません。"
           }
         },
         "pt-BR": {
@@ -8480,8 +8480,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Codenotch reads usage from tools already signed in on this Mac — it never asks for your password. Install and sign in to any of Claude Code (the terminal tool, not the Claude app), Cursor (the editor or cursor-agent), Codex, Antigravity, GLM, Grok, OpenCode, GitHub Copilot or a Gemini API key (via Gemini CLI, OpenCode or Hermes), and its ring appears in the notch."
+            "state": "translated",
+            "value": "Codenotch は、この Mac ですでにサインイン済みのツールから使用量を読み取ります。パスワードを尋ねることはありません。Claude Code（Claude アプリではなくターミナルのツール）、Cursor（エディタまたは cursor-agent）、Codex、Antigravity、GLM、Grok、OpenCode、GitHub Copilot、または Gemini API キー（Gemini CLI、OpenCode、Hermes 経由）のいずれかをインストールしてサインインすると、そのリングがノッチに現れます。"
           }
         },
         "pt-BR": {
@@ -8509,8 +8509,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "macOS will ask once for permission to read Claude Code's, Antigravity's and cursor-agent's saved logins. Choose Always Allow — plain Allow makes it ask again every time."
+            "state": "translated",
+            "value": "macOS は Claude Code、Antigravity、cursor-agent の保存済みログインを読み取る許可を一度だけ尋ねます。「常に許可」を選んでください。「許可」だけでは毎回尋ねられます。"
           }
         },
         "pt-BR": {
@@ -8538,8 +8538,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Reorder the rings, pick a display, and get told when a limit is close."
+            "state": "translated",
+            "value": "リングの並べ替え、ディスプレイの選択、そして上限が近づいたときの通知。"
           }
         },
         "pt-BR": {
@@ -8567,8 +8567,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Drag to reorder the rings"
+            "state": "translated",
+            "value": "ドラッグでリングを並べ替え"
           }
         },
         "pt-BR": {
@@ -8596,8 +8596,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Settings splits into Connected and Not connected; drag a connected row by its handle to change the order the notch draws them in."
+            "state": "translated",
+            "value": "設定が「接続済み」と「未接続」に分かれます。接続済みの行をハンドルでドラッグすると、ノッチが描く順序を変えられます。"
           }
         },
         "pt-BR": {
@@ -8625,8 +8625,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Pin the notch to one display, or show it on every one"
+            "state": "translated",
+            "value": "ノッチを 1 つのディスプレイに固定、またはすべてに表示"
           }
         },
         "pt-BR": {
@@ -8654,8 +8654,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "A Displays picker in Appearance offers the main display or all of them; a second picker pins a single notch to a named screen."
+            "state": "translated",
+            "value": "「外観」の「ディスプレイ」ピッカーで、メインディスプレイかすべてかを選べます。2 つ目のピッカーでは、1 つのノッチを指定した画面に固定できます。"
           }
         },
         "pt-BR": {
@@ -8683,8 +8683,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "A ring says when it crosses 80% and 100%"
+            "state": "translated",
+            "value": "リングが 80% と 100% の到達を知らせます"
           }
         },
         "pt-BR": {
@@ -8712,8 +8712,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "A system notification once per crossing, muted per provider from its own settings row."
+            "state": "translated",
+            "value": "超えるたびにシステム通知を 1 回。サービスごとに、その設定行からミュートできます。"
           }
         },
         "pt-BR": {
@@ -8741,8 +8741,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "GitHub Copilot is a new ring"
+            "state": "translated",
+            "value": "GitHub Copilot が新しいリングに"
           }
         },
         "pt-BR": {
@@ -8770,8 +8770,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Reads GitHub's Copilot quota endpoint using the GitHub CLI session already on the Mac."
+            "state": "translated",
+            "value": "Mac にすでにある GitHub CLI のセッションを使って、GitHub の Copilot 割り当てエンドポイントを読み取ります。"
           }
         },
         "pt-BR": {
@@ -8799,8 +8799,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Say when a session ends"
+            "state": "translated",
+            "value": "セッションの終了を知らせる"
           }
         },
         "pt-BR": {
@@ -8828,8 +8828,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "The notch opens itself for a few seconds and sounds a chime when an agent stops working or starts waiting on you; a click jumps to it."
+            "state": "translated",
+            "value": "エージェントが作業を止めるか、あなたを待ち始めると、ノッチが数秒だけ開いてチャイムを鳴らします。クリックするとそこへ移動します。"
           }
         },
         "pt-BR": {
@@ -8857,8 +8857,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "⌥-drag the pill along its edge"
+            "state": "translated",
+            "value": "⌥ ドラッグでピルを辺に沿って移動"
           }
         },
         "pt-BR": {
@@ -8886,8 +8886,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Nudge it clear of another menu-bar app anchored to the same spot; remembered per edge."
+            "state": "translated",
+            "value": "同じ位置に固定された別のメニューバーアプリを避けてずらせます。位置は辺ごとに記憶されます。"
           }
         },
         "pt-BR": {
@@ -8915,8 +8915,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Choose an accent colour"
+            "state": "translated",
+            "value": "アクセントカラーを選択"
           }
         },
         "pt-BR": {
@@ -8944,8 +8944,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "The device accent by default, or a fixed colour for the ring's positive state — the amber and red warning colours stay fixed regardless."
+            "state": "translated",
+            "value": "既定ではデバイスのアクセントカラー。リングの正常時の色を固定することもできます。警告のアンバーと赤は、いずれの場合も固定のままです。"
           }
         },
         "pt-BR": {
@@ -8973,8 +8973,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "A countdown instead of a reset date"
+            "state": "translated",
+            "value": "リセット日ではなくカウントダウン"
           }
         },
         "pt-BR": {
@@ -9002,8 +9002,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Appearance's Reset time picker can show \"Resets in 3h 20m\" instead of a date and time."
+            "state": "translated",
+            "value": "「外観」の「リセット時刻」ピッカーで、日時の代わりに「3 時間 20 分後にリセット」と表示できます。"
           }
         },
         "pt-BR": {
@@ -9031,8 +9031,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Read Cursor from cursor-agent, and enterprise plans correctly"
+            "state": "translated",
+            "value": "Cursor を cursor-agent から読み取り、エンタープライズプランも正しく"
           }
         },
         "pt-BR": {
@@ -9060,8 +9060,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "A CLI-only Cursor login now gets a ring, and enterprise/team plans read their real usage instead of reporting nothing to meter."
+            "state": "translated",
+            "value": "CLI だけの Cursor ログインにもリングが出るようになり、エンタープライズ/チームプランは「計測対象なし」ではなく実際の使用量を読み取ります。"
           }
         },
         "pt-BR": {
@@ -9089,8 +9089,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Fewer keychain prompts for Claude and Antigravity"
+            "state": "translated",
+            "value": "Claude と Antigravity のキーチェーン確認を削減"
           }
         },
         "pt-BR": {
@@ -9118,8 +9118,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Claude reads its own CLI's /usage first, touching the keychain only as a fallback; Antigravity's language server is asked before it."
+            "state": "translated",
+            "value": "Claude はまず自身の CLI の /usage を読み、キーチェーンは代替手段としてのみ使います。Antigravity は、その前に言語サーバーへ問い合わせます。"
           }
         },
         "pt-BR": {
@@ -9147,8 +9147,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Sub-1% usage no longer reads as 0%"
+            "state": "translated",
+            "value": "1% 未満の使用量が 0% と表示されないように"
           }
         },
         "pt-BR": {
@@ -9176,8 +9176,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "A reading under one percent shows a tenth (\"<0.1%\") instead of rounding to nothing."
+            "state": "translated",
+            "value": "1 パーセント未満の読み取りは、丸めて 0 にせず小数第 1 位（「<0.1%」）で表示します。"
           }
         },
         "pt-BR": {
@@ -9205,8 +9205,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Contributors can build without Xcode signing"
+            "state": "translated",
+            "value": "Xcode の署名なしでコントリビューターがビルドできるように"
           }
         },
         "pt-BR": {
@@ -9234,8 +9234,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "make build and make test sign themselves automatically when the maintainer's certificate isn't present, and CI now runs the suite on every push and pull request."
+            "state": "translated",
+            "value": "メンテナの証明書がない場合、make build と make test が自動的に自己署名するようになりました。CI もすべてのプッシュとプルリクエストでテストを実行します。"
           }
         },
         "pt-BR": {
@@ -9263,8 +9263,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Follow System"
+            "state": "translated",
+            "value": "システムに従う"
           }
         },
         "pt-BR": {
@@ -9292,8 +9292,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Matches the Mac's preferred language."
+            "state": "translated",
+            "value": "Mac の優先言語に合わせます。"
           }
         },
         "pt-BR": {
@@ -9321,8 +9321,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Codenotch uses this language even if the Mac does not."
+            "state": "translated",
+            "value": "Mac がこの言語でなくても、Codenotch はこの言語を使います。"
           }
         },
         "pt-BR": {
@@ -9350,8 +9350,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Language"
+            "state": "translated",
+            "value": "言語"
           }
         },
         "pt-BR": {
@@ -9379,8 +9379,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Show usage pace"
+            "state": "translated",
+            "value": "使用ペースを表示"
           }
         },
         "pt-BR": {
@@ -9408,8 +9408,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Compares each timed allowance with the time left until reset, showing quota in deficit or held in reserve."
+            "state": "translated",
+            "value": "時間で区切られた枠ごとに、リセットまでの残り時間と比べて、超過分か余裕分かを示します。"
           }
         },
         "pt-BR": {
@@ -9437,8 +9437,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Size"
+            "state": "translated",
+            "value": "サイズ"
           }
         },
         "pt-BR": {
@@ -9466,8 +9466,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Small"
+            "state": "translated",
+            "value": "小"
           }
         },
         "pt-BR": {
@@ -9495,8 +9495,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Medium"
+            "state": "translated",
+            "value": "中"
           }
         },
         "pt-BR": {
@@ -9524,8 +9524,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Large"
+            "state": "translated",
+            "value": "大"
           }
         },
         "pt-BR": {
@@ -9553,8 +9553,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Takes the least room on the edge. Readable, but not from across the desk."
+            "state": "translated",
+            "value": "辺で占める場所が最小。読めますが、机の向こうからは無理です。"
           }
         },
         "pt-BR": {
@@ -9582,8 +9582,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "The size the notch was drawn at."
+            "state": "translated",
+            "value": "ノッチが本来描かれるサイズ。"
           }
         },
         "pt-BR": {
@@ -9611,8 +9611,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Easier to read at a glance, and harder to ignore."
+            "state": "translated",
+            "value": "ひと目で読みやすく、無視しにくいサイズ。"
           }
         },
         "pt-BR": {
@@ -9640,8 +9640,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Hold ⌥ and drag the notch to slide it along its edge. Each edge remembers where you left it."
+            "state": "translated",
+            "value": "⌥ を押しながらノッチをドラッグすると、辺に沿って動かせます。位置は辺ごとに記憶されます。"
           }
         },
         "pt-BR": {
@@ -9669,8 +9669,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Recentre"
+            "state": "translated",
+            "value": "中央に戻す"
           }
         },
         "pt-BR": {
@@ -9698,8 +9698,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "%@% deficit"
+            "state": "translated",
+            "value": "%@% 超過"
           }
         },
         "pt-BR": {
@@ -9727,8 +9727,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "%@% reserved"
+            "state": "translated",
+            "value": "%@% 余裕"
           }
         },
         "pt-BR": {
@@ -9756,8 +9756,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Idle"
+            "state": "translated",
+            "value": "アイドル"
           }
         },
         "pt-BR": {
@@ -9785,8 +9785,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Sign in to Codex in ~/.codex-%@ to read your usage"
+            "state": "translated",
+            "value": "使用量を読み取るには ~/.codex-%@ で Codex にサインイン"
           }
         },
         "pt-BR": {
@@ -9814,8 +9814,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Sign in with the Command Code app to read your usage"
+            "state": "translated",
+            "value": "使用量を読み取るには Command Code アプリでサインイン"
           }
         },
         "pt-BR": {
@@ -9843,8 +9843,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Enter an Ollama API key in Settings, or export OLLAMA_API_KEY"
+            "state": "translated",
+            "value": "設定で Ollama の API キーを入力するか、OLLAMA_API_KEY を export してください"
           }
         },
         "pt-BR": {
@@ -9872,8 +9872,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Start Ollama to monitor your local models"
+            "state": "translated",
+            "value": "ローカルモデルを監視するには Ollama を起動してください"
           }
         },
         "pt-BR": {
@@ -9901,8 +9901,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Enter an Ollama API key below, or export OLLAMA_API_KEY in your shell."
+            "state": "translated",
+            "value": "下に Ollama の API キーを入力するか、シェルで OLLAMA_API_KEY を export してください。"
           }
         },
         "pt-BR": {
@@ -9930,8 +9930,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Sign in with the Command Code app — it writes ~/.commandcode/auth.json and the notch reads it."
+            "state": "translated",
+            "value": "Command Code アプリでサインインしてください。~/.commandcode/auth.json が書き出され、ノッチがそれを読み取ります。"
           }
         },
         "pt-BR": {
@@ -9959,8 +9959,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Command Code has nothing metered on this account yet"
+            "state": "translated",
+            "value": "このアカウントには、Command Code が計測する対象がまだありません"
           }
         },
         "pt-BR": {
@@ -9988,8 +9988,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Monthly usage"
+            "state": "translated",
+            "value": "月間の使用量"
           }
         },
         "pt-BR": {
@@ -10017,8 +10017,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Session usage"
+            "state": "translated",
+            "value": "セッションの使用量"
           }
         },
         "pt-BR": {
@@ -10046,8 +10046,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Weekly usage"
+            "state": "translated",
+            "value": "週間の使用量"
           }
         },
         "pt-BR": {
@@ -10075,8 +10075,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Local Models"
+            "state": "translated",
+            "value": "ローカルモデル"
           }
         },
         "pt-BR": {
@@ -10104,8 +10104,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Localhost"
+            "state": "translated",
+            "value": "localhost"
           }
         },
         "pt-BR": {
@@ -10133,8 +10133,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Codenotch reads usage from tools already signed in on this Mac — it never asks for your password. Install and sign in to any of Claude Code (the terminal tool, not the Claude app), Cursor (the editor or cursor-agent), Codex, Antigravity, GLM, Grok, OpenCode, Command Code, GitHub Copilot or a Gemini API key (via Gemini CLI, OpenCode or Hermes), and its ring appears in the notch."
+            "state": "translated",
+            "value": "Codenotch は、この Mac ですでにサインイン済みのツールから使用量を読み取ります。パスワードを尋ねることはありません。Claude Code（Claude アプリではなくターミナルのツール）、Cursor（エディタまたは cursor-agent）、Codex、Antigravity、GLM、Grok、OpenCode、Command Code、GitHub Copilot、または Gemini API キー（Gemini CLI、OpenCode、Hermes 経由）のいずれかをインストールしてサインインすると、そのリングがノッチに現れます。"
           }
         },
         "pt-BR": {
@@ -10156,8 +10156,8 @@
       "localizations": {
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "complete"
+            "state": "translated",
+            "value": "完了"
           }
         },
         "zh-Hans": {
@@ -10173,8 +10173,8 @@
       "localizations": {
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Complete"
+            "state": "translated",
+            "value": "完了"
           }
         },
         "zh-Hans": {
@@ -10190,8 +10190,8 @@
       "localizations": {
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Waiting"
+            "state": "translated",
+            "value": "待機中"
           }
         },
         "zh-Hans": {
@@ -10207,8 +10207,8 @@
       "localizations": {
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Local Session"
+            "state": "translated",
+            "value": "ローカルセッション"
           }
         },
         "zh-Hans": {
@@ -10224,8 +10224,8 @@
       "localizations": {
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Active"
+            "state": "translated",
+            "value": "実行中"
           }
         },
         "zh-Hans": {
@@ -10241,8 +10241,8 @@
       "localizations": {
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Ensure Antigravity IDE is running to read this account."
+            "state": "translated",
+            "value": "このアカウントを読み取るには、Antigravity IDE を起動しておいてください。"
           }
         },
         "zh-Hans": {
@@ -10258,8 +10258,8 @@
       "localizations": {
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Automatic"
+            "state": "translated",
+            "value": "自動"
           }
         },
         "zh-Hans": {
@@ -10275,8 +10275,8 @@
       "localizations": {
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "5-Hour Limit"
+            "state": "translated",
+            "value": "5 時間の上限"
           }
         },
         "zh-Hans": {
@@ -10292,8 +10292,8 @@
       "localizations": {
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Weekly Limit"
+            "state": "translated",
+            "value": "週間の上限"
           }
         },
         "zh-Hans": {
@@ -10309,7 +10309,7 @@
       "localizations": {
         "ja": {
           "stringUnit": {
-            "state": "new",
+            "state": "translated",
             "value": "Liquid Glass"
           }
         },
@@ -10326,8 +10326,8 @@
       "localizations": {
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Solid black"
+            "state": "translated",
+            "value": "不透明な黒"
           }
         },
         "zh-Hans": {
@@ -10343,8 +10343,8 @@
       "localizations": {
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "System Liquid Glass. Follows this Mac's Appearance settings, including Clear or Tinted glass and light or dark mode."
+            "state": "translated",
+            "value": "システムの Liquid Glass。クリアか色付きか、ライトかダークかを含め、この Mac の「外観」設定に従います。"
           }
         },
         "zh-Hans": {
@@ -10360,8 +10360,8 @@
       "localizations": {
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "The original opaque black notch. Always dark, whatever the Mac's appearance."
+            "state": "translated",
+            "value": "従来の不透明な黒いノッチ。Mac の外観にかかわらず常にダークです。"
           }
         },
         "zh-Hans": {
@@ -10377,8 +10377,8 @@
       "localizations": {
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "A second ring for the week, Liquid Glass, French, and Claude Desktop read straight from its own cache."
+            "state": "translated",
+            "value": "週間用の 2 本目のリング、Liquid Glass、フランス語、そして Claude Desktop を自身のキャッシュから直接読み取り。"
           }
         },
         "zh-Hans": {
@@ -10394,8 +10394,8 @@
       "localizations": {
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "The week gets a ring of its own"
+            "state": "translated",
+            "value": "週間に専用のリング"
           }
         },
         "zh-Hans": {
@@ -10411,8 +10411,8 @@
       "localizations": {
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "A second arc, inside the headline ring or outside it, for providers that publish a weekly limit as well as a session one. Off by default; Appearance has the switch."
+            "state": "translated",
+            "value": "セッションの上限に加えて週間の上限を公表しているサービス向けに、主リングの内側または外側へ 2 本目の弧を描きます。既定はオフで、「外観」に切り替えがあります。"
           }
         },
         "zh-Hans": {
@@ -10428,8 +10428,8 @@
       "localizations": {
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "The open notch, its tooltip and the settings orb take the system's own glass surface, so they refract what is behind them instead of sitting on it. Reduce Transparency turns it solid."
+            "state": "translated",
+            "value": "開いたノッチ、そのツールチップ、設定のオーブが、システム自身のガラス面を使います。背景の上に載るのではなく、背景を屈折させます。「透明度を下げる」をオンにすると不透明になります。"
           }
         },
         "zh-Hans": {
@@ -10445,7 +10445,7 @@
       "localizations": {
         "ja": {
           "stringUnit": {
-            "state": "new",
+            "state": "translated",
             "value": "Français"
           }
         },
@@ -10462,8 +10462,8 @@
       "localizations": {
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "A third language in Appearance, alongside English and 简体中文."
+            "state": "translated",
+            "value": "「外観」に English と 简体中文 に続く 3 つ目の言語。"
           }
         },
         "zh-Hans": {
@@ -10479,8 +10479,8 @@
       "localizations": {
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Claude Desktop usage, read from its own cache"
+            "state": "translated",
+            "value": "Claude Desktop の使用量を、自身のキャッシュから読み取り"
           }
         },
         "zh-Hans": {
@@ -10496,8 +10496,8 @@
       "localizations": {
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "A third way to read a Claude account, used when the CLI and the token cannot answer. Nothing is sent anywhere: the cache is on this Mac and is only decompressed."
+            "state": "translated",
+            "value": "Claude アカウントを読む 3 つ目の方法。CLI もトークンも答えられないときに使います。どこにも送信しません。キャッシュはこの Mac 上にあり、解凍するだけです。"
           }
         },
         "zh-Hans": {
@@ -10513,8 +10513,8 @@
       "localizations": {
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Claude Code found where npm puts it"
+            "state": "translated",
+            "value": "npm が置いた場所の Claude Code も見つかるように"
           }
         },
         "zh-Hans": {
@@ -10530,8 +10530,8 @@
       "localizations": {
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "An install under nvm, Volta or pnpm is discovered like any other, which also restores the background sign-in renewal for those setups."
+            "state": "translated",
+            "value": "nvm、Volta、pnpm 配下のインストールも他と同じように検出されます。これらの構成でバックグラウンドのサインイン更新も復活します。"
           }
         },
         "zh-Hans": {
@@ -10547,8 +10547,8 @@
       "localizations": {
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "No more transcript folders left behind"
+            "state": "translated",
+            "value": "トランスクリプトのフォルダが残らないように"
           }
         },
         "zh-Hans": {
@@ -10564,8 +10564,8 @@
       "localizations": {
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Reading Claude usage ran in a fresh directory every poll, and Claude Code filed a transcript folder for each one. It now runs from a single place, in print mode, writing no session at all."
+            "state": "translated",
+            "value": "Claude の使用量の読み取りは、ポーリングのたびに新しいディレクトリで実行され、Claude Code がその都度トランスクリプトのフォルダを作っていました。今は 1 か所から print モードで実行し、セッションを一切書き出しません。"
           }
         },
         "zh-Hans": {
@@ -10581,8 +10581,8 @@
       "localizations": {
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Reset times follow the Mac's clock"
+            "state": "translated",
+            "value": "リセット時刻が Mac の時刻表示に従う"
           }
         },
         "zh-Hans": {
@@ -10598,8 +10598,8 @@
       "localizations": {
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "A 24-hour Mac gets 24-hour reset times instead of AM and PM."
+            "state": "translated",
+            "value": "24 時間表示の Mac では、午前/午後ではなく 24 時間表示のリセット時刻になります。"
           }
         },
         "zh-Hans": {
@@ -10615,8 +10615,8 @@
       "localizations": {
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "A finished session says so"
+            "state": "translated",
+            "value": "終わったセッションがそう表示される"
           }
         },
         "zh-Hans": {
@@ -10632,8 +10632,8 @@
       "localizations": {
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Agent sessions carry a success state, so a run that has completed reads differently from one still going."
+            "state": "translated",
+            "value": "エージェントのセッションが成功状態を持つようになり、完了した実行と進行中の実行が区別して表示されます。"
           }
         },
         "zh-Hans": {
@@ -10649,8 +10649,8 @@
       "localizations": {
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Antigravity: choose which limit leads"
+            "state": "translated",
+            "value": "Antigravity: どの上限を主にするか選択"
           }
         },
         "zh-Hans": {
@@ -10666,8 +10666,8 @@
       "localizations": {
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "The headline ring can follow a named limit rather than whichever happens to be tightest, and a CLI-only install counts as a real account."
+            "state": "translated",
+            "value": "主リングを、たまたま最も逼迫している上限ではなく、指定した上限に従わせられます。また CLI だけのインストールも実アカウントとして扱われます。"
           }
         },
         "zh-Hans": {
@@ -10683,8 +10683,8 @@
       "localizations": {
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Only the hardware notch wakes a notch joined to it"
+            "state": "translated",
+            "value": "一体化したノッチは実機のノッチでのみ反応"
           }
         },
         "zh-Hans": {
@@ -10700,8 +10700,8 @@
       "localizations": {
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "A notch merged with the camera housing no longer wakes from a pointer anywhere along the whole top edge."
+            "state": "translated",
+            "value": "カメラ部と一体化したノッチが、上端のどこにポインタを置いても反応してしまうことがなくなりました。"
           }
         },
         "zh-Hans": {
@@ -10717,8 +10717,8 @@
       "localizations": {
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Weekly ring"
+            "state": "translated",
+            "value": "週間のリング"
           }
         },
         "zh-Hans": {
@@ -10734,8 +10734,8 @@
       "localizations": {
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Surface"
+            "state": "translated",
+            "value": "表面"
           }
         },
         "zh-Hans": {
@@ -10751,8 +10751,8 @@
       "localizations": {
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Notch reads"
+            "state": "translated",
+            "value": "ノッチに表示する上限"
           }
         },
         "zh-Hans": {
@@ -10768,8 +10768,8 @@
       "localizations": {
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Choose which limit appears in the main notch for Antigravity."
+            "state": "translated",
+            "value": "Antigravity で主ノッチに表示する上限を選びます。"
           }
         },
         "zh-Hans": {
@@ -10785,8 +10785,8 @@
       "localizations": {
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Off"
+            "state": "translated",
+            "value": "オフ"
           }
         },
         "zh-Hans": {
@@ -10802,8 +10802,8 @@
       "localizations": {
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Inside"
+            "state": "translated",
+            "value": "内側"
           }
         },
         "zh-Hans": {
@@ -10819,8 +10819,8 @@
       "localizations": {
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Outside"
+            "state": "translated",
+            "value": "外側"
           }
         },
         "zh-Hans": {
@@ -10836,8 +10836,8 @@
       "localizations": {
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "One ring per provider, showing the headline limit. The weekly allowance stays in the hover card."
+            "state": "translated",
+            "value": "サービスごとに 1 本のリングで主な上限を表示します。週間の枠はホバーカードに残ります。"
           }
         },
         "zh-Hans": {
@@ -10853,8 +10853,8 @@
       "localizations": {
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "A thinner ring for the weekly limit, drawn inside the main one. It shares the gap with the working indicator."
+            "state": "translated",
+            "value": "週間の上限を細いリングで主リングの内側に描きます。作業中インジケータと同じ隙間を共有します。"
           }
         },
         "zh-Hans": {
@@ -10870,8 +10870,8 @@
       "localizations": {
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "A thinner ring for the weekly limit, drawn around the main one, in the margin between the ring and the notch edge."
+            "state": "translated",
+            "value": "週間の上限を細いリングで主リングの外側、リングとノッチの端の間の余白に描きます。"
           }
         },
         "zh-Hans": {
@@ -10887,8 +10887,8 @@
       "localizations": {
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Run %@ in Terminal to sign in to %@."
+            "state": "translated",
+            "value": "%@ をターミナルで実行して %@ にサインインしてください。"
           }
         },
         "zh-Hans": {
@@ -10904,8 +10904,8 @@
       "localizations": {
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Requests today · last used %@"
+            "state": "translated",
+            "value": "本日のリクエスト · 最終利用 %@"
           }
         },
         "zh-Hans": {
@@ -10921,8 +10921,8 @@
       "localizations": {
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "yesterday"
+            "state": "translated",
+            "value": "昨日"
           }
         },
         "zh-Hans": {
@@ -10938,8 +10938,8 @@
       "localizations": {
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "%lld days ago"
+            "state": "translated",
+            "value": "%lld 日前"
           }
         },
         "zh-Hans": {
@@ -10955,8 +10955,8 @@
       "localizations": {
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Personal"
+            "state": "translated",
+            "value": "個人"
           }
         },
         "zh-Hans": {
@@ -10972,8 +10972,8 @@
       "localizations": {
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Gemini Models"
+            "state": "translated",
+            "value": "Gemini モデル"
           }
         },
         "zh-Hans": {
@@ -10989,8 +10989,8 @@
       "localizations": {
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "5-hour Limit"
+            "state": "translated",
+            "value": "5 時間の上限"
           }
         },
         "zh-Hans": {
@@ -11006,8 +11006,8 @@
       "localizations": {
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Claude and GPT models"
+            "state": "translated",
+            "value": "Claude と GPT のモデル"
           }
         },
         "zh-Hans": {
@@ -11023,8 +11023,8 @@
       "localizations": {
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Question"
+            "state": "translated",
+            "value": "質問"
           }
         },
         "zh-Hans": {
@@ -11040,8 +11040,8 @@
       "localizations": {
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Approval"
+            "state": "translated",
+            "value": "承認"
           }
         },
         "zh-Hans": {
@@ -11057,8 +11057,8 @@
       "localizations": {
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Permission"
+            "state": "translated",
+            "value": "許可"
           }
         },
         "zh-Hans": {
@@ -11074,8 +11074,8 @@
       "localizations": {
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "needs your input"
+            "state": "translated",
+            "value": "入力待ち"
           }
         },
         "zh-Hans": {
@@ -11091,8 +11091,8 @@
       "localizations": {
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Working in %@"
+            "state": "translated",
+            "value": "%@ で作業中"
           }
         },
         "zh-Hans": {
@@ -11108,8 +11108,8 @@
       "localizations": {
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Connection"
+            "state": "translated",
+            "value": "接続"
           }
         },
         "zh-Hans": {
@@ -11125,8 +11125,8 @@
       "localizations": {
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Preset"
+            "state": "translated",
+            "value": "プリセット"
           }
         },
         "zh-Hans": {
@@ -11142,8 +11142,8 @@
       "localizations": {
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Custom"
+            "state": "translated",
+            "value": "カスタム"
           }
         },
         "zh-Hans": {
@@ -11159,8 +11159,8 @@
       "localizations": {
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Preset size"
+            "state": "translated",
+            "value": "プリセットのサイズ"
           }
         },
         "zh-Hans": {
@@ -11176,8 +11176,8 @@
       "localizations": {
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Scales the whole surface — rings, text and tooltip together — so the proportions stay as drawn. 100% is the size the notch was designed at."
+            "state": "translated",
+            "value": "リング、文字、ツールチップをまとめて拡大縮小するので、比率は設計どおりのままです。100% がノッチの設計サイズです。"
           }
         },
         "zh-Hans": {
@@ -11193,8 +11193,8 @@
       "localizations": {
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Ollama API key"
+            "state": "translated",
+            "value": "Ollama の API キー"
           }
         },
         "zh-Hans": {
@@ -11210,8 +11210,8 @@
       "localizations": {
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Paste your key"
+            "state": "translated",
+            "value": "キーを貼り付け"
           }
         },
         "zh-Hans": {
@@ -11227,8 +11227,8 @@
       "localizations": {
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Save"
+            "state": "translated",
+            "value": "保存"
           }
         },
         "zh-Hans": {
@@ -11244,8 +11244,8 @@
       "localizations": {
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Saved"
+            "state": "translated",
+            "value": "保存しました"
           }
         },
         "zh-Hans": {
@@ -11261,8 +11261,8 @@
       "localizations": {
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "%@ usage needs its sign-in renewed — run `claude` once in a terminal."
+            "state": "translated",
+            "value": "%@ の使用量はサインインの更新が必要です — ターミナルで `claude` を一度実行してください。"
           }
         },
         "zh-Hans": {
@@ -11278,8 +11278,8 @@
       "localizations": {
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "%@ %@ · via Ollama"
+            "state": "translated",
+            "value": "%@ %@ · Ollama 経由"
           }
         },
         "zh-Hans": {
@@ -11295,8 +11295,8 @@
       "localizations": {
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Hidden from the notch · Loaded in Ollama"
+            "state": "translated",
+            "value": "ノッチでは非表示 · Ollama には読み込み済み"
           }
         },
         "zh-Hans": {
@@ -11312,8 +11312,8 @@
       "localizations": {
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Show or hide this model in the notch. It stays loaded in Ollama."
+            "state": "translated",
+            "value": "このモデルをノッチに表示するかどうか。Ollama には読み込まれたままです。"
           }
         },
         "zh-Hans": {
@@ -11329,8 +11329,8 @@
       "localizations": {
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Thinking"
+            "state": "translated",
+            "value": "思考中"
           }
         },
         "zh-Hans": {
@@ -11346,8 +11346,8 @@
       "localizations": {
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "%@ · Local"
+            "state": "translated",
+            "value": "%@ · ローカル"
           }
         },
         "zh-Hans": {
@@ -11363,8 +11363,8 @@
       "localizations": {
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "No Ollama usage recorded yet for this period."
+            "state": "translated",
+            "value": "この期間の Ollama の使用量はまだ記録されていません。"
           }
         },
         "zh-Hans": {
@@ -11380,8 +11380,8 @@
       "localizations": {
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Unused resets"
+            "state": "translated",
+            "value": "未使用のリセット"
           }
         },
         "zh-Hans": {
@@ -11397,8 +11397,8 @@
       "localizations": {
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "No unused resets"
+            "state": "translated",
+            "value": "未使用のリセットなし"
           }
         },
         "zh-Hans": {
@@ -11414,8 +11414,8 @@
       "localizations": {
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "1 unused reset"
+            "state": "translated",
+            "value": "未使用のリセット 1 件"
           }
         },
         "zh-Hans": {
@@ -11431,8 +11431,8 @@
       "localizations": {
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "%lld unused resets"
+            "state": "translated",
+            "value": "未使用のリセット %lld 件"
           }
         },
         "zh-Hans": {
@@ -11448,8 +11448,8 @@
       "localizations": {
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Expires %@"
+            "state": "translated",
+            "value": "%@ に期限切れ"
           }
         },
         "zh-Hans": {
@@ -11465,8 +11465,8 @@
       "localizations": {
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Next expires %@"
+            "state": "translated",
+            "value": "次は %@ に期限切れ"
           }
         },
         "zh-Hans": {

--- a/Sources/Localizable.xcstrings
+++ b/Sources/Localizable.xcstrings
@@ -10,6 +10,12 @@
             "value": "à l'instant"
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "just now"
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -30,6 +36,12 @@
         "fr": {
           "stringUnit": {
             "state": "translated",
+            "value": "%lld min"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
             "value": "%lld min"
           }
         },
@@ -56,6 +68,12 @@
             "value": "%lld h"
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "%lld hr"
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -77,6 +95,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "%lld h %lld min"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "%lld hr %lld min"
           }
         },
         "pt-BR": {
@@ -102,6 +126,12 @@
             "value": "il y a %@"
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "%@ ago"
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -123,6 +153,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Réinitialisation…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Resetting…"
           }
         },
         "pt-BR": {
@@ -148,6 +184,12 @@
             "value": "Réinit. dans %lld min"
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Resets in %lld min"
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -169,6 +211,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Réinit. %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Resets %@"
           }
         },
         "pt-BR": {
@@ -194,6 +242,12 @@
             "value": "%lld%% utilisés · %lld%% restants"
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "%lld%% Used · %lld%% left"
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -215,6 +269,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "1 restant"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "1 left"
           }
         },
         "pt-BR": {
@@ -240,6 +300,12 @@
             "value": "%lld restants"
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "%lld left"
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -261,6 +327,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "1 utilisé"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "1 used"
           }
         },
         "pt-BR": {
@@ -286,6 +358,12 @@
             "value": "%lld utilisés"
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "%lld used"
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -307,6 +385,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Aucun relevé"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No reading"
           }
         },
         "pt-BR": {
@@ -332,6 +416,12 @@
             "value": "%@ jusqu'à %@"
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "%@ until %@"
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -353,6 +443,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Connectez-vous à Claude Code pour lire votre consommation"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sign in to Claude Code to read your usage"
           }
         },
         "pt-BR": {
@@ -378,6 +474,12 @@
             "value": "Connectez-vous à Claude Code dans ~/.claude-%@ pour lire votre consommation"
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sign in to Claude Code in ~/.claude-%@ to read your usage"
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -399,6 +501,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Connectez-vous à Cursor dans l'éditeur"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sign in to Cursor in the editor"
           }
         },
         "pt-BR": {
@@ -424,6 +532,12 @@
             "value": "Connectez-vous à Codex pour lire votre consommation"
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sign in to Codex to read your usage"
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -445,6 +559,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Connectez-vous à Antigravity pour lire votre consommation"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sign in to Antigravity to read your usage"
           }
         },
         "pt-BR": {
@@ -470,6 +590,12 @@
             "value": "Configurez une clé GLM Coding Plan dans un outil de code pour lire votre consommation"
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Set up a GLM Coding Plan key for a coding tool to read your usage"
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -491,6 +617,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Connectez le plan Go dans OpenCode pour lire votre consommation"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Connect the Go plan in OpenCode to read your usage"
           }
         },
         "pt-BR": {
@@ -516,6 +648,12 @@
             "value": "Connectez-vous à %@ pour lire votre consommation"
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sign in to %@ to read your usage"
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -537,6 +675,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Codenotch s'est vu refuser l'accès aux identifiants enregistrés de %@. Cliquez sur cet anneau pour redemander, puis choisissez Toujours autoriser."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Codenotch was refused access to %@'s saved login. Click this ring to ask again, and choose Always Allow."
           }
         },
         "pt-BR": {
@@ -562,6 +706,12 @@
             "value": "Lecture de la consommation impossible — %@"
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Couldn't read usage — %@"
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -583,6 +733,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "En attente du premier relevé…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Waiting for the first reading…"
           }
         },
         "pt-BR": {
@@ -608,6 +764,12 @@
             "value": "Session en cours"
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Current session"
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -631,6 +793,12 @@
             "value": "Tous les modèles"
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "All models"
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -651,6 +819,12 @@
         "fr": {
           "stringUnit": {
             "state": "translated",
+            "value": "Opus"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
             "value": "Opus"
           }
         },
@@ -677,6 +851,12 @@
             "value": "Sonnet"
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sonnet"
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -698,6 +878,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Consommation incluse"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Included usage"
           }
         },
         "pt-BR": {
@@ -723,6 +909,12 @@
             "value": "Consommation API"
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "API usage"
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -744,6 +936,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "À la demande"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "On demand"
           }
         },
         "pt-BR": {
@@ -769,6 +967,12 @@
             "value": "Limite 5 h"
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "5h limit"
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -790,6 +994,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Limite hebdomadaire"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Weekly limit"
           }
         },
         "pt-BR": {
@@ -815,6 +1025,12 @@
             "value": "Limite mensuelle"
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Monthly limit"
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -836,6 +1052,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Quota quotidien"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Daily quota"
           }
         },
         "pt-BR": {
@@ -861,6 +1083,12 @@
             "value": "Fenêtre plus longue"
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Longer window"
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -882,6 +1110,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Limite %lld min"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "%lldm limit"
           }
         },
         "pt-BR": {
@@ -907,6 +1141,12 @@
             "value": "Limite %lld h"
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "%lldh limit"
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -928,6 +1168,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Limite %lld j"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "%lldd limit"
           }
         },
         "pt-BR": {
@@ -953,6 +1199,12 @@
             "value": "Hebdomadaire"
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Weekly"
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -974,6 +1226,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "MCP (1 mois)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "MCP (1 month)"
           }
         },
         "pt-BR": {
@@ -999,6 +1257,12 @@
             "value": "Consommation (%lld h)"
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Usage (%lld h)"
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -1020,6 +1284,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Consommation (%lld sem.)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Usage (%lld wk)"
           }
         },
         "pt-BR": {
@@ -1045,6 +1315,12 @@
             "value": "Consommation"
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Usage"
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -1066,6 +1342,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Recherches Pro"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Pro searches"
           }
         },
         "pt-BR": {
@@ -1091,6 +1373,12 @@
             "value": "Recherche"
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Research"
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -1114,6 +1402,12 @@
             "value": "Recherche agentique"
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Agentic research"
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -1134,6 +1428,12 @@
         "fr": {
           "stringUnit": {
             "state": "translated",
+            "value": "Labs"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
             "value": "Labs"
           }
         },
@@ -1160,6 +1460,12 @@
             "value": "Requêtes gratuites"
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Free queries"
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -1181,6 +1487,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Requêtes aujourd'hui · aucune limite publiée"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Requests today · no limit published"
           }
         },
         "pt-BR": {
@@ -1206,6 +1518,12 @@
             "value": "aucune requête aujourd'hui"
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "no requests today"
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -1227,6 +1545,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "~%lld requête aujourd'hui"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "~%lld request today"
           }
         },
         "pt-BR": {
@@ -1252,6 +1576,12 @@
             "value": "~%lld requêtes aujourd'hui"
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "~%lld requests today"
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -1272,6 +1602,12 @@
         "fr": {
           "stringUnit": {
             "state": "translated",
+            "value": "Grok Build"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
             "value": "Grok Build"
           }
         },
@@ -1298,6 +1634,12 @@
             "value": "Consommation %@"
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "%@ Usage"
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -1319,6 +1661,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "et %lld de plus"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "and %lld more"
           }
         },
         "pt-BR": {
@@ -1344,6 +1692,12 @@
             "value": "en cours"
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "working"
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -1365,6 +1719,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "en attente"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "waiting"
           }
         },
         "pt-BR": {
@@ -1390,6 +1750,12 @@
             "value": "inactive"
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "idle"
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -1411,6 +1777,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "En cours"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Working"
           }
         },
         "pt-BR": {
@@ -1436,6 +1808,12 @@
             "value": "Bureau"
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Desktop"
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -1456,6 +1834,12 @@
         "fr": {
           "stringUnit": {
             "state": "translated",
+            "value": "VS Code"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
             "value": "VS Code"
           }
         },
@@ -1482,6 +1866,12 @@
             "value": "Agent"
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Agent"
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -1502,6 +1892,12 @@
         "fr": {
           "stringUnit": {
             "state": "translated",
+            "value": "Terminal"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
             "value": "Terminal"
           }
         },
@@ -1528,6 +1924,12 @@
             "value": "Conversation sans titre"
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Untitled chat"
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -1549,6 +1951,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Toujours afficher"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Always show"
           }
         },
         "pt-BR": {
@@ -1574,6 +1982,12 @@
             "value": "Afficher au survol"
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Show on hover"
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -1595,6 +2009,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Masquer"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Hide"
           }
         },
         "pt-BR": {
@@ -1620,6 +2040,12 @@
             "value": "L'encoche reste ouverte, tous les relevés visibles."
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "The notch stays open with every reading visible."
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -1641,6 +2067,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Une petite pastille au bord de l'écran, qui s'ouvre quand vous l'atteignez."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "A small pill at the screen edge that opens when you reach it."
           }
         },
         "pt-BR": {
@@ -1666,6 +2098,12 @@
             "value": "Rien à l'écran. Rouvrez Codenotch depuis Applications pour retrouver ces réglages."
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Nothing on screen. Open Codenotch again from Applications to bring these settings back."
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -1686,6 +2124,12 @@
         "fr": {
           "stringUnit": {
             "state": "translated",
+            "value": "Dock"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
             "value": "Dock"
           }
         },
@@ -1712,6 +2156,12 @@
             "value": "Barre des menus"
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Menu bar"
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -1733,6 +2183,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Aucun"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Neither"
           }
         },
         "pt-BR": {
@@ -1758,6 +2214,12 @@
             "value": "Une icône d'app normale dans le Dock tant que Codenotch fonctionne."
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "A normal app icon in the Dock while Codenotch is running."
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -1779,6 +2241,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Une petite icône dans la barre des menus à la place, et rien dans le Dock."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "A small icon in the menu bar instead, and nothing in the Dock."
           }
         },
         "pt-BR": {
@@ -1804,6 +2272,12 @@
             "value": "Aucune icône nulle part. Rouvrez Codenotch depuis Applications pour retrouver ces réglages."
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No icon anywhere. Open Codenotch again from Applications to bring these settings back."
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -1825,6 +2299,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Droite"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Right"
           }
         },
         "pt-BR": {
@@ -1850,6 +2330,12 @@
             "value": "Gauche"
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Left"
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -1871,6 +2357,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Haut"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Top"
           }
         },
         "pt-BR": {
@@ -1896,6 +2388,12 @@
             "value": "Bas"
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Bottom"
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -1917,6 +2415,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Le long du bord droit, à l'écart d'un Dock placé de ce côté."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Down the right-hand edge, clear of a Dock on that side."
           }
         },
         "pt-BR": {
@@ -1942,6 +2446,12 @@
             "value": "Le long du bord gauche, à l'écart d'un Dock placé de ce côté."
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Down the left-hand edge, clear of a Dock on that side."
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -1963,6 +2473,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Une barre large en haut, relevés côte à côte. Sur un Mac doté de sa propre encoche, elle remonte la rejoindre pour ne former qu'une seule forme."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "A wide bar across the top, readings side by side. On a Mac with a notch of its own it runs up to meet it, so the two read as one shape."
           }
         },
         "pt-BR": {
@@ -1988,6 +2504,12 @@
             "value": "Une barre large posée sur le Dock, relevés côte à côte."
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "A wide bar resting on top of the Dock, readings side by side."
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -2009,6 +2531,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Intégrations"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Integrations"
           }
         },
         "pt-BR": {
@@ -2034,6 +2562,12 @@
             "value": "Apparence"
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Appearance"
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -2055,6 +2589,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Général"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "General"
           }
         },
         "pt-BR": {
@@ -2080,6 +2620,12 @@
             "value": "Affichage"
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Show"
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -2101,6 +2647,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Bord"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Edge"
           }
         },
         "pt-BR": {
@@ -2126,6 +2678,12 @@
             "value": "Icône de l'app"
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "App icon"
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -2147,6 +2705,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Ouvrir Codenotch à l'ouverture de session"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Open Codenotch at login"
           }
         },
         "pt-BR": {
@@ -2172,6 +2736,12 @@
             "value": "Installer les mises à jour automatiquement"
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Install updates automatically"
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -2193,6 +2763,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Vérifier maintenant"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Check now"
           }
         },
         "pt-BR": {
@@ -2218,6 +2794,12 @@
             "value": "App conçue et développée par"
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "App designed and developed by"
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -2239,6 +2821,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Connectez un assistant pour commencer"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Connect an assistant to get started"
           }
         },
         "pt-BR": {
@@ -2264,6 +2852,12 @@
             "value": "Codenotch ne se connecte jamais — chaque relevé est emprunté à l'outil qui détient déjà le compte. Vous déconnecter ici arrête la lecture de l'identifiant et oublie les chiffres, mais vous restez connecté à cet outil. macOS demande une fois par outil la première fois, puis à nouveau chaque fois que vous vous connectez à un autre compte ; Toujours autoriser évite les rappels."
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Codenotch never signs in — each reading is borrowed from the tool that already holds the account. Signing out here stops the credential being read and forgets the numbers, but leaves you signed in to that tool. macOS asks once per tool the first time, and again whenever you sign in to a different account; Always Allow keeps it quiet."
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -2285,6 +2879,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Codenotch lit la consommation des outils déjà connectés sur ce Mac — il ne demande jamais votre mot de passe. Installez l'un de Claude Code (l'outil en terminal, pas l'app Claude), Cursor, Codex, Antigravity, GLM, Grok ou OpenCode et connectez-vous : son anneau apparaît dans l'encoche."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Codenotch reads usage from tools already signed in on this Mac — it never asks for your password. Install and sign in to any of Claude Code (the terminal tool, not the Claude app), Cursor, Codex, Antigravity, GLM, Grok or OpenCode, and its ring appears in the notch."
           }
         },
         "pt-BR": {
@@ -2310,6 +2910,12 @@
             "value": "macOS demandera une fois l'autorisation de lire les identifiants enregistrés de Claude Code et d'Antigravity. Choisissez Toujours autoriser — un simple Autoriser fait redemander à chaque fois."
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "macOS will ask once for permission to read Claude Code's and Antigravity's saved logins. Choose Always Allow — plain Allow makes it ask again every time."
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -2331,6 +2937,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Version %@. Les mises à jour s'installent en arrière-plan et s'appliquent au prochain démarrage de Codenotch."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Version %@. Updates install in the background and apply next time Codenotch starts."
           }
         },
         "pt-BR": {
@@ -2356,6 +2968,12 @@
             "value": "Déconnecté — rien n'est lu, et aucun relevé n'est conservé."
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Signed out — nothing is read, and no readings are kept."
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -2377,6 +2995,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Autoriser l'accès…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Allow access…"
           }
         },
         "pt-BR": {
@@ -2402,6 +3026,12 @@
             "value": "Changer…"
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Switch…"
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -2423,6 +3053,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Redemande à macOS les identifiants enregistrés de %@. Choisissez Toujours autoriser et il cessera de demander."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Asks macOS for %@'s saved login again. Choose Always Allow and it will stop asking."
           }
         },
         "pt-BR": {
@@ -2448,6 +3084,12 @@
             "value": "Désactivez pour arrêter de lire %@ et oublier ses relevés. %@"
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Switch off to stop reading %@ and forget its readings. %@"
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -2469,6 +3111,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Activez pour vous reconnecter et lire %@ à nouveau."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Switch on to sign in and read %@ again."
           }
         },
         "pt-BR": {
@@ -2494,6 +3142,12 @@
             "value": "macOS n'autorise pas Codenotch à lire les identifiants enregistrés de %@. Choisissez Autoriser l'accès… ci-dessus, puis Toujours autoriser."
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "macOS is not letting Codenotch read %@'s saved login. Choose Allow access… above, then Always Allow."
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -2515,6 +3169,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Ouvrir %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Open %@"
           }
         },
         "pt-BR": {
@@ -2540,6 +3200,12 @@
             "value": "Ouvre %@, où ce compte est connecté."
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Opens %@, which is where this account is signed in."
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -2561,6 +3227,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Ouvre %@ dans votre navigateur. Ce site a sa propre connexion, distincte de l'identifiant lu ici."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Opens %@ in your browser. That site has its own sign-in, separate from the credential read here."
           }
         },
         "pt-BR": {
@@ -2586,6 +3258,12 @@
             "value": "Réglages de Codenotch"
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Codenotch Settings"
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -2607,6 +3285,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Nouveautés"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "What's New"
           }
         },
         "pt-BR": {
@@ -2632,6 +3316,12 @@
             "value": "Les nouveautés de Codenotch"
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "What's new in Codenotch"
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -2652,6 +3342,12 @@
         "fr": {
           "stringUnit": {
             "state": "translated",
+            "value": "Version %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
             "value": "Version %@"
           }
         },
@@ -2678,6 +3374,12 @@
             "value": "Continuer"
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Continue"
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -2701,6 +3403,12 @@
             "value": "macOS a refusé — essayez de déplacer Codenotch dans /Applications."
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "macOS refused this — try moving Codenotch to /Applications."
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -2721,6 +3429,12 @@
         "fr": {
           "stringUnit": {
             "state": "translated",
+            "value": "via %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
             "value": "via %@"
           }
         },
@@ -2747,6 +3461,12 @@
             "value": "Se connecter à %@"
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sign in to %@"
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -2768,6 +3488,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Connectez-vous à %@ pour lire ce compte."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sign in to %@ to read this account."
           }
         },
         "pt-BR": {
@@ -2793,6 +3519,12 @@
             "value": "Connectez-vous avec %@ pour lire ce compte."
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sign in with %@ to read this account."
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -2814,6 +3546,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Déconnectez-vous dans la fenêtre %@ pour utiliser un autre compte."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sign out in the %@ window to use another account."
           }
         },
         "pt-BR": {
@@ -2839,6 +3577,12 @@
             "value": "Changez de compte dans %@ ; l'encoche suit."
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Switch accounts in %@; the notch follows."
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -2860,6 +3604,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Changez de compte dans l'outil qui le détient ; l'encoche suit."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Switch accounts in the tool that owns it; the notch follows."
           }
         },
         "pt-BR": {
@@ -2885,6 +3635,12 @@
             "value": "Vous déconnecte de %@ — la session appartient à Codenotch."
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Signs out of %@ — the session belongs to Codenotch."
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -2906,6 +3662,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Vous restez connecté à %@ — terminez cette session dans %@ même."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "You stay signed in to %@ — end that session in %@ itself."
           }
         },
         "pt-BR": {
@@ -2931,6 +3693,12 @@
             "value": "Vous restez connecté à l'outil qui détient le compte."
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "You stay signed in to the tool that owns the account."
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -2952,6 +3720,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Connectez-vous avec l'outil qui détient ce compte."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sign in with the tool that owns this account."
           }
         },
         "pt-BR": {
@@ -2977,6 +3751,12 @@
             "value": "Se connecter à %@…"
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sign in to %@…"
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -2998,6 +3778,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Exécutez grok login — il vous connecte et rafraîchit le jeton lu ici."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Run grok login — it signs in and refreshes the token this reads."
           }
         },
         "pt-BR": {
@@ -3023,6 +3809,12 @@
             "value": "La consommation repose sur la clé opencode-go qu'OpenCode enregistre à la connexion — connectez Go dans OpenCode (`opencode auth login`) et l'encoche la lit."
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Usage rides on the opencode-go key OpenCode stores on sign-in — connect Go inside OpenCode (`opencode auth login`) and the notch reads it."
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -3044,6 +3836,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "La consommation repose sur une clé Z.ai GLM Coding Plan détenue par un outil de code — le settings.json de Claude Code, ZCode ou OpenCode. Configurez-en une là-bas et l'encoche la lit."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Usage rides on a Z.ai GLM Coding Plan key held by a coding tool — Claude Code's settings.json, ZCode or OpenCode. Set one up there and the notch reads it."
           }
         },
         "pt-BR": {
@@ -3069,6 +3867,12 @@
             "value": "Exécutez `%@` une fois — il vous connecte et rafraîchit le jeton lu ici. Utilisez /login là-bas pour changer de compte."
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Run `%@` once — it signs in and refreshes the token this reads. Use /login there to change account."
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -3090,6 +3894,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Illimité avec le plan %@ — rien à mesurer"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Unlimited on the %@ plan — nothing to meter"
           }
         },
         "pt-BR": {
@@ -3115,6 +3925,12 @@
             "value": "Le plan %@ n'a encore rien à mesurer pour Cursor"
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "The %@ plan has nothing for Cursor to meter yet"
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -3136,6 +3952,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Codex n'a signalé aucune fenêtre de consommation"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Codex reported no usage windows"
           }
         },
         "pt-BR": {
@@ -3161,6 +3983,12 @@
             "value": "Aucun abonnement OpenCode Go sur cette clé"
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No OpenCode Go subscription on this key"
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -3182,6 +4010,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Grok n'a encore rien de mesuré sur ce compte"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Grok has nothing metered on this account yet"
           }
         },
         "pt-BR": {
@@ -3207,6 +4041,12 @@
             "value": "Réglages…"
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Settings…"
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -3228,6 +4068,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Quitter Codenotch"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Quit Codenotch"
           }
         },
         "pt-BR": {
@@ -3253,6 +4099,12 @@
             "value": "Garder ouverte"
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Keep open"
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -3274,6 +4126,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Actualiser maintenant"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Refresh now"
           }
         },
         "pt-BR": {
@@ -3299,6 +4157,12 @@
             "value": "Codenotch est réglé sur Toujours afficher. Modifiez-le dans les Réglages."
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Codenotch is set to Always show. Change it in Settings."
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -3320,6 +4184,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Vérification…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Checking…"
           }
         },
         "pt-BR": {
@@ -3345,6 +4215,12 @@
             "value": "Codenotch est à jour."
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Codenotch is up to date."
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -3366,6 +4242,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "La version %@ est disponible et s'installera sous peu."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Version %@ is available and will install shortly."
           }
         },
         "pt-BR": {
@@ -3391,6 +4273,12 @@
             "value": "Serveur de mise à jour injoignable. Codenotch réessaiera de lui-même — cette copie n'a aucun problème."
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Couldn't reach the update server. Codenotch will try again on its own — nothing is wrong with this copy."
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -3412,6 +4300,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Deux fournisseurs de plus, et un plan de compte actif qui passait silencieusement à la trappe."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Two more providers, and a live account plan that was silently dropped."
           }
         },
         "pt-BR": {
@@ -3437,6 +4331,12 @@
             "value": "Grok est un nouvel anneau"
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Grok is a new ring"
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -3458,6 +4358,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "L'allocation hebdomadaire Grok Build de SuperGrok, lue depuis le même point de facturation que la CLI, avec la session dans ~/.grok/auth.json."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "SuperGrok's weekly Grok Build allowance, read from the same billing endpoint the CLI uses, with the session in ~/.grok/auth.json."
           }
         },
         "pt-BR": {
@@ -3483,6 +4389,12 @@
             "value": "Le plan Go d'OpenCode est un nouvel anneau"
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "OpenCode's Go plan is a new ring"
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -3504,6 +4416,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Lit le point de consommation officiel du plan Go avec la clé qu'OpenCode enregistre lui-même à la connexion — pas de seconde connexion."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Reads the Go plan's official usage endpoint with the key OpenCode itself stores on sign-in — no second sign-in."
           }
         },
         "pt-BR": {
@@ -3529,6 +4447,12 @@
             "value": "Un vrai compte Codex restait non mesuré"
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "A real Codex account went unmetered"
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -3550,6 +4474,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Le relevé en direct de Codex ne reconnaissait qu'une fenêtre de 5 heures et une de 7 jours. La vraie limite d'un compte en plan gratuit était sur 30 jours : elle passait inaperçue et s'affichait comme « rien à mesurer » sur un compte pourtant bien suivi."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Codex's live reading only recognised a 5-hour and a 7-day window. A free-plan account's real limit was a 30-day one, which fell through unnoticed and showed as nothing metered on an account that was genuinely tracked."
           }
         },
         "pt-BR": {
@@ -3575,6 +4505,12 @@
             "value": "Désactiver un fournisseur l'arrête vraiment"
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Switching a provider off now really stops it"
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -3596,6 +4532,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Ouvrir les Réglages pouvait encore lire le compte d'un fournisseur désactivé, et une réponse déjà en vol pouvait restaurer un relevé que vous veniez de demander d'oublier."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Opening Settings could still read a switched-off provider's account, and a reply already in flight could restore a reading you had just asked it to forget."
           }
         },
         "pt-BR": {
@@ -3621,6 +4563,12 @@
             "value": "Les contributeurs peuvent compiler sans certificat"
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Contributors can build without a certificate"
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -3642,6 +4590,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "make build et make test se signent désormais tout seuls quand le Developer ID du mainteneur est absent — aucun compte Apple nécessaire pour contribuer."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "make build and make test now sign themselves automatically when the maintainer's Developer ID isn't present — no Apple account needed to work on this."
           }
         },
         "pt-BR": {
@@ -3667,6 +4621,12 @@
             "value": "La sortie de veille n'efface plus un relevé."
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Waking from sleep no longer erases a reading."
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -3688,6 +4648,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Un anneau survit au réveil de votre Mac"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "A ring survives waking your Mac"
           }
         },
         "pt-BR": {
@@ -3713,6 +4679,12 @@
             "value": "Un bref instant juste après la veille, où macOS n'autorise pas encore d'invite du trousseau, était pris pour une déconnexion — ce qui effaçait le relevé et laissait « en attente du premier relevé » à l'écran. Le chiffre vieillit désormais au lieu d'être jeté, et la lecture repart d'elle-même."
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "A brief window right after sleep, where macOS won't allow a keychain prompt yet, was mistaken for being signed out — which erased the reading and left \"waiting for the first reading\" on screen. It now ages the number instead of throwing it away, and picks back up on its own."
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -3734,6 +4706,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Deux comptes de plus, quatre correctifs de la communauté, et des doublons honnêtes."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Two more accounts, four community fixes, and honest duplicates."
           }
         },
         "pt-BR": {
@@ -3759,6 +4737,12 @@
             "value": "Plusieurs comptes Claude Code"
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Multiple Claude Code accounts"
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -3780,6 +4764,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Vous gardez un compte pro à part avec CLAUDE_CONFIG_DIR ? Il obtient désormais son propre anneau, ses propres limites et sa propre ligne dans les Réglages, à côté de votre compte personnel."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Keep a work login apart with CLAUDE_CONFIG_DIR? It now gets its own ring, its own limits, and its own row in Settings, beside your personal one."
           }
         },
         "pt-BR": {
@@ -3805,6 +4795,12 @@
             "value": "GLM ajouté"
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "GLM added"
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -3826,6 +4822,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Le Coding Plan de Z.ai se lit aussi en direct désormais, avec une clé empruntée à l'outil qui en détient déjà une."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Z.ai's Coding Plan reads live now too, with a key borrowed from whichever tool already holds one."
           }
         },
         "pt-BR": {
@@ -3851,6 +4853,12 @@
             "value": "Un anneau Claude bloqué se rétablit tout seul"
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "A stuck Claude ring recovers on its own"
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -3872,6 +4880,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Une défaillance momentanée — le plus souvent la sortie de veille du Mac — bloquait l'anneau jusqu'au redémarrage de l'app. Il se débloque désormais à la vérification suivante."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "One momentary failure — the Mac waking from sleep, most often — used to lock the ring until the app restarted. It now clears itself on the next check."
           }
         },
         "pt-BR": {
@@ -3897,6 +4911,12 @@
             "value": "Les sessions Cursor cessent de signaler un travail déjà terminé"
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Cursor sessions stop reporting work that already ended"
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -3918,6 +4938,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Une conversation plantée ou abandonnée pouvait se lire « toujours en cours » pendant un jour ou plus. Elle remarque désormais quand l'écriture s'est réellement arrêtée."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "A crashed or abandoned chat could read as \"still working\" for a day or more. It now notices when the writing has actually stopped."
           }
         },
         "pt-BR": {
@@ -3943,6 +4969,12 @@
             "value": "Un doublon vieux de plusieurs mois ne peut plus l'emporter"
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "A months-old duplicate can no longer win"
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -3964,6 +4996,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Claude Code dépose une nouvelle entrée dans le trousseau à chaque rotation de jeton. Un compte connecté depuis un moment pouvait en choisir une ancienne, expirée, au hasard, et afficher « en attente du premier relevé » indéfiniment."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Claude Code files a new keychain entry on every token rotation. An account signed in for a while could pick an old, expired one at random and show \"waiting for the first reading\" forever."
           }
         },
         "pt-BR": {
@@ -3989,6 +5027,12 @@
             "value": "Un clic malencontreux ne bloque plus l'encoche ouverte"
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "A stray click no longer pins the notch open"
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -4010,6 +5054,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Cliquer près du bord de l'écran avant même l'ouverture de l'encoche pouvait la laisser bloquée ouverte, sans rien à l'écran pour l'expliquer."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Clicking near the screen edge before the notch had even opened could leave it stuck open with nothing on screen explaining why."
           }
         },
         "pt-BR": {
@@ -4035,6 +5085,12 @@
             "value": "Codex se lit en direct, et Toujours afficher le reste."
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Codex reads live, and Always show stays on."
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -4056,6 +5112,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Codex est lu en direct plutôt que depuis un journal"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Codex is read live instead of from a log"
           }
         },
         "pt-BR": {
@@ -4081,6 +5143,12 @@
             "value": "Le chiffre venait d'un fichier que Codex écrit pendant un tour : il datait donc de votre dernière utilisation — trois jours de retard dans un cas. Codenotch interroge désormais Codex lui-même, et correspond à son propre panneau."
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "The figure came from a file Codex writes during a turn, so it was as old as the last time you used it — three days stale in one case. Codenotch now asks Codex itself, and matches its own panel."
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -4102,6 +5170,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "L'anneau Codex remarque l'app de bureau"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "The Codex ring notices the desktop app"
           }
         },
         "pt-BR": {
@@ -4127,6 +5201,12 @@
             "value": "Il ne surveillait que les fichiers écrits par la CLI et l'extension VS Code : le travail fait dans l'app de bureau ne le faisait donc jamais tourner."
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "It only ever watched the files the CLI and the VS Code extension write, so work done in the desktop app never made it spin."
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -4148,6 +5228,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Toujours afficher ne se désactive plus tout seul"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Always show no longer turns itself off"
           }
         },
         "pt-BR": {
@@ -4173,6 +5259,12 @@
             "value": "Cliquer sur l'encoche basculait le même indicateur que le réglage : un clic malencontreux la remettait discrètement sur affichage au survol."
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Clicking the notch toggled the same flag the setting used, so a stray click quietly put it back to showing on hover."
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -4194,6 +5286,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Bien moins d'invites du trousseau"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Far fewer keychain prompts"
           }
         },
         "pt-BR": {
@@ -4219,6 +5317,12 @@
             "value": "Une fois un jeton expiré, chaque vérification retournait au trousseau — une invite par minute. Le secret n'est désormais lu que lorsque l'app propriétaire l'a modifié, et un refus n'est jamais réessayé sur minuterie."
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Once a token expired, every check went back to the keychain — a prompt a minute. It now reads the secret only when the owning app has changed it, and never retries a refusal on a timer."
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -4240,6 +5344,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Une limite en pause est affichée comme telle"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "A paused limit is shown as paused"
           }
         },
         "pt-BR": {
@@ -4265,6 +5375,12 @@
             "value": "Certaines limites sont atteintes alors que le chiffre principal indique encore de la marge. L'anneau se lit comme épuisé et indique quand elle se lève."
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Some limits are reached while the headline still shows room. The ring reads as spent and says when it lifts."
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -4286,6 +5402,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Les longs messages ne sont plus tronqués"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Long messages are no longer cut off"
           }
         },
         "pt-BR": {
@@ -4311,6 +5433,12 @@
             "value": "Une info-bulle ayant quelque chose à expliquer ne réservait qu'une seule ligne, quelle que soit la longueur du texte."
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "A tooltip with something to explain reserved one line for it however much it said."
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -4332,6 +5460,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Toutes les sessions, et une info-bulle qui tient à l'écran."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Every session, and a tooltip that fits on the screen."
           }
         },
         "pt-BR": {
@@ -4357,6 +5491,12 @@
             "value": "Les info-bulles ne sont plus tronquées"
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Tooltips are no longer cut off"
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -4378,6 +5518,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Une carte est centrée sur l'anneau auquel elle appartient : le premier et le dernier fournisseur en projetaient donc la moitié hors du panneau — et ce qui débordait, c'était le titre. Le panneau lui garde désormais de la place."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "A card is centred on the ring it belongs to, so the first and last providers threw half of it past the end of the panel — and what fell off was the title. The panel now keeps room for it."
           }
         },
         "pt-BR": {
@@ -4403,6 +5549,12 @@
             "value": "Autant de sessions que votre écran peut en contenir"
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "As many sessions as your screen can hold"
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -4424,6 +5576,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "La liste était plafonnée à quatre quel que soit votre matériel. Elle est désormais calculée pour l'écran : dix sur un grand, et « et N de plus » uniquement quand il n'y a vraiment plus de place."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "The list was capped at four whatever you were running on. It is now solved for the display: ten on a large one, and \"and N more\" only when there is genuinely no room for the rest."
           }
         },
         "pt-BR": {
@@ -4449,6 +5607,12 @@
             "value": "Celles qui vous attendent passent en premier"
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "The ones that need you come first"
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -4470,6 +5634,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "En attente, puis en cours, puis inactives — ainsi, si quelque chose est résumé, c'est ce qui compte le moins."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Waiting, then busy, then idle — so if anything is summarised away, it is what matters least."
           }
         },
         "pt-BR": {
@@ -4495,6 +5665,12 @@
             "value": "Les vrais chiffres d'Antigravity, et un interrupteur qui reste éteint."
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Antigravity's real numbers, and a switch that stays off."
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -4516,6 +5692,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Antigravity affiche son quota réel"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Antigravity shows its actual quota"
           }
         },
         "pt-BR": {
@@ -4541,6 +5723,12 @@
             "value": "Google ne répond pas directement à Codenotch, qui interroge donc le serveur de langage d'Antigravity — là où le panneau de consommation d'Antigravity prend son chiffre."
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Google will not answer Codenotch directly, so it asks Antigravity's own language server instead — the same place Antigravity's usage panel gets its figure."
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -4562,6 +5750,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "La consommation se lit dans les deux sens"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Usage reads both ways"
           }
         },
         "pt-BR": {
@@ -4587,6 +5781,12 @@
             "value": "« 12 % utilisés · 88 % restants », pour qu'un relevé corresponde au bout que votre fournisseur affiche."
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "\"12% used · 88% left\", so a reading lines up with whichever end your vendor happens to show."
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -4608,6 +5808,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Un retour possible après une invite du trousseau refusée"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "A way back from a declined keychain prompt"
           }
         },
         "pt-BR": {
@@ -4633,6 +5839,12 @@
             "value": "Refuser ne ressemble plus à une déconnexion, et Autoriser l'accès… redemande à macOS."
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Declining no longer looks like being signed out, and Allow access… asks macOS again."
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -4654,6 +5866,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Désactiver un fournisseur tient désormais"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Switching a provider off now sticks"
           }
         },
         "pt-BR": {
@@ -4679,6 +5897,12 @@
             "value": "Il cessait d'être lu mais son dernier relevé était conservé : l'anneau revenait au lancement suivant."
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "It stopped being read but its last reading was kept, so the ring came back at the next launch."
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -4700,6 +5924,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Les réinitialisations lointaines affichent une date"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Distant resets show a date"
           }
         },
         "pt-BR": {
@@ -4725,6 +5955,12 @@
             "value": "Une limite se renouvelant dans quatre semaines indiquait « lun. », qu'on lisait comme ce lundi-ci. Elle indique désormais « 28 sept. »."
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "A limit renewing in four weeks said \"Mon\", which read as this Monday. It says \"28 Sep\"."
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -4746,6 +5982,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "La première version."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "The first release."
           }
         },
         "pt-BR": {
@@ -4771,6 +6013,12 @@
             "value": "Placez l'encoche où vous voulez"
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Put the notch anywhere"
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -4792,6 +6040,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Droite, gauche, haut ou bas. Elle reste à l'écart du Dock et de la barre des menus, et suit quand le Dock se déplace."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Right, left, top or bottom. It keeps clear of the Dock and the menu bar, and follows when the Dock moves."
           }
         },
         "pt-BR": {
@@ -4817,6 +6071,12 @@
             "value": "Elle rejoint l'encoche de votre Mac"
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "It joins your Mac's own notch"
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -4838,6 +6098,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Sur le bord supérieur, elle épouse la forme du matériel : les deux se lisent comme une seule forme plutôt que comme une barre garée en dessous."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "On the top edge it takes the hardware's shape, so the two read as one rather than as a bar parked underneath."
           }
         },
         "pt-BR": {
@@ -4863,6 +6129,12 @@
             "value": "Claude, Cursor, Codex et Gemini"
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Claude, Cursor, Codex and Gemini"
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -4884,6 +6156,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Chacun lu depuis l'outil déjà connecté sur ce Mac. Codenotch ne demande jamais de mot de passe."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Each read from the tool already signed in on this Mac. Codenotch never asks for a password."
           }
         },
         "pt-BR": {
@@ -4909,6 +6187,12 @@
             "value": "Choisissez où Codenotch apparaît"
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Choose where Codenotch appears"
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -4932,6 +6216,12 @@
             "value": "Dans le Dock, dans la barre des menus, ou nulle part."
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "In the Dock, in the menu bar, or nowhere at all."
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -4952,6 +6242,12 @@
         "fr": {
           "stringUnit": {
             "state": "translated",
+            "value": "Codenotch"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
             "value": "Codenotch"
           }
         },
@@ -4978,6 +6274,12 @@
             "value": "%@%% utilisés · %@%% restants"
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "%@%% Used · %@%% left"
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -4999,6 +6301,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "%@ restants"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "%@ left"
           }
         },
         "pt-BR": {
@@ -5024,6 +6332,12 @@
             "value": "%@ utilisés"
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "%@ used"
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -5045,6 +6359,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Connectez-vous avec la CLI GitHub pour lire votre consommation Copilot"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sign in with GitHub CLI to read your Copilot usage"
           }
         },
         "pt-BR": {
@@ -5070,6 +6390,12 @@
             "value": "Connectez-vous avec la CLI GitHub via `gh auth login`, puis activez GitHub Copilot."
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sign in with GitHub CLI using `gh auth login`, then enable GitHub Copilot."
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -5091,6 +6417,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "GitHub Copilot n'a signalé aucun quota mesuré"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "GitHub Copilot reported no metered quotas"
           }
         },
         "pt-BR": {
@@ -5116,6 +6448,12 @@
             "value": "Il n'y a rien à quoi se connecter : le total est additionné à partir de ce que Gemini CLI, OpenCode et Hermes ont enregistré sur leurs propres appels. Votre clé API n'est jamais lue."
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "There is nothing to sign in to: the count is added up from what Gemini CLI, OpenCode and Hermes recorded about their own calls. Your API key is never read."
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -5137,6 +6475,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Aucune session Gemini CLI, OpenCode ou Hermes trouvée"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No Gemini CLI, OpenCode or Hermes sessions found"
           }
         },
         "pt-BR": {
@@ -5162,6 +6506,12 @@
             "value": "Exécutez `%@` une fois — il vous connecte et c'est de là que viennent ces relevés. Utilisez /login là-bas pour changer de compte."
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Run `%@` once — it signs in and is what these readings come from. Use /login there to change account."
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -5183,6 +6533,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Restreint"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Scoped"
           }
         },
         "pt-BR": {
@@ -5208,6 +6564,12 @@
             "value": "Consommation auto"
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Auto usage"
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -5229,6 +6591,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Équipe à la demande"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Team on demand"
           }
         },
         "pt-BR": {
@@ -5254,6 +6622,12 @@
             "value": "Tout actualiser"
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Refresh all"
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -5275,6 +6649,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Date de réinitialisation"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Reset date"
           }
         },
         "pt-BR": {
@@ -5300,6 +6680,12 @@
             "value": "Temps restant"
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Time remaining"
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -5321,6 +6707,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Des minutes en dessous d'une heure ; sinon la date et l'heure de réinitialisation."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Minutes under an hour; otherwise the reset date and time."
           }
         },
         "pt-BR": {
@@ -5346,6 +6738,12 @@
             "value": "Temps avant la réinitialisation de la consommation, par exemple 3 j 3h ou 3h 20m."
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Time until usage resets, such as 3 Days 3h or 3h 20m."
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -5367,6 +6765,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Réinit. dans %lld j %lldh"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Resets in %lld Day %lldh"
           }
         },
         "pt-BR": {
@@ -5392,6 +6796,12 @@
             "value": "Réinit. dans %lld j %lldh"
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Resets in %lld Days %lldh"
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -5413,6 +6823,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Réinit. dans %lldh %lldm"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Resets in %lldh %lldm"
           }
         },
         "pt-BR": {
@@ -5438,6 +6854,12 @@
             "value": "Rien à l'écran. Les relevés restent dans le menu de la barre des menus quand Icône de l'app est réglée sur Barre des menus. Sinon, rouvrez Codenotch depuis Applications pour retrouver ces réglages."
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Nothing on screen. The readings stay in the menu bar menu when App icon is Menu bar. Otherwise, open Codenotch again from Applications to bring these settings back."
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -5459,6 +6881,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Écran principal"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Main display"
           }
         },
         "pt-BR": {
@@ -5484,6 +6912,12 @@
             "value": "Tous les écrans"
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "All displays"
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -5505,6 +6939,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "L'encoche n'apparaît que sur l'écran qui porte la barre des menus."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "The notch appears only on the display with the menu bar."
           }
         },
         "pt-BR": {
@@ -5530,6 +6970,12 @@
             "value": "Chaque écran a sa propre encoche, et en survoler une n'ouvre que celle-là."
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Each display gets its own notch, and hovering one opens only that one."
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -5551,6 +6997,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "3 secondes"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "3 seconds"
           }
         },
         "pt-BR": {
@@ -5576,6 +7028,12 @@
             "value": "5 secondes"
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "5 seconds"
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -5597,6 +7055,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "10 secondes"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "10 seconds"
           }
         },
         "pt-BR": {
@@ -5622,6 +7086,12 @@
             "value": "Assez long pour être remarqué, assez court pour être ignoré."
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Long enough to notice, short enough to ignore."
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -5643,6 +7113,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Assez long pour lire le nom de la session et l'atteindre."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Long enough to read the session's name and reach for it."
           }
         },
         "pt-BR": {
@@ -5668,6 +7144,12 @@
             "value": "Reste jusqu'à ce que vous ayez eu l'occasion de lever les yeux."
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Stays until you have had a chance to look up."
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -5689,6 +7171,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Couleur d'accentuation de l'appareil"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Device accent color"
           }
         },
         "pt-BR": {
@@ -5714,6 +7202,12 @@
             "value": "Connectés"
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Connected"
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -5735,6 +7229,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Non connectés"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Not connected"
           }
         },
         "pt-BR": {
@@ -5760,6 +7260,12 @@
             "value": "Comptes"
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Accounts"
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -5780,6 +7286,12 @@
         "fr": {
           "stringUnit": {
             "state": "translated",
+            "value": "Notifications"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
             "value": "Notifications"
           }
         },
@@ -5806,6 +7318,12 @@
             "value": "Rien n'est connecté : l'encoche n'a donc aucun anneau à dessiner."
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Nothing is connected, so the notch has no rings to draw."
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -5827,6 +7345,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "L'encoche les dessine dans cet ordre. Faites glisser une ligne par sa poignée pour la déplacer."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "The notch draws these in this order. Drag one by its handle to move it."
           }
         },
         "pt-BR": {
@@ -5852,6 +7376,12 @@
             "value": "Ceux-ci n'ont pas d'anneau à placer. Activez-en un et il rejoint la fin de la liste ci-dessus."
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "These have no ring to place. Switch one on and it joins the end of the list above."
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -5873,6 +7403,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Encoche"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Notch"
           }
         },
         "pt-BR": {
@@ -5898,6 +7434,12 @@
             "value": "Réinitialisation"
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Reset time"
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -5919,6 +7461,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Écrans"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Displays"
           }
         },
         "pt-BR": {
@@ -5944,6 +7492,12 @@
             "value": "Écran"
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Display"
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -5965,6 +7519,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Suivre la fenêtre active"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Follow active window"
           }
         },
         "pt-BR": {
@@ -5990,6 +7550,12 @@
             "value": "Écran indisponible"
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Unavailable display"
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -6010,6 +7576,12 @@
         "fr": {
           "stringUnit": {
             "state": "translated",
+            "value": "App"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
             "value": "App"
           }
         },
@@ -6036,6 +7608,12 @@
             "value": "Couleur d'accentuation"
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Accent color"
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -6057,6 +7635,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Quand une session se termine"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "When a session ends"
           }
         },
         "pt-BR": {
@@ -6082,6 +7666,12 @@
             "value": "Ouvrir l'encoche un instant"
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Open the notch for a moment"
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -6103,6 +7693,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Pendant"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "For"
           }
         },
         "pt-BR": {
@@ -6128,6 +7724,12 @@
             "value": "Émettre un son"
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Play a sound"
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -6149,6 +7751,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Terminée"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Finished"
           }
         },
         "pt-BR": {
@@ -6174,6 +7782,12 @@
             "value": "En attente de vous"
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Waiting on you"
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -6195,6 +7809,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Alertes de seuil"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Threshold alerts"
           }
         },
         "pt-BR": {
@@ -6220,6 +7840,12 @@
             "value": "Masquer la barre latérale"
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Hide Sidebar"
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -6241,6 +7867,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Afficher la barre latérale"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Show Sidebar"
           }
         },
         "pt-BR": {
@@ -6266,6 +7898,12 @@
             "value": "Sélectionné"
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Selected"
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -6287,6 +7925,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Non sélectionné"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Not selected"
           }
         },
         "pt-BR": {
@@ -6312,6 +7956,12 @@
             "value": "%@ (introuvable)"
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "%@ (missing)"
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -6333,6 +7983,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Écouter %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Play %@"
           }
         },
         "pt-BR": {
@@ -6358,6 +8014,12 @@
             "value": "Budget mensuel"
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Monthly budget"
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -6379,6 +8041,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Aucun"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "None"
           }
         },
         "pt-BR": {
@@ -6404,6 +8072,12 @@
             "value": "jetons"
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "tokens"
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -6425,6 +8099,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Limite %@ atteinte"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "%@ limit reached"
           }
         },
         "pt-BR": {
@@ -6450,6 +8130,12 @@
             "value": "%@ est à %lld%%"
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "%@ is at %lld%%"
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -6471,6 +8157,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Sa limite %@ est épuisée."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Its %@ limit is spent."
           }
         },
         "pt-BR": {
@@ -6496,6 +8188,12 @@
             "value": "Sa limite %@ est épuisée — réinit. %@"
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Its %@ limit is spent — resets %@"
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -6517,6 +8215,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "%lld%% de sa limite %@ utilisés."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "%lld%% of its %@ limit used."
           }
         },
         "pt-BR": {
@@ -6542,6 +8246,12 @@
             "value": "Se déplace vers l'écran contenant la fenêtre qui reçoit la saisie clavier."
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Moves to the display containing the window receiving keyboard input."
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -6563,6 +8273,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Fixée sur %@."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Pinned to %@."
           }
         },
         "pt-BR": {
@@ -6588,6 +8304,12 @@
             "value": "Cet écran est déconnecté. Codenotch suit la fenêtre active jusqu'à son retour."
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "That display is disconnected. Codenotch follows the active window until it returns."
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -6609,6 +8331,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Faites glisser pour réordonner. L'encoche dessine les anneaux dans cet ordre."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Drag to reorder. The notch draws the rings in this order."
           }
         },
         "pt-BR": {
@@ -6634,6 +8362,12 @@
             "value": "Activez ceci pour lui donner un anneau dans l'encoche."
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Switch this on to give it a ring in the notch."
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -6655,6 +8389,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Les alertes pour %@ sont coupées. Cliquez pour les réactiver."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Alerts for %@ are muted. Click to unmute."
           }
         },
         "pt-BR": {
@@ -6680,6 +8420,12 @@
             "value": "Alerter quand %@ franchit 80 % et 100 % d'une limite."
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Alert when %@ crosses 80% and 100% of a limit."
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -6701,6 +8447,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Remplit l'anneau par rapport à un plafond que vous choisissez ; Google n'en publie aucun pour une clé API."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Fills the ring against a ceiling you choose; Google publishes none for an API key."
           }
         },
         "pt-BR": {
@@ -6726,6 +8478,12 @@
             "value": "Codenotch lit la consommation des outils déjà connectés sur ce Mac — il ne demande jamais votre mot de passe. Installez l'un de Claude Code (l'outil en terminal, pas l'app Claude), Cursor (l'éditeur ou cursor-agent), Codex, Antigravity, GLM, Grok, OpenCode, GitHub Copilot ou une clé API Gemini (via Gemini CLI, OpenCode ou Hermes) et connectez-vous : son anneau apparaît dans l'encoche."
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Codenotch reads usage from tools already signed in on this Mac — it never asks for your password. Install and sign in to any of Claude Code (the terminal tool, not the Claude app), Cursor (the editor or cursor-agent), Codex, Antigravity, GLM, Grok, OpenCode, GitHub Copilot or a Gemini API key (via Gemini CLI, OpenCode or Hermes), and its ring appears in the notch."
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -6747,6 +8505,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "macOS demandera une fois l'autorisation de lire les identifiants enregistrés de Claude Code, d'Antigravity et de cursor-agent. Choisissez Toujours autoriser — un simple Autoriser fait redemander à chaque fois."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "macOS will ask once for permission to read Claude Code's, Antigravity's and cursor-agent's saved logins. Choose Always Allow — plain Allow makes it ask again every time."
           }
         },
         "pt-BR": {
@@ -6772,6 +8536,12 @@
             "value": "Réordonnez les anneaux, choisissez un écran, et soyez prévenu quand une limite approche."
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Reorder the rings, pick a display, and get told when a limit is close."
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -6793,6 +8563,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Faites glisser pour réordonner les anneaux"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Drag to reorder the rings"
           }
         },
         "pt-BR": {
@@ -6818,6 +8594,12 @@
             "value": "Les Réglages se divisent en Connectés et Non connectés ; faites glisser une ligne connectée par sa poignée pour changer l'ordre dans lequel l'encoche les dessine."
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Settings splits into Connected and Not connected; drag a connected row by its handle to change the order the notch draws them in."
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -6839,6 +8621,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Fixez l'encoche sur un écran, ou affichez-la sur tous"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Pin the notch to one display, or show it on every one"
           }
         },
         "pt-BR": {
@@ -6864,6 +8652,12 @@
             "value": "Un sélecteur Écrans dans Apparence propose l'écran principal ou tous les écrans ; un second sélecteur fixe une encoche unique sur un écran nommé."
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "A Displays picker in Appearance offers the main display or all of them; a second picker pins a single notch to a named screen."
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -6885,6 +8679,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Un anneau prévient quand il franchit 80 % et 100 %"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "A ring says when it crosses 80% and 100%"
           }
         },
         "pt-BR": {
@@ -6910,6 +8710,12 @@
             "value": "Une notification système une fois par franchissement, que l'on peut couper fournisseur par fournisseur depuis sa propre ligne de réglages."
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "A system notification once per crossing, muted per provider from its own settings row."
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -6931,6 +8737,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "GitHub Copilot est un nouvel anneau"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "GitHub Copilot is a new ring"
           }
         },
         "pt-BR": {
@@ -6956,6 +8768,12 @@
             "value": "Lit le point de quota Copilot de GitHub en utilisant la session de la CLI GitHub déjà présente sur le Mac."
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Reads GitHub's Copilot quota endpoint using the GitHub CLI session already on the Mac."
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -6977,6 +8795,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Signaler la fin d'une session"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Say when a session ends"
           }
         },
         "pt-BR": {
@@ -7002,6 +8826,12 @@
             "value": "L'encoche s'ouvre quelques secondes et émet un son quand un agent cesse de travailler ou se met à vous attendre ; un clic vous y amène."
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "The notch opens itself for a few seconds and sounds a chime when an agent stops working or starts waiting on you; a click jumps to it."
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -7023,6 +8853,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "⌥-glissez la pastille le long de son bord"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "⌥-drag the pill along its edge"
           }
         },
         "pt-BR": {
@@ -7048,6 +8884,12 @@
             "value": "Décalez-la pour dégager une autre app de la barre des menus ancrée au même endroit ; mémorisé pour chaque bord."
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Nudge it clear of another menu-bar app anchored to the same spot; remembered per edge."
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -7069,6 +8911,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Choisissez une couleur d'accentuation"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Choose an accent colour"
           }
         },
         "pt-BR": {
@@ -7094,6 +8942,12 @@
             "value": "L'accentuation de l'appareil par défaut, ou une couleur fixe pour l'état positif de l'anneau — les couleurs d'alerte ambre et rouge restent fixes quoi qu'il arrive."
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "The device accent by default, or a fixed colour for the ring's positive state — the amber and red warning colours stay fixed regardless."
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -7115,6 +8969,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Un décompte plutôt qu'une date de réinitialisation"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "A countdown instead of a reset date"
           }
         },
         "pt-BR": {
@@ -7140,6 +9000,12 @@
             "value": "Le sélecteur Réinitialisation dans Apparence peut afficher « Réinit. dans 3h 20m » au lieu d'une date et d'une heure."
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Appearance's Reset time picker can show \"Resets in 3h 20m\" instead of a date and time."
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -7161,6 +9027,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Lecture de Cursor depuis cursor-agent, et plans entreprise corrects"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Read Cursor from cursor-agent, and enterprise plans correctly"
           }
         },
         "pt-BR": {
@@ -7186,6 +9058,12 @@
             "value": "Une connexion Cursor en CLI seule obtient désormais un anneau, et les plans entreprise/équipe lisent leur consommation réelle au lieu de signaler qu'il n'y a rien à mesurer."
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "A CLI-only Cursor login now gets a ring, and enterprise/team plans read their real usage instead of reporting nothing to meter."
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -7207,6 +9085,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Moins d'invites du trousseau pour Claude et Antigravity"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Fewer keychain prompts for Claude and Antigravity"
           }
         },
         "pt-BR": {
@@ -7232,6 +9116,12 @@
             "value": "Claude lit d'abord le /usage de sa propre CLI et ne touche au trousseau qu'en repli ; le serveur de langage d'Antigravity est interrogé avant lui."
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Claude reads its own CLI's /usage first, touching the keychain only as a fallback; Antigravity's language server is asked before it."
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -7253,6 +9143,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Une consommation sous 1 % ne se lit plus 0 %"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sub-1% usage no longer reads as 0%"
           }
         },
         "pt-BR": {
@@ -7278,6 +9174,12 @@
             "value": "Un relevé sous un pour cent affiche un dixième (« <0,1 % ») au lieu d'être arrondi à rien."
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "A reading under one percent shows a tenth (\"<0.1%\") instead of rounding to nothing."
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -7299,6 +9201,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Les contributeurs peuvent compiler sans signature Xcode"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Contributors can build without Xcode signing"
           }
         },
         "pt-BR": {
@@ -7324,6 +9232,12 @@
             "value": "make build et make test se signent tout seuls quand le certificat du mainteneur est absent, et la CI exécute désormais la suite à chaque push et chaque pull request."
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "make build and make test sign themselves automatically when the maintainer's certificate isn't present, and CI now runs the suite on every push and pull request."
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -7345,6 +9259,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Suivre le système"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Follow System"
           }
         },
         "pt-BR": {
@@ -7370,6 +9290,12 @@
             "value": "Correspond à la langue préférée du Mac."
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Matches the Mac's preferred language."
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -7391,6 +9317,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Codenotch utilise cette langue même si le Mac ne le fait pas."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Codenotch uses this language even if the Mac does not."
           }
         },
         "pt-BR": {
@@ -7416,6 +9348,12 @@
             "value": "Langue"
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Language"
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -7437,6 +9375,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Afficher le rythme de consommation"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Show usage pace"
           }
         },
         "pt-BR": {
@@ -7462,6 +9406,12 @@
             "value": "Compare chaque allocation temporisée au temps restant avant réinitialisation, en montrant le quota en déficit ou gardé en réserve."
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Compares each timed allowance with the time left until reset, showing quota in deficit or held in reserve."
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -7483,6 +9433,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Taille"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Size"
           }
         },
         "pt-BR": {
@@ -7508,6 +9464,12 @@
             "value": "Petite"
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Small"
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -7529,6 +9491,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Moyenne"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Medium"
           }
         },
         "pt-BR": {
@@ -7554,6 +9522,12 @@
             "value": "Grande"
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Large"
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -7575,6 +9549,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Prend le moins de place sur le bord. Lisible, mais pas de l'autre bout du bureau."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Takes the least room on the edge. Readable, but not from across the desk."
           }
         },
         "pt-BR": {
@@ -7600,6 +9580,12 @@
             "value": "La taille à laquelle l'encoche était dessinée."
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "The size the notch was drawn at."
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -7621,6 +9607,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Plus facile à lire d'un coup d'œil, et plus difficile à ignorer."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Easier to read at a glance, and harder to ignore."
           }
         },
         "pt-BR": {
@@ -7646,6 +9638,12 @@
             "value": "Maintenez ⌥ et faites glisser l'encoche pour la déplacer le long de son bord. Chaque bord retient où vous l'avez laissée."
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Hold ⌥ and drag the notch to slide it along its edge. Each edge remembers where you left it."
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -7667,6 +9665,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Recentrer"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Recentre"
           }
         },
         "pt-BR": {
@@ -7692,6 +9696,12 @@
             "value": "%@ % de déficit"
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "%@% deficit"
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -7713,6 +9723,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "%@ % en réserve"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "%@% reserved"
           }
         },
         "pt-BR": {
@@ -7738,6 +9754,12 @@
             "value": "Inactive"
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Idle"
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -7759,6 +9781,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Connectez-vous à Codex dans ~/.codex-%@ pour lire votre consommation"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sign in to Codex in ~/.codex-%@ to read your usage"
           }
         },
         "pt-BR": {
@@ -7784,6 +9812,12 @@
             "value": "Connectez-vous avec l'app Command Code pour lire votre consommation"
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sign in with the Command Code app to read your usage"
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -7805,6 +9839,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Saisissez une clé API Ollama dans les Réglages, ou exportez OLLAMA_API_KEY"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Enter an Ollama API key in Settings, or export OLLAMA_API_KEY"
           }
         },
         "pt-BR": {
@@ -7830,6 +9870,12 @@
             "value": "Démarrez Ollama pour surveiller vos modèles locaux"
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Start Ollama to monitor your local models"
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -7851,6 +9897,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Saisissez une clé API Ollama ci-dessous, ou exportez OLLAMA_API_KEY dans votre shell."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Enter an Ollama API key below, or export OLLAMA_API_KEY in your shell."
           }
         },
         "pt-BR": {
@@ -7876,6 +9928,12 @@
             "value": "Connectez-vous avec l'app Command Code — elle écrit ~/.commandcode/auth.json et l'encoche le lit."
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sign in with the Command Code app — it writes ~/.commandcode/auth.json and the notch reads it."
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -7897,6 +9955,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Command Code n'a encore rien de mesuré sur ce compte"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Command Code has nothing metered on this account yet"
           }
         },
         "pt-BR": {
@@ -7922,6 +9986,12 @@
             "value": "Consommation mensuelle"
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Monthly usage"
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -7943,6 +10013,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Consommation de la session"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Session usage"
           }
         },
         "pt-BR": {
@@ -7968,6 +10044,12 @@
             "value": "Consommation hebdomadaire"
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Weekly usage"
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -7991,6 +10073,12 @@
             "value": "Modèles locaux"
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Local Models"
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -8011,6 +10099,12 @@
         "fr": {
           "stringUnit": {
             "state": "translated",
+            "value": "Localhost"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
             "value": "Localhost"
           }
         },
@@ -8037,6 +10131,12 @@
             "value": "Codenotch lit la consommation des outils déjà connectés sur ce Mac — il ne demande jamais votre mot de passe. Installez l'un de Claude Code (l'outil en terminal, pas l'app Claude), Cursor (l'éditeur ou cursor-agent), Codex, Antigravity, GLM, Grok, OpenCode, Command Code, GitHub Copilot ou une clé API Gemini (via Gemini CLI, OpenCode ou Hermes) et connectez-vous : son anneau apparaît dans l'encoche."
           }
         },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Codenotch reads usage from tools already signed in on this Mac — it never asks for your password. Install and sign in to any of Claude Code (the terminal tool, not the Claude app), Cursor (the editor or cursor-agent), Codex, Antigravity, GLM, Grok, OpenCode, Command Code, GitHub Copilot or a Gemini API key (via Gemini CLI, OpenCode or Hermes), and its ring appears in the notch."
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -8054,6 +10154,12 @@
     "complete": {
       "extractionState": "manual",
       "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "complete"
+          }
+        },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
@@ -8065,6 +10171,12 @@
     "Complete": {
       "extractionState": "manual",
       "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Complete"
+          }
+        },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
@@ -8076,6 +10188,12 @@
     "Waiting": {
       "extractionState": "manual",
       "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Waiting"
+          }
+        },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
@@ -8087,6 +10205,12 @@
     "Local Session": {
       "extractionState": "manual",
       "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Local Session"
+          }
+        },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
@@ -8098,6 +10222,12 @@
     "Active": {
       "extractionState": "manual",
       "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Active"
+          }
+        },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
@@ -8109,6 +10239,12 @@
     "Ensure Antigravity IDE is running to read this account.": {
       "extractionState": "manual",
       "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Ensure Antigravity IDE is running to read this account."
+          }
+        },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
@@ -8120,6 +10256,12 @@
     "Automatic": {
       "extractionState": "manual",
       "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Automatic"
+          }
+        },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
@@ -8131,6 +10273,12 @@
     "5-Hour Limit": {
       "extractionState": "manual",
       "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "5-Hour Limit"
+          }
+        },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
@@ -8142,6 +10290,12 @@
     "Weekly Limit": {
       "extractionState": "manual",
       "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Weekly Limit"
+          }
+        },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
@@ -8153,6 +10307,12 @@
     "Liquid Glass": {
       "extractionState": "manual",
       "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Liquid Glass"
+          }
+        },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
@@ -8164,6 +10324,12 @@
     "Solid black": {
       "extractionState": "manual",
       "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Solid black"
+          }
+        },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
@@ -8175,6 +10341,12 @@
     "System Liquid Glass. Follows this Mac's Appearance settings, including Clear or Tinted glass and light or dark mode.": {
       "extractionState": "manual",
       "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "System Liquid Glass. Follows this Mac's Appearance settings, including Clear or Tinted glass and light or dark mode."
+          }
+        },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
@@ -8186,6 +10358,12 @@
     "The original opaque black notch. Always dark, whatever the Mac's appearance.": {
       "extractionState": "manual",
       "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "The original opaque black notch. Always dark, whatever the Mac's appearance."
+          }
+        },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
@@ -8197,6 +10375,12 @@
     "A second ring for the week, Liquid Glass, French, and Claude Desktop read straight from its own cache.": {
       "extractionState": "manual",
       "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "A second ring for the week, Liquid Glass, French, and Claude Desktop read straight from its own cache."
+          }
+        },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
@@ -8208,6 +10392,12 @@
     "The week gets a ring of its own": {
       "extractionState": "manual",
       "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "The week gets a ring of its own"
+          }
+        },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
@@ -8219,6 +10409,12 @@
     "A second arc, inside the headline ring or outside it, for providers that publish a weekly limit as well as a session one. Off by default; Appearance has the switch.": {
       "extractionState": "manual",
       "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "A second arc, inside the headline ring or outside it, for providers that publish a weekly limit as well as a session one. Off by default; Appearance has the switch."
+          }
+        },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
@@ -8230,6 +10426,12 @@
     "The open notch, its tooltip and the settings orb take the system's own glass surface, so they refract what is behind them instead of sitting on it. Reduce Transparency turns it solid.": {
       "extractionState": "manual",
       "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "The open notch, its tooltip and the settings orb take the system's own glass surface, so they refract what is behind them instead of sitting on it. Reduce Transparency turns it solid."
+          }
+        },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
@@ -8241,6 +10443,12 @@
     "Français": {
       "extractionState": "manual",
       "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Français"
+          }
+        },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
@@ -8252,6 +10460,12 @@
     "A third language in Appearance, alongside English and 简体中文.": {
       "extractionState": "manual",
       "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "A third language in Appearance, alongside English and 简体中文."
+          }
+        },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
@@ -8263,6 +10477,12 @@
     "Claude Desktop usage, read from its own cache": {
       "extractionState": "manual",
       "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Claude Desktop usage, read from its own cache"
+          }
+        },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
@@ -8274,6 +10494,12 @@
     "A third way to read a Claude account, used when the CLI and the token cannot answer. Nothing is sent anywhere: the cache is on this Mac and is only decompressed.": {
       "extractionState": "manual",
       "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "A third way to read a Claude account, used when the CLI and the token cannot answer. Nothing is sent anywhere: the cache is on this Mac and is only decompressed."
+          }
+        },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
@@ -8285,6 +10511,12 @@
     "Claude Code found where npm puts it": {
       "extractionState": "manual",
       "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Claude Code found where npm puts it"
+          }
+        },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
@@ -8296,6 +10528,12 @@
     "An install under nvm, Volta or pnpm is discovered like any other, which also restores the background sign-in renewal for those setups.": {
       "extractionState": "manual",
       "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "An install under nvm, Volta or pnpm is discovered like any other, which also restores the background sign-in renewal for those setups."
+          }
+        },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
@@ -8307,6 +10545,12 @@
     "No more transcript folders left behind": {
       "extractionState": "manual",
       "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No more transcript folders left behind"
+          }
+        },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
@@ -8318,6 +10562,12 @@
     "Reading Claude usage ran in a fresh directory every poll, and Claude Code filed a transcript folder for each one. It now runs from a single place, in print mode, writing no session at all.": {
       "extractionState": "manual",
       "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Reading Claude usage ran in a fresh directory every poll, and Claude Code filed a transcript folder for each one. It now runs from a single place, in print mode, writing no session at all."
+          }
+        },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
@@ -8329,6 +10579,12 @@
     "Reset times follow the Mac's clock": {
       "extractionState": "manual",
       "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Reset times follow the Mac's clock"
+          }
+        },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
@@ -8340,6 +10596,12 @@
     "A 24-hour Mac gets 24-hour reset times instead of AM and PM.": {
       "extractionState": "manual",
       "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "A 24-hour Mac gets 24-hour reset times instead of AM and PM."
+          }
+        },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
@@ -8351,6 +10613,12 @@
     "A finished session says so": {
       "extractionState": "manual",
       "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "A finished session says so"
+          }
+        },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
@@ -8362,6 +10630,12 @@
     "Agent sessions carry a success state, so a run that has completed reads differently from one still going.": {
       "extractionState": "manual",
       "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Agent sessions carry a success state, so a run that has completed reads differently from one still going."
+          }
+        },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
@@ -8373,6 +10647,12 @@
     "Antigravity: choose which limit leads": {
       "extractionState": "manual",
       "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Antigravity: choose which limit leads"
+          }
+        },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
@@ -8384,6 +10664,12 @@
     "The headline ring can follow a named limit rather than whichever happens to be tightest, and a CLI-only install counts as a real account.": {
       "extractionState": "manual",
       "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "The headline ring can follow a named limit rather than whichever happens to be tightest, and a CLI-only install counts as a real account."
+          }
+        },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
@@ -8395,6 +10681,12 @@
     "Only the hardware notch wakes a notch joined to it": {
       "extractionState": "manual",
       "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Only the hardware notch wakes a notch joined to it"
+          }
+        },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
@@ -8406,6 +10698,12 @@
     "A notch merged with the camera housing no longer wakes from a pointer anywhere along the whole top edge.": {
       "extractionState": "manual",
       "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "A notch merged with the camera housing no longer wakes from a pointer anywhere along the whole top edge."
+          }
+        },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
@@ -8417,6 +10715,12 @@
     "Weekly ring": {
       "extractionState": "manual",
       "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Weekly ring"
+          }
+        },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
@@ -8428,6 +10732,12 @@
     "Surface": {
       "extractionState": "manual",
       "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Surface"
+          }
+        },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
@@ -8439,6 +10749,12 @@
     "Notch reads": {
       "extractionState": "manual",
       "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Notch reads"
+          }
+        },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
@@ -8450,6 +10766,12 @@
     "Choose which limit appears in the main notch for Antigravity.": {
       "extractionState": "manual",
       "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Choose which limit appears in the main notch for Antigravity."
+          }
+        },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
@@ -8461,6 +10783,12 @@
     "Off": {
       "extractionState": "manual",
       "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Off"
+          }
+        },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
@@ -8472,6 +10800,12 @@
     "Inside": {
       "extractionState": "manual",
       "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Inside"
+          }
+        },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
@@ -8483,6 +10817,12 @@
     "Outside": {
       "extractionState": "manual",
       "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Outside"
+          }
+        },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
@@ -8494,6 +10834,12 @@
     "One ring per provider, showing the headline limit. The weekly allowance stays in the hover card.": {
       "extractionState": "manual",
       "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "One ring per provider, showing the headline limit. The weekly allowance stays in the hover card."
+          }
+        },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
@@ -8505,6 +10851,12 @@
     "A thinner ring for the weekly limit, drawn inside the main one. It shares the gap with the working indicator.": {
       "extractionState": "manual",
       "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "A thinner ring for the weekly limit, drawn inside the main one. It shares the gap with the working indicator."
+          }
+        },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
@@ -8516,6 +10868,12 @@
     "A thinner ring for the weekly limit, drawn around the main one, in the margin between the ring and the notch edge.": {
       "extractionState": "manual",
       "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "A thinner ring for the weekly limit, drawn around the main one, in the margin between the ring and the notch edge."
+          }
+        },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
@@ -8527,6 +10885,12 @@
     "Run %@ in Terminal to sign in to %@.": {
       "extractionState": "manual",
       "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Run %@ in Terminal to sign in to %@."
+          }
+        },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
@@ -8538,6 +10902,12 @@
     "Requests today · last used %@": {
       "extractionState": "manual",
       "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Requests today · last used %@"
+          }
+        },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
@@ -8549,6 +10919,12 @@
     "yesterday": {
       "extractionState": "manual",
       "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "yesterday"
+          }
+        },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
@@ -8560,6 +10936,12 @@
     "%lld days ago": {
       "extractionState": "manual",
       "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "%lld days ago"
+          }
+        },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
@@ -8571,6 +10953,12 @@
     "Personal": {
       "extractionState": "manual",
       "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Personal"
+          }
+        },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
@@ -8582,6 +10970,12 @@
     "Gemini Models": {
       "extractionState": "manual",
       "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Gemini Models"
+          }
+        },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
@@ -8593,6 +10987,12 @@
     "5-hour Limit": {
       "extractionState": "manual",
       "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "5-hour Limit"
+          }
+        },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
@@ -8604,6 +11004,12 @@
     "Claude and GPT models": {
       "extractionState": "manual",
       "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Claude and GPT models"
+          }
+        },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
@@ -8615,6 +11021,12 @@
     "Question": {
       "extractionState": "manual",
       "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Question"
+          }
+        },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
@@ -8626,6 +11038,12 @@
     "Approval": {
       "extractionState": "manual",
       "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Approval"
+          }
+        },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
@@ -8637,6 +11055,12 @@
     "Permission": {
       "extractionState": "manual",
       "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Permission"
+          }
+        },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
@@ -8648,6 +11072,12 @@
     "needs your input": {
       "extractionState": "manual",
       "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "needs your input"
+          }
+        },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
@@ -8659,6 +11089,12 @@
     "Working in %@": {
       "extractionState": "manual",
       "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Working in %@"
+          }
+        },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
@@ -8670,6 +11106,12 @@
     "Connection": {
       "extractionState": "manual",
       "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Connection"
+          }
+        },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
@@ -8681,6 +11123,12 @@
     "Preset": {
       "extractionState": "manual",
       "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Preset"
+          }
+        },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
@@ -8692,6 +11140,12 @@
     "Custom": {
       "extractionState": "manual",
       "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Custom"
+          }
+        },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
@@ -8703,6 +11157,12 @@
     "Preset size": {
       "extractionState": "manual",
       "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Preset size"
+          }
+        },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
@@ -8714,6 +11174,12 @@
     "Scales the whole surface — rings, text and tooltip together — so the proportions stay as drawn. 100% is the size the notch was designed at.": {
       "extractionState": "manual",
       "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Scales the whole surface — rings, text and tooltip together — so the proportions stay as drawn. 100% is the size the notch was designed at."
+          }
+        },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
@@ -8725,6 +11191,12 @@
     "Ollama API key": {
       "extractionState": "manual",
       "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Ollama API key"
+          }
+        },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
@@ -8736,6 +11208,12 @@
     "Paste your key": {
       "extractionState": "manual",
       "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Paste your key"
+          }
+        },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
@@ -8747,6 +11225,12 @@
     "Save": {
       "extractionState": "manual",
       "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Save"
+          }
+        },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
@@ -8758,6 +11242,12 @@
     "Saved": {
       "extractionState": "manual",
       "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Saved"
+          }
+        },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
@@ -8769,6 +11259,12 @@
     "%@ usage needs its sign-in renewed — run `claude` once in a terminal.": {
       "extractionState": "manual",
       "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "%@ usage needs its sign-in renewed — run `claude` once in a terminal."
+          }
+        },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
@@ -8780,6 +11276,12 @@
     "%@ %@ · via Ollama": {
       "extractionState": "manual",
       "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "%@ %@ · via Ollama"
+          }
+        },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
@@ -8791,6 +11293,12 @@
     "Hidden from the notch · Loaded in Ollama": {
       "extractionState": "manual",
       "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Hidden from the notch · Loaded in Ollama"
+          }
+        },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
@@ -8802,6 +11310,12 @@
     "Show or hide this model in the notch. It stays loaded in Ollama.": {
       "extractionState": "manual",
       "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Show or hide this model in the notch. It stays loaded in Ollama."
+          }
+        },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
@@ -8813,6 +11327,12 @@
     "Thinking": {
       "extractionState": "manual",
       "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Thinking"
+          }
+        },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
@@ -8824,6 +11344,12 @@
     "%@ · Local": {
       "extractionState": "manual",
       "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "%@ · Local"
+          }
+        },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
@@ -8835,6 +11361,12 @@
     "No Ollama usage recorded yet for this period.": {
       "extractionState": "manual",
       "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No Ollama usage recorded yet for this period."
+          }
+        },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
@@ -8846,6 +11378,12 @@
     "Unused resets": {
       "extractionState": "manual",
       "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Unused resets"
+          }
+        },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
@@ -8857,6 +11395,12 @@
     "No unused resets": {
       "extractionState": "manual",
       "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No unused resets"
+          }
+        },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
@@ -8868,6 +11412,12 @@
     "1 unused reset": {
       "extractionState": "manual",
       "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "1 unused reset"
+          }
+        },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
@@ -8879,6 +11429,12 @@
     "%lld unused resets": {
       "extractionState": "manual",
       "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "%lld unused resets"
+          }
+        },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
@@ -8890,6 +11446,12 @@
     "Expires %@": {
       "extractionState": "manual",
       "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Expires %@"
+          }
+        },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
@@ -8901,6 +11463,12 @@
     "Next expires %@": {
       "extractionState": "manual",
       "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Next expires %@"
+          }
+        },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",

--- a/Sources/Settings/AppLanguage.swift
+++ b/Sources/Settings/AppLanguage.swift
@@ -2,14 +2,14 @@ import Foundation
 
 /// Which language Codenotch's own copy uses.
 ///
-/// Follow System is the default. A forced English, French, Brazilian
-/// Portuguese or Simplified Chinese choice exists because the Mac's
+/// Follow System is the default. A forced choice exists because the Mac's
 /// language is not always the one the person wants this app in — bilingual
 /// machines, or a Mac in a language we do not ship.
 enum AppLanguage: String, CaseIterable, Identifiable {
     case system = "system"
     case english = "en"
     case french = "fr"
+    case japanese = "ja"
     case brazilianPortuguese = "pt-BR"
     case simplifiedChinese = "zh-Hans"
 
@@ -26,19 +26,21 @@ enum AppLanguage: String, CaseIterable, Identifiable {
         case .system:              return nil
         case .english:             return Locale(identifier: "en")
         case .french:              return Locale(identifier: "fr")
+        case .japanese:            return Locale(identifier: "ja")
         case .brazilianPortuguese: return Locale(identifier: "pt-BR")
         case .simplifiedChinese:   return Locale(identifier: "zh-Hans")
         }
     }
 
-    /// English, Français, Português (Brasil) and 简体中文 stay in their own
-    /// language so the row is recognizable when the rest of Settings is in
+    /// English, Français, 日本語, Português (Brasil) and 简体中文 stay in their
+    /// own language so the row is recognizable when the rest of Settings is in
     /// another one.
     var title: String {
         switch self {
         case .system:              return L10n.t("Follow System")
         case .english:             return "English"
         case .french:              return "Français"
+        case .japanese:            return "日本語"
         case .brazilianPortuguese: return "Português (Brasil)"
         case .simplifiedChinese:   return "简体中文"
         }
@@ -48,7 +50,7 @@ enum AppLanguage: String, CaseIterable, Identifiable {
         switch self {
         case .system:
             return L10n.t("Matches the Mac's preferred language.")
-        case .english, .french, .brazilianPortuguese, .simplifiedChinese:
+        case .english, .french, .japanese, .brazilianPortuguese, .simplifiedChinese:
             return L10n.t("Codenotch uses this language even if the Mac does not.")
         }
     }

--- a/Tests/AppLanguageTests.swift
+++ b/Tests/AppLanguageTests.swift
@@ -59,4 +59,22 @@ final class AppLanguageTests: XCTestCase {
         L10n.testLocale = nil
         XCTAssertEqual(L10n.t("Always show"), "始终显示")
     }
+
+    /// Japanese is offered in the picker under the identifier the catalog
+    /// files its translations under. Deliberately no assertion on the copy
+    /// `ja` serves: the catalog carries no Japanese yet, so today it falls
+    /// back to English, and pinning that would turn into a failing test the
+    /// moment a translation lands — which is the point of the branch.
+    func testJapaneseIsOfferedAndMapsToJa() {
+        XCTAssertTrue(AppLanguage.allCases.contains(.japanese))
+        XCTAssertEqual(AppLanguage.japanese.title, "日本語")
+    }
+
+    /// The override round-trips through the store like any other language,
+    /// even while the catalog has nothing to serve for it.
+    func testApplyJapaneseStoresTheOverride() {
+        L10n.apply(.japanese)
+        L10n.testLocale = nil
+        XCTAssertEqual(L10n.locale.identifier, "ja")
+    }
 }

--- a/Tests/LocalizationTests.swift
+++ b/Tests/LocalizationTests.swift
@@ -7,6 +7,7 @@ import XCTest
 final class LocalizationTests: XCTestCase {
     private let zhHans = Locale(identifier: "zh-Hans")
     private let french = Locale(identifier: "fr")
+    private let japanese = Locale(identifier: "ja")
     private let brazilianPortuguese = Locale(identifier: "pt-BR")
     private let english = Locale(identifier: "en")
     private let now = Date(timeIntervalSince1970: 1_787_900_000)
@@ -301,6 +302,85 @@ final class LocalizationTests: XCTestCase {
     func testPortugueseIsServedUnderTheRegionQualifiedIdentifier() {
         XCTAssertEqual(L10n.t("Usage", locale: brazilianPortuguese), "Uso")
         XCTAssertEqual(AppLanguage.brazilianPortuguese.locale?.identifier, "pt-BR")
+    }
+
+    // MARK: - Japanese
+
+    func testElapsedCopyInJapanese() {
+        XCTAssertEqual(
+            ElapsedCopy.text(since: now.addingTimeInterval(-5), now: now, locale: japanese),
+            "たった今"
+        )
+        XCTAssertEqual(
+            ElapsedCopy.text(since: now.addingTimeInterval(-6 * 60), now: now, locale: japanese),
+            "6 分"
+        )
+        XCTAssertEqual(
+            ElapsedCopy.text(since: now.addingTimeInterval(-60 * 60), now: now, locale: japanese),
+            "1 時間"
+        )
+        XCTAssertEqual(
+            ElapsedCopy.text(since: now.addingTimeInterval(-65 * 60), now: now, locale: japanese),
+            "1 時間 5 分"
+        )
+        XCTAssertEqual(
+            ElapsedCopy.ago(since: now.addingTimeInterval(-6 * 60), now: now, locale: japanese),
+            "6 分前"
+        )
+    }
+
+    func testResetCopyUnderAnHourInJapanese() {
+        XCTAssertEqual(
+            ResetCopy.text(for: resetNow.addingTimeInterval(51 * 60), now: resetNow, locale: japanese),
+            "51 分後にリセット"
+        )
+        XCTAssertEqual(
+            ResetCopy.text(for: resetNow.addingTimeInterval(-5), now: resetNow, locale: japanese),
+            "リセット中…"
+        )
+    }
+
+    func testWindowSummaryInJapanese() {
+        XCTAssertEqual(
+            percentWindow(0.12).summary(locale: japanese),
+            "12% 使用 · 残り 88%"
+        )
+        XCTAssertEqual(
+            LimitWindow(id: "w", label: "Requests", used: 8).summary(locale: japanese),
+            "8 使用"
+        )
+        XCTAssertEqual(
+            LimitWindow(id: "w", label: "Requests", remaining: 3).summary(locale: japanese),
+            "残り 3"
+        )
+        XCTAssertEqual(
+            LimitWindow(id: "w", label: "Requests").summary(locale: japanese),
+            "読み取りなし"
+        )
+    }
+
+    func testMenuCopyInJapanese() {
+        XCTAssertEqual(L10n.t("Always show", locale: japanese), "常に表示")
+        XCTAssertEqual(L10n.t("Settings…", locale: japanese), "設定…")
+    }
+
+    func testSignInCopyInJapanese() {
+        XCTAssertEqual(
+            L10n.t("Sign in to \("Perplexity")", locale: japanese),
+            "Perplexity にサインイン"
+        )
+    }
+
+    /// The Japanese keeps every format specifier in the order the English put
+    /// them, so an `Int` still lands on `%lld` and a `String` on `%@`. This is
+    /// the threshold alert, whose two arguments are of different types and
+    /// would be read through the wrong conversion if a translation swapped
+    /// them without positional specifiers.
+    func testThresholdAlertKeepsArgumentOrderInJapanese() {
+        XCTAssertEqual(
+            L10n.t("\(80)% of its \("weekly") limit used.", locale: japanese),
+            "80% を使用（weekly の上限）。"
+        )
     }
 
     /// Every language the picker offers must resolve to a locale the catalog

--- a/Tests/LocalizationTests.swift
+++ b/Tests/LocalizationTests.swift
@@ -309,7 +309,7 @@ final class LocalizationTests: XCTestCase {
     func testEveryOfferedLanguageResolves() {
         XCTAssertEqual(
             AppLanguage.allCases.map(\.rawValue),
-            ["system", "en", "fr", "pt-BR", "zh-Hans"]
+            ["system", "en", "fr", "ja", "pt-BR", "zh-Hans"]
         )
         XCTAssertNil(AppLanguage.system.locale)
         for language in AppLanguage.allCases where language != .system {

--- a/project.yml
+++ b/project.yml
@@ -74,6 +74,7 @@ targets:
         CFBundleLocalizations:
           - en
           - fr
+          - ja
           - pt-BR
           - zh-Hans
         LSMinimumSystemVersion: "15.0"


### PR DESCRIPTION
Adds Japanese as a fourth translation, alongside Français, Português (Brasil) and 简体中文.

All 428 keys in the catalog are translated, so no Japanese string falls back to English. `ja` joins `CFBundleLocalizations`, `knownRegions` and the Language picker, between Français and Português (Brasil).

Two commits: the first wires the language up with English placeholders, the second replaces them with the copy. They are separable if you would rather take only one.

### Translation notes

Terminology follows what macOS itself says in Japanese, so the copy does not read as translated software: 設定, 常に許可, メニューバー, サインイン, アクセントカラー. Labels and buttons are 体言止め rather than です・ます, which is what keeps a menu-bar app's rows from running long.

Every format specifier stays in the order the English put it, in every key. That is deliberate — see below.

### A crash in the Simplified Chinese, not fixed here

While checking specifier order I found an existing one that reorders without positional specifiers:

```
EN: %lld%% of its %@ limit used.
zh: 已用其 %@ 额度的 %lld%%。
```

`ThresholdNotifier.swift` builds that with an `Int` first and a `String` second, so in Chinese the integer reaches `%@` and is dereferenced as an object pointer. Evaluating it segfaults:

```
Exception Type:    EXC_BAD_ACCESS (SIGSEGV)
Exception Subtype: KERN_INVALID_ADDRESS at 0x0000000000000050

0  libobjc.A.dylib   objc_opt_respondsToSelector
1  Foundation        _NSDescriptionWithStringProxyFunc
2  CoreFoundation    __CFSTRING_IS_CALLING_OUT_TO_AN_OBJECT_FORMAT_ARGUMENT_WITH_CONTEXT__
3  CoreFoundation    __CFStringAppendFormatCore
```

`0x50` is 80 — the `usedPercent` value passed in. In practice that means a Chinese user crashes when a limit crosses 80% or 100%. The fix is `已用其 %2$@ 额度的 %1$lld%%。`, or restoring the English order.

I have left it alone so this PR stays a translation. I scanned the whole catalog: only two keys carry multiple arguments of differing types, and this is the only one whose order is broken — fr, pt-BR and ja are all consistent. Happy to send it as a separate PR if you want.

`testThresholdAlertKeepsArgumentOrderInJapanese` pins the Japanese against the same mistake.

### Tests

Six tests mirror the French and Brazilian Portuguese ones: elapsed copy, reset copy, window summary, menu copy, sign-in copy, and the threshold alert above. `testEveryOfferedLanguageResolves` grows by one entry.

`make test` on this branch fails 8 tests in `EdgeArrivalTests`, `EdgeCrossfadeTests` and `SessionChimeTests`. Those same 8 fail on a clean `main` on this machine, so they are not from this change — they look environment-sensitive (animation timing and audio device). Everything else passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0186RtTxiXLXiuZTxwZ3sDD9
