### PR TITLE
feat: add DeepSeek Platform usage card

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ A Windows port — Rust/Tauri 2, same design and providers — lives in [`window
 | **Claude Code** | official | Claude Desktop's own cached usage response, where Desktop is running and signed into the same account. Then Claude Code's own `/usage`, asked of the installed `claude`. Then the OAuth token in the login keychain, against the endpoint that command uses. |
 | **Cursor** | official | The editor's signed-in session in its local SQLite state, or the `cursor-agent` login in the keychain — no separate sign-in. |
 | **Codex** | official | ChatGPT's usage endpoint, using the local Codex sign-in. Shows the 5-hour and weekly limits when available. |
+| **DeepSeek Platform** | derived from official Platform responses | Explicit sign-in in Codenotch's own WKWebView, then the Platform account summary and API-key/model usage endpoints. Shows funded/spent balance, 30-day tokens/cost, requests and API-key count. |
 | **Antigravity** | official where licensed, otherwise a request count | Antigravity's local language server first, then Google's quota endpoint; a plain count when neither will answer for the account. |
 | **GLM** | official | Z.ai's Coding Plan monitor endpoint, with a key borrowed from whichever coding tool already holds one — Claude Code's `settings.json`, ZCode, or OpenCode. |
 | **Ollama (Local)** | local runtime | Automatically detected local models, RAM/VRAM, unload time and context. Optional response capture adds thinking and generation speed. |
@@ -67,6 +68,9 @@ A Windows port — Rust/Tauri 2, same design and providers — lives in [`window
 | **GitHub Copilot** | official | GitHub's Copilot quota endpoint, authenticated with the GitHub CLI session already on the Mac (`gh auth login`). |
 
 Most providers borrow a credential or session from a tool already on your Mac.
+DeepSeek is the explicit browser-login exception: it never reads a browser's
+cookies or credentials, and only makes requests after you choose **Sign in to
+DeepSeek** from Codenotch.
 Ollama Cloud accepts an API key in Settings. Switching a provider off stops its
 usage polling and forgets its readings; borrowed accounts stay signed in to
 the tools that own them.

--- a/Sources/App/AppDelegate.swift
+++ b/Sources/App/AppDelegate.swift
@@ -96,10 +96,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         if ProcessInfo.processInfo.environment["CODENOTCH_DEMO"] == "1" {
             fleet.setSnapshots(Fixtures.snapshots())
         } else {
-            // Nothing needs a browser session at the moment. `WebSessionProvider`
-            // and `Sites.perplexity` are kept: they are the working pattern for a
-            // site behind bot management, and re-registering is one line.
-            let webProviders: [WebSessionProvider] = []
+            // DeepSeek's Platform usage page is a browser-session provider:
+            // login is explicit, stays in Codenotch's own WKWebView store, and
+            // the page-local requests are refreshed only after that login.
+            let deepSeek = WebSessionProvider(site: Sites.deepSeek)
+            let webProviders: [WebSessionProvider] = [deepSeek]
             fleet.signInItems = webProviders.map { provider in
                 (title: L10n.t("Sign in to \(provider.displayName)…"),
                  action: { [weak provider] in provider?.presentSignIn() })
@@ -141,6 +142,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 // order for a frame and then visibly shuffles.
                 order: preferences.providerOrder
             )
+            deepSeek.onAuthenticated = { [weak store] in
+                store?.refresh(providerID: "deepseek")
+            }
 
             let updater = Updater()
             self.updater = updater

--- a/Sources/App/AppDelegate.swift
+++ b/Sources/App/AppDelegate.swift
@@ -228,7 +228,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 signOut: { [weak store] in store?.signOut(providerID: $0) },
                 signIn: { [weak store] in store?.signIn(providerID: $0) ?? false },
                 switchAccount: { [weak store] in
-                    store?.openAccountSource(providerID: $0) ?? false
+                    store?.openAccountSource(providerID: $0, switching: true) ?? false
                 },
                 retry: { [weak store] in store?.reauthorize(providerID: $0) },
                 // Both halves, because the stored nudge and the live one are

--- a/Sources/Features/DeepSeekUsageDetail.swift
+++ b/Sources/Features/DeepSeekUsageDetail.swift
@@ -1,0 +1,136 @@
+import SwiftUI
+
+/// The account-level section shown below DeepSeek's funded/spent bar.
+/// It mirrors the compact Codex activity section, but keeps DeepSeek's CNY
+/// cost and API-key/model aggregation explicit.
+struct DeepSeekUsageDetail: View {
+    let detail: ProviderUsageDetail
+
+    private var timeZoneText: String {
+        let absolute = abs(detail.timeZoneSeconds)
+        let sign = detail.timeZoneSeconds >= 0 ? "+" : "-"
+        let hours = absolute / 3_600
+        let minutes = (absolute % 3_600) / 60
+        return minutes == 0 ? "UTC\(sign)\(hours)" : "UTC\(sign)\(hours):\(String(format: "%02d", minutes))"
+    }
+
+    private var points: [Point] {
+        var values = [Int: Point]()
+        for group in detail.visibleGroups {
+            for day in group.days {
+                let timestamp = Int(day.date.timeIntervalSince1970)
+                var point = values[timestamp] ?? Point(timestamp: timestamp)
+                point.tokens += day.totalTokens
+                point.cost += day.cost
+                values[timestamp] = point
+            }
+        }
+        return values.values.sorted { $0.timestamp < $1.timestamp }
+    }
+
+    private var moneyText: String {
+        Self.money(detail.totalCost, currency: detail.currency)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Rectangle()
+                .fill(Palette.ringTrack)
+                .frame(height: NotchLayout.hairline)
+                .padding(.top, NotchLayout.blockSpacing)
+
+            SplitRow(leading: "Usage details", trailing: timeZoneText)
+                .padding(.top, NotchLayout.blockSpacing)
+
+            HStack(spacing: NotchLayout.blockSpacing) {
+                DeepSeekMetric(label: "Tokens", value: UsageFormat.tokens(detail.totalTokens))
+                DeepSeekMetric(label: "Cost", value: moneyText)
+                DeepSeekMetric(label: "Requests", value: "\(detail.totalRequests)")
+                DeepSeekMetric(label: "API keys", value: "\(detail.visibleAPIKeyCount)")
+            }
+            .frame(width: NotchLayout.cardTextWidth)
+            .padding(.top, NotchLayout.blockSpacing)
+
+            DeepSeekUsageChart(title: "Daily tokens", values: points.map { Double($0.tokens) }, formatter: {
+                UsageFormat.tokens(Int($0))
+            })
+                .padding(.top, NotchLayout.blockSpacing)
+            DeepSeekUsageChart(title: "Daily cost", values: points.map { $0.cost }, formatter: {
+                Self.money($0, currency: detail.currency)
+            })
+            .padding(.top, NotchLayout.usageDetailChartGap)
+        }
+    }
+
+    private struct Point {
+        let timestamp: Int
+        var tokens = 0
+        var cost = 0.0
+    }
+
+    private static func money(_ value: Double, currency: String) -> String {
+        let symbol: String
+        switch currency.uppercased() {
+        case "CNY", "RMB", "JPY": symbol = "¥"
+        case "USD": symbol = "$"
+        case "EUR": symbol = "€"
+        default: symbol = currency + " "
+        }
+        return "\(symbol)\(String(format: "%.2f", locale: Locale(identifier: "en_US_POSIX"), value))"
+    }
+}
+
+private struct DeepSeekMetric: View {
+    let label: String
+    let value: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: NotchLayout.moneyStatGap) {
+            Text(label).foregroundStyle(Palette.textSecondary).lineLimit(1)
+            Text(value).foregroundStyle(Palette.textPrimary).monospacedDigit().lineLimit(1)
+        }
+        .font(Typography.cardBody)
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+private struct DeepSeekUsageChart: View {
+    let title: String
+    let values: [Double]
+    let formatter: (Double) -> String
+
+    private var maximum: Double { max(values.max() ?? 0, 1) }
+    private var barWidth: CGFloat {
+        let count = CGFloat(max(values.count, 1))
+        return max(1, (NotchLayout.cardTextWidth - (count - 1) * NotchLayout.usageDetailBarGap) / count)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            HStack(alignment: .firstTextBaseline) {
+                Text(title).foregroundStyle(Palette.textPrimary)
+                Spacer(minLength: 0)
+                Text("peak \(formatter(values.max() ?? 0))")
+                    .foregroundStyle(Palette.textSecondary)
+                    .lineLimit(1)
+            }
+            .font(Typography.cardBody)
+
+            ZStack(alignment: .bottom) {
+                Rectangle().fill(Palette.ringTrack).frame(height: NotchLayout.hairline)
+                HStack(alignment: .bottom, spacing: NotchLayout.usageDetailBarGap) {
+                    ForEach(Array(values.enumerated()), id: \.offset) { index, value in
+                        RoundedRectangle(cornerRadius: Design.px(4), style: .continuous)
+                            .fill(index == values.count - 1 ? Palette.textPrimary : Palette.textSecondary)
+                            .frame(width: barWidth,
+                                   height: value > 0 ? max(Design.px(4), NotchLayout.usageDetailChartHeight * value / maximum) : 0)
+                    }
+                }
+            }
+            .frame(width: NotchLayout.cardTextWidth,
+                   height: NotchLayout.usageDetailChartHeight,
+                   alignment: .bottom)
+            .padding(.top, NotchLayout.usageDetailLabelToBar)
+        }
+    }
+}

--- a/Sources/Features/TooltipCard.swift
+++ b/Sources/Features/TooltipCard.swift
@@ -262,7 +262,7 @@ private struct TooltipHeader<Mark: View>: View {
 
 /// A label on the left and a quieter value on the right — the row shape the
 /// design frame uses throughout.
-private struct SplitRow<Accessory: View>: View {
+struct SplitRow<Accessory: View>: View {
     let leading: String
     let trailing: String
     var leadingColor: Color = Palette.textPrimary
@@ -391,12 +391,14 @@ private struct LimitWindowRow: View {
     /// A count-only row (no fraction, no reset) — like Ollama's per-model request
     /// counts — renders as a single table line: name left, count right.
     private var isCountRow: Bool {
-        window.usedFraction == nil && window.used != nil
+        window.usedFraction == nil && (window.used != nil || window.detail != nil)
     }
 
     var body: some View {
-        if isCountRow {
-            SplitRow(leading: window.label, trailing: window.usedText ?? "\(window.used ?? 0)",
+        if let money = window.money {
+            MoneyBreakdownView(title: window.label, money: money, fidelity: fidelity)
+        } else if isCountRow {
+            SplitRow(leading: window.label, trailing: window.detail ?? window.usedText ?? "\(window.used ?? 0)",
                      trailingColor: Palette.textSecondary)
         } else {
             VStack(alignment: .leading, spacing: 0) {
@@ -413,7 +415,7 @@ private struct LimitWindowRow: View {
                     .padding(.top, NotchLayout.labelToBar)
                 }
 
-                Text("\(window.usedFraction == nil ? "" : fidelity.qualifier)\(window.summary)\(paceText)")
+                Text("\(window.usedFraction == nil ? "" : fidelity.qualifier)\(window.detail ?? window.summary)\(paceText)")
                     .font(Typography.cardBody)
                     .foregroundStyle(Palette.textPrimary)
                     .lineLimit(1)
@@ -421,6 +423,67 @@ private struct LimitWindowRow: View {
                     .padding(.top, NotchLayout.barToUsed)
             }
         }
+    }
+}
+
+private struct MoneyBreakdownView: View {
+    let title: String
+    let money: UsageMoneyBreakdown
+    let fidelity: Fidelity
+    @Environment(\.codenotchAccentColor) private var accentColor
+
+    private var symbol: String {
+        switch money.currency.uppercased() {
+        case "CNY", "RMB", "JPY": return "¥"
+        case "USD": return "$"
+        case "EUR": return "€"
+        default: return "\(money.currency) "
+        }
+    }
+
+    private func amount(_ value: Double) -> String {
+        "\(symbol)\(String(format: "%.2f", locale: Locale(identifier: "en_US_POSIX"), value))"
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            SplitRow(leading: title,
+                     trailing: "\(fidelity.qualifier)\(Percent.text(for: money.spentFraction))% used")
+            GeometryReader { proxy in
+                HStack(spacing: 0) {
+                    Rectangle()
+                        .fill(UsageBand.band(for: money.spentFraction).color(accent: accentColor))
+                        .frame(width: proxy.size.width * CGFloat(money.spentFraction))
+                    Rectangle().fill(Palette.barTrack)
+                }
+            }
+            .frame(width: NotchLayout.cardTextWidth, height: NotchLayout.moneyBarHeight)
+            .clipShape(Capsule())
+            .padding(.top, NotchLayout.labelToBar)
+
+            HStack(spacing: NotchLayout.blockSpacing) {
+                MoneyStat(label: "Spent", value: amount(money.spent), color: accentColor)
+                MoneyStat(label: "Remaining", value: amount(money.remaining), color: Palette.textSecondary)
+                MoneyStat(label: "Funded", value: amount(money.funded), color: Palette.textPrimary)
+            }
+            .frame(width: NotchLayout.cardTextWidth)
+            .padding(.top, NotchLayout.moneyBarToStats)
+        }
+    }
+}
+
+private struct MoneyStat: View {
+    let label: String
+    let value: String
+    let color: Color
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: NotchLayout.moneyStatGap) {
+            Text(label).foregroundStyle(Palette.textSecondary).lineLimit(1)
+            Text(value).foregroundStyle(color).monospacedDigit().lineLimit(1)
+        }
+        .font(Typography.cardBody)
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 }
 
@@ -569,7 +632,7 @@ private struct RuntimeModelDetails: View {
     }
 }
 
-private enum UsageFormat {
+enum UsageFormat {
     static func tokens(_ value: Int?) -> String {
         guard let value else { return "—" }
         switch value {
@@ -938,6 +1001,8 @@ struct TooltipCard: View {
         NotchLayout.cardHeight(
             windowCount: snapshot.windows.count,
             groupCount: snapshot.windowGroupCount,
+            moneyWindowCount: snapshot.windows.filter { $0.money != nil }.count,
+            usageDetailGroupCount: snapshot.usageDetail?.visibleGroups.count ?? 0,
             sessionCount: snapshot.localModel == nil ? (activity?.sessions.count ?? 0) : 0,
             sessionCap: sessionCap,
             statusMessage: snapshot.statusMessage,
@@ -967,6 +1032,9 @@ struct TooltipCard: View {
                     }
                     if let tokenUsage = snapshot.tokenUsage {
                         CodexUsageSection(usage: tokenUsage, now: now)
+                    }
+                    if let usageDetail = snapshot.usageDetail, usageDetail.hasUsage {
+                        DeepSeekUsageDetail(detail: usageDetail)
                     }
                     if let activity, snapshot.localModel == nil {
                         SessionList(summary: activity, now: now, cap: sessionCap)

--- a/Sources/Model/UsageArchive.swift
+++ b/Sources/Model/UsageArchive.swift
@@ -22,6 +22,7 @@ struct UsageArchive {
         /// Optional so archives written before Codex token activity existed
         /// continue to open and show their last quota reading.
         let tokenUsage: CodexTokenUsage?
+        let usageDetail: ProviderUsageDetail?
     }
 
     private let defaults: UserDefaults
@@ -88,7 +89,8 @@ struct UsageArchive {
                 windows: entry.windows,
                 headlineID: entry.headlineID,
                 weeklyID: entry.weeklyID,
-                tokenUsage: entry.tokenUsage
+                tokenUsage: entry.tokenUsage,
+                usageDetail: entry.usageDetail
             )
             result[entry.id] = (snapshot, entry.fetchedAt)
         }
@@ -106,7 +108,8 @@ struct UsageArchive {
                 fetchedAt: $0.fetchedAt,
                 headlineID: $0.snapshot.headlineID,
                 weeklyID: $0.snapshot.weeklyID,
-                tokenUsage: $0.snapshot.tokenUsage
+                tokenUsage: $0.snapshot.tokenUsage,
+                usageDetail: $0.snapshot.usageDetail
             )
         }
         guard let data = try? JSONEncoder().encode(entries) else { return }

--- a/Sources/Model/UsageDetail.swift
+++ b/Sources/Model/UsageDetail.swift
@@ -1,0 +1,62 @@
+import Foundation
+
+/// Provider-owned usage detail for one explicit time range.
+///
+/// This is separate from the generic limit windows: a window answers what is
+/// left, while this structure answers what has been consumed by API key/model.
+struct ProviderUsageDetail: Codable, Equatable, Sendable {
+    let start: Date
+    let end: Date
+    let timeZoneSeconds: Int
+    let currency: String
+    let groups: [UsageDetailGroup]
+
+    var hasUsage: Bool {
+        groups.contains { $0.totalTokens > 0 || $0.totalCost > 0 || $0.requests > 0 }
+    }
+
+    var visibleGroups: [UsageDetailGroup] { groups.filter(\.hasUsage) }
+
+    var visibleAPIKeyCount: Int {
+        Set(visibleGroups.map(\.apiKeyID)).count
+    }
+
+    var totalTokens: Int { groups.reduce(0) { $0 + $1.totalTokens } }
+    var totalCost: Double { groups.reduce(0) { $0 + $1.totalCost } }
+    var totalRequests: Int { groups.reduce(0) { $0 + $1.requests } }
+}
+
+/// One API key × model series. The tracking ID is an internal join key and is
+/// never displayed in the card.
+struct UsageDetailGroup: Codable, Equatable, Sendable, Identifiable {
+    let apiKeyID: String
+    let apiKeyLabel: String
+    let model: String
+    let days: [UsageDetailDay]
+
+    var id: String { "\(apiKeyID)|\(model)" }
+    var cacheHitTokens: Int { days.reduce(0) { $0 + $1.cacheHitTokens } }
+    var cacheMissTokens: Int { days.reduce(0) { $0 + $1.cacheMissTokens } }
+    var outputTokens: Int { days.reduce(0) { $0 + $1.outputTokens } }
+    var totalTokens: Int { cacheHitTokens + cacheMissTokens + outputTokens }
+    var requests: Int { days.reduce(0) { $0 + $1.requests } }
+    var totalCost: Double { days.reduce(0) { $0 + $1.cost } }
+    var hasUsage: Bool { totalTokens > 0 || totalCost > 0 || requests > 0 }
+
+    var cacheHitRate: Double? {
+        let input = cacheHitTokens + cacheMissTokens
+        guard input > 0 else { return nil }
+        return Double(cacheHitTokens) / Double(input)
+    }
+}
+
+struct UsageDetailDay: Codable, Equatable, Sendable {
+    let date: Date
+    let cacheHitTokens: Int
+    let cacheMissTokens: Int
+    let outputTokens: Int
+    let requests: Int
+    let cost: Double
+
+    var totalTokens: Int { cacheHitTokens + cacheMissTokens + outputTokens }
+}

--- a/Sources/Model/UsageModel.swift
+++ b/Sources/Model/UsageModel.swift
@@ -19,6 +19,21 @@ enum Fidelity: String, Codable, Equatable {
     var qualifier: String { self == .official ? "" : "~" }
 }
 
+/// A provider-reported money balance. The percentage is derived from these
+/// exact account amounts; the amounts themselves come from the provider.
+struct UsageMoneyBreakdown: Codable, Equatable, Sendable {
+    let currency: String
+    let spent: Double
+    let remaining: Double
+
+    var funded: Double { spent + remaining }
+
+    var spentFraction: Double {
+        guard funded > 0 else { return 0 }
+        return min(max(spent / funded, 0), 1)
+    }
+}
+
 enum ProviderStatus: Equatable {
     case ok
     case stale(since: Date)
@@ -95,6 +110,10 @@ struct LimitWindow: Identifiable, Codable, Equatable {
     /// How many have been spent, when the provider counts up rather than down
     /// and never states the ceiling. Cursor does this.
     let used: Int?
+    /// Optional provider-specific value for count-only rows.
+    let detail: String?
+    /// Structured money data for providers whose account is metered in money.
+    let money: UsageMoneyBreakdown?
     /// Optional display override for `used` — used when the raw count would
     /// be the wrong unit (e.g. a dollar balance formatted as "$14.28").
     let usedText: String?
@@ -105,7 +124,8 @@ struct LimitWindow: Identifiable, Codable, Equatable {
     let duration: TimeInterval?
 
     init(id: String, group: String? = nil, label: String, usedFraction: Double? = nil,
-         remaining: Int? = nil, used: Int? = nil, usedText: String? = nil, resetsAt: Date? = nil,
+         remaining: Int? = nil, used: Int? = nil, usedText: String? = nil, detail: String? = nil,
+         money: UsageMoneyBreakdown? = nil, resetsAt: Date? = nil,
          duration: TimeInterval? = nil) {
         self.id = id
         self.group = group
@@ -114,6 +134,8 @@ struct LimitWindow: Identifiable, Codable, Equatable {
         self.remaining = remaining
         self.used = used
         self.usedText = usedText
+        self.detail = detail
+        self.money = money
         self.resetsAt = resetsAt
         self.duration = duration
     }
@@ -251,6 +273,9 @@ struct ProviderSnapshot: Identifiable, Equatable {
     /// Unused rate-limit resets on this Codex account, listed by the same
     /// backend as usage.
     var resetCredits: CodexResetCredits? = nil
+    /// Provider-owned online usage detail, such as DeepSeek's API key/model
+    /// breakdown and daily token/cost series.
+    var usageDetail: ProviderUsageDetail? = nil
 
     /// The number on the cell: the provider's declared primary window — for
     /// Claude, the current session.
@@ -318,7 +343,7 @@ struct ProviderSnapshot: Identifiable, Equatable {
     /// How many windows are count-only (no fraction, no bar) — they render as
     /// single-line rows and take less vertical space than full bar rows.
     var compactRowCount: Int {
-        windows.filter { $0.usedFraction == nil && $0.used != nil }.count
+        windows.filter { $0.usedFraction == nil && ($0.used != nil || $0.detail != nil) }.count
     }
 
     /// A ring can only be drawn when the provider said what the limit was. A
@@ -343,6 +368,7 @@ struct ProviderSnapshot: Identifiable, Equatable {
             return L10n.t("Sign in to Claude Code in ~/.claude-\(slug) to read your usage", locale: locale)
         case "cursor":     return L10n.t("Sign in to Cursor in the editor", locale: locale)
         case "codex":      return L10n.t("Sign in to Codex to read your usage", locale: locale)
+        case "deepseek":   return L10n.t("Sign in to DeepSeek Platform to read your usage", locale: locale)
         case _ where CodexProfile.slug(fromProviderID: id) != nil:
             let slug = CodexProfile.slug(fromProviderID: id)!
             return L10n.t("Sign in to Codex in ~/.codex-\(slug) to read your usage", locale: locale)

--- a/Sources/Model/UsageStore.swift
+++ b/Sources/Model/UsageStore.swift
@@ -540,12 +540,16 @@ final class UsageStore: ObservableObject {
     /// Claude Code, Cursor or Codex, and the most this can honestly do is open
     /// the thing that owns it.
     @discardableResult
-    func openAccountSource(providerID: String) -> Bool {
+    func openAccountSource(providerID: String, switching: Bool = false) -> Bool {
         guard let provider = providers.first(where: { $0.id == providerID }) else { return false }
 
         switch provider.signInRoute {
         case .modal:
-            provider.presentSignIn()
+            if switching {
+                provider.presentAccountSwitch()
+            } else {
+                provider.presentSignIn()
+            }
             return true
         case .openApp(let bundleID, _):
             guard let url = NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleID)

--- a/Sources/Notch/NotchLayout.swift
+++ b/Sources/Notch/NotchLayout.swift
@@ -146,6 +146,16 @@ enum NotchLayout {
     static let labelToBar    = Design.px(16.8)
     static let barToUsed     = Design.px(17.8)
     static let blockSpacing  = Design.px(20)
+    static let moneyBarHeight = Design.px(12)
+    static let moneyBarToStats = Design.px(14)
+    static let moneyStatGap = Design.px(4)
+    static let usageDetailIdentityGap = Design.px(4)
+    static let usageDetailBarHeight = Design.px(10.5)
+    static let usageDetailLabelToBar = Design.px(12)
+    static let usageDetailBarToStats = Design.px(10)
+    static let usageDetailChartHeight = Design.px(96)
+    static let usageDetailChartGap = Design.px(18)
+    static let usageDetailBarGap = Design.px(5)
     static let sessionRowGap = Design.px(10)   // the two lines of one session
     /// The spinner beside a session's status. Sized against the body text's cap
     /// (18px) rather than picked by eye, so it reads as part of the word rather
@@ -307,7 +317,17 @@ enum NotchLayout {
     /// The tooltip's height for a given number of limit windows and live
     /// sessions. Worked out here rather than left to SwiftUI so the hover region
     /// can be computed before the card is ever laid out.
-    static func cardHeight(windowCount: Int, groupCount: Int = 0, sessionCount: Int = 0,
+    static func usageDetailHeight(_ groupCount: Int) -> CGFloat {
+        guard groupCount > 0 else { return 0 }
+        let summary = hairline + blockSpacing + cardBodyLineHeight
+            + blockSpacing + 2 * cardBodyLineHeight + moneyStatGap
+        let chart = cardBodyLineHeight + usageDetailLabelToBar + usageDetailChartHeight
+        return blockSpacing + summary + blockSpacing + 2 * chart + usageDetailChartGap
+    }
+
+    static func cardHeight(windowCount: Int, groupCount: Int = 0,
+                           moneyWindowCount: Int = 0, usageDetailGroupCount: Int = 0,
+                           sessionCount: Int = 0,
                            sessionCap: Int = defaultSessionCap,
                            statusMessage: String? = nil,
                            blockMessage: String? = nil,
@@ -335,13 +355,17 @@ enum NotchLayout {
             height += headerToBlock + modelNameHeight(localModelName)
                 + blockSpacing + rows * cardBodyLineHeight + (rows - 1) * sessionRowGap
         } else if windowCount > 0 {
-            let fullCount = windowCount - compactRowCount
+            let moneyCount = min(max(0, moneyWindowCount), windowCount)
+            let fullCount = windowCount - compactRowCount - moneyCount
             // A full window row: label + bar + summary.
             let fullBlock = 2 * cardBodyLineHeight + labelToBar + barHeight + barToUsed
+            let moneyBlock = cardBodyLineHeight + labelToBar + moneyBarHeight
+                + moneyBarToStats + 2 * cardBodyLineHeight + moneyStatGap
             // A compact (count-only) row: a single SplitRow line.
             let compactBlock = cardBodyLineHeight
             height += headerToBlock
                 + CGFloat(fullCount) * fullBlock
+                + CGFloat(moneyCount) * moneyBlock
                 + CGFloat(compactRowCount) * compactBlock
                 + CGFloat(windowCount - 1) * blockSpacing
             if groupCount > 0 {
@@ -365,6 +389,8 @@ enum NotchLayout {
         if hasResetCredits {
             height += codexUsageTop + hairline + codexResetCreditsHeight
         }
+
+        height += usageDetailHeight(usageDetailGroupCount)
 
         if hasTokenUsage {
             height += codexUsageTop + hairline + blockSpacing

--- a/Sources/Notch/NotchRootView.swift
+++ b/Sources/Notch/NotchRootView.swift
@@ -349,6 +349,8 @@ struct NotchRootView: View {
             ? NotchLayout.cardHeight(
                 windowCount: snapshot.windows.count,
                 groupCount: snapshot.windowGroupCount,
+                moneyWindowCount: snapshot.windows.filter { $0.money != nil }.count,
+                usageDetailGroupCount: snapshot.usageDetail?.visibleGroups.count ?? 0,
                 sessionCount: snapshot.localModel == nil ? (model.activity(for: snapshot.id)?.sessions.count ?? 0) : 0,
                 sessionCap: model.sessionCap,
                 statusMessage: snapshot.statusMessage,
@@ -379,6 +381,8 @@ struct NotchRootView: View {
             : NotchLayout.cardHeight(
                 windowCount: snapshot.windows.count,
                 groupCount: snapshot.windowGroupCount,
+                moneyWindowCount: snapshot.windows.filter { $0.money != nil }.count,
+                usageDetailGroupCount: snapshot.usageDetail?.visibleGroups.count ?? 0,
                 sessionCount: snapshot.localModel == nil ? (model.activity(for: snapshot.id)?.sessions.count ?? 0) : 0,
                 sessionCap: model.sessionCap,
                 statusMessage: snapshot.statusMessage,

--- a/Sources/Notch/NotchViewModel.swift
+++ b/Sources/Notch/NotchViewModel.swift
@@ -556,6 +556,8 @@ final class NotchViewModel: ObservableObject {
         snapshots.map { snapshot in
             NotchLayout.cardHeight(windowCount: snapshot.windows.count,
                 groupCount: Set(snapshot.windows.compactMap(\.group)).count,
+                moneyWindowCount: snapshot.windows.filter { $0.money != nil }.count,
+                usageDetailGroupCount: snapshot.usageDetail?.visibleGroups.count ?? 0,
                 sessionCount: snapshot.localModel == nil ? sessionCap + 1 : 0,
                 sessionCap: sessionCap,
                 statusMessage: snapshot.statusMessage,

--- a/Sources/Notch/NotchWindowController.swift
+++ b/Sources/Notch/NotchWindowController.swift
@@ -395,6 +395,8 @@ final class NotchWindowController {
         let cardHeight = NotchLayout.cardHeight(
             windowCount: snapshot.windows.count,
             groupCount: snapshot.windowGroupCount,
+            moneyWindowCount: snapshot.windows.filter { $0.money != nil }.count,
+            usageDetailGroupCount: snapshot.usageDetail?.visibleGroups.count ?? 0,
             sessionCount: snapshot.localModel == nil ? (model.activity(for: snapshot.id)?.sessions.count ?? 0) : 0,
             sessionCap: model.sessionCap,
             statusMessage: snapshot.statusMessage,

--- a/Sources/Providers/DeepSeekUsage.swift
+++ b/Sources/Providers/DeepSeekUsage.swift
@@ -1,0 +1,213 @@
+import Foundation
+
+/// Decodes the signed-in DeepSeek Platform responses used by the usage card.
+enum DeepSeekUsage {
+    struct FetchPayload: Decodable {
+        let summary: String
+        let amount: String
+        let cost: String
+        let start: Int
+        let end: Int
+        let timeZoneSeconds: Int
+
+        enum CodingKeys: String, CodingKey {
+            case summary, amount, cost, start, end
+            case timeZoneSeconds = "time_zone_seconds"
+        }
+    }
+
+    struct Reading: Equatable {
+        let currency: String
+        let spent: Double
+        let balance: Double
+        let availableTokens: Int?
+
+        var usedFraction: Double {
+            let funded = spent + balance
+            guard funded > 0 else { return 0 }
+            return min(max(spent / funded, 0), 1)
+        }
+    }
+
+    enum ParseError: Error { case malformed, noWallet }
+
+    static func payload(fromJSON json: String) throws -> FetchPayload {
+        guard let data = json.data(using: .utf8) else { throw ParseError.malformed }
+        return try JSONDecoder().decode(FetchPayload.self, from: data)
+    }
+
+    static func reading(fromJSON json: String) throws -> Reading {
+        guard let data = json.data(using: .utf8) else { throw ParseError.malformed }
+        let envelope = try JSONDecoder().decode(Envelope.self, from: data)
+        guard let summary = envelope.data?.bizData,
+              let wallet = summary.normalWallets.first else { throw ParseError.noWallet }
+        let spent = summary.totalCosts.first(where: { $0.currency == wallet.currency })
+            .flatMap { Double($0.amount) } ?? 0
+        guard let balance = Double(wallet.balance), spent >= 0, balance >= 0 else {
+            throw ParseError.malformed
+        }
+        return Reading(currency: wallet.currency, spent: spent, balance: balance,
+                       availableTokens: summary.totalAvailableTokenEstimation.flatMap(Int.init))
+    }
+
+    static func detail(fromJSON json: String) throws -> ProviderUsageDetail? {
+        let payload = try payload(fromJSON: json)
+        guard let amountData = try? JSONDecoder().decode(AmountEnvelope.self, from: Data(payload.amount.utf8)),
+              let costData = try? JSONDecoder().decode(CostEnvelope.self, from: Data(payload.cost.utf8)) else {
+            throw ParseError.malformed
+        }
+        guard amountData.data?.bizData != nil || costData.data?.bizData != nil else { return nil }
+
+        var groups = [String: GroupAccumulator]()
+        for series in amountData.data?.bizData?.series ?? [] {
+            let key = apiKey(for: series.apiKey)
+            var group = groups[key.id + "|" + series.model]
+                ?? GroupAccumulator(apiKeyID: key.id, apiKeyLabel: key.label, model: series.model)
+            for bucket in series.buckets where bucket.time >= payload.start && bucket.time < payload.end {
+                var day = group.days[bucket.time] ?? DayAccumulator()
+                day.cacheHitTokens += integer(bucket.usage["PROMPT_CACHE_HIT_TOKEN"])
+                day.cacheMissTokens += integer(bucket.usage["PROMPT_CACHE_MISS_TOKEN"])
+                day.outputTokens += integer(bucket.usage["RESPONSE_TOKEN"])
+                day.requests += integer(bucket.usage["REQUEST"])
+                group.days[bucket.time] = day
+            }
+            groups[group.id] = group
+        }
+        let currencyData = costData.data?.bizData?.data.first
+        for series in currencyData?.series ?? [] {
+            let key = apiKey(for: series.apiKey)
+            var group = groups[key.id + "|" + series.model]
+                ?? GroupAccumulator(apiKeyID: key.id, apiKeyLabel: key.label, model: series.model)
+            for bucket in series.buckets where bucket.time >= payload.start && bucket.time < payload.end {
+                var day = group.days[bucket.time] ?? DayAccumulator()
+                day.cost += Double(bucket.cost.value) ?? 0
+                group.days[bucket.time] = day
+            }
+            groups[group.id] = group
+        }
+
+        var detailGroups = [UsageDetailGroup]()
+        for group in groups.values {
+            var days = [UsageDetailDay]()
+            for timestamp in group.days.keys.sorted() {
+                guard let day = group.days[timestamp] else { continue }
+                let date = Date(timeIntervalSince1970: TimeInterval(timestamp))
+                let cacheHit = day.cacheHitTokens
+                let cacheMiss = day.cacheMissTokens
+                let output = day.outputTokens
+                let requests = day.requests
+                let cost = day.cost
+                days.append(UsageDetailDay(date: date, cacheHitTokens: cacheHit,
+                                           cacheMissTokens: cacheMiss, outputTokens: output,
+                                           requests: requests, cost: cost))
+            }
+            detailGroups.append(UsageDetailGroup(apiKeyID: group.apiKeyID,
+                                                 apiKeyLabel: group.apiKeyLabel,
+                                                 model: group.model,
+                                                 days: days))
+        }
+        detailGroups.sort {
+            $0.apiKeyLabel == $1.apiKeyLabel ? $0.model < $1.model : $0.apiKeyLabel < $1.apiKeyLabel
+        }
+        return ProviderUsageDetail(start: Date(timeIntervalSince1970: TimeInterval(payload.start)),
+                                   end: Date(timeIntervalSince1970: TimeInterval(payload.end)),
+                                   timeZoneSeconds: payload.timeZoneSeconds,
+                                   currency: currencyData?.currency ?? "CNY",
+                                   groups: detailGroups)
+    }
+
+    private struct Envelope: Decodable { let data: DataContainer? }
+    private struct DataContainer: Decodable {
+        let bizData: Summary
+        enum CodingKeys: String, CodingKey { case bizData = "biz_data" }
+    }
+    private struct Summary: Decodable {
+        let normalWallets: [Wallet]
+        let totalCosts: [Cost]
+        let totalAvailableTokenEstimation: String?
+        enum CodingKeys: String, CodingKey {
+            case normalWallets = "normal_wallets"
+            case totalCosts = "total_costs"
+            case totalAvailableTokenEstimation = "total_available_token_estimation"
+        }
+    }
+    private struct Wallet: Decodable { let currency: String; let balance: String }
+    private struct Cost: Decodable { let currency: String; let amount: String }
+    private struct AmountEnvelope: Decodable { let data: AmountData? }
+    private struct AmountData: Decodable {
+        let bizData: AmountSummary?
+        enum CodingKeys: String, CodingKey { case bizData = "biz_data" }
+    }
+    private struct AmountSummary: Decodable { let series: [AmountSeries] }
+    private struct AmountSeries: Decodable {
+        let apiKey: APIKey?
+        let model: String
+        let buckets: [AmountBucket]
+        enum CodingKeys: String, CodingKey { case apiKey = "api_key"; case model, buckets }
+    }
+    private struct AmountBucket: Decodable {
+        let time: Int
+        let usage: [String: ScalarString]
+    }
+    private struct CostEnvelope: Decodable { let data: CostData? }
+    private struct CostData: Decodable {
+        let bizData: CostSummary?
+        enum CodingKeys: String, CodingKey { case bizData = "biz_data" }
+    }
+    private struct CostSummary: Decodable { let data: [CostCurrency] }
+    private struct CostCurrency: Decodable {
+        let currency: String
+        let series: [CostSeries]
+    }
+    private struct CostSeries: Decodable {
+        let apiKey: APIKey?
+        let model: String
+        let buckets: [CostBucket]
+        enum CodingKeys: String, CodingKey { case apiKey = "api_key"; case model, buckets }
+    }
+    private struct CostBucket: Decodable { let time: Int; let cost: ScalarString }
+    private struct ScalarString: Decodable {
+        let value: String
+        init(from decoder: Decoder) throws {
+            let container = try decoder.singleValueContainer()
+            if container.decodeNil() { value = "0" }
+            else if let string = try? container.decode(String.self) { value = string }
+            else if let int = try? container.decode(Int.self) { value = String(int) }
+            else if let double = try? container.decode(Double.self) { value = String(double) }
+            else { throw DecodingError.typeMismatch(String.self, .init(codingPath: decoder.codingPath, debugDescription: "Expected scalar")) }
+        }
+    }
+    private struct APIKey: Decodable {
+        let name: String?
+        let trackingID: String?
+        enum CodingKeys: String, CodingKey { case name; case trackingID = "tracking_id" }
+    }
+    private struct DayAccumulator {
+        var cacheHitTokens = 0
+        var cacheMissTokens = 0
+        var outputTokens = 0
+        var requests = 0
+        var cost = 0.0
+    }
+    private struct GroupAccumulator {
+        let apiKeyID: String
+        let apiKeyLabel: String
+        let model: String
+        var days = [Int: DayAccumulator]()
+        var id: String { apiKeyID + "|" + model }
+    }
+    private static func apiKey(for key: APIKey?) -> (id: String, label: String) {
+        if let name = key?.name?.trimmingCharacters(in: .whitespacesAndNewlines), !name.isEmpty {
+            let id = key?.trackingID?.trimmingCharacters(in: .whitespacesAndNewlines)
+            return (id?.isEmpty == false ? id! : name, name)
+        }
+        if let id = key?.trackingID?.trimmingCharacters(in: .whitespacesAndNewlines), !id.isEmpty {
+            return (id, "Unnamed API key")
+        }
+        return ("unknown", "Unnamed API key")
+    }
+    private static func integer(_ value: ScalarString?) -> Int {
+        guard let value else { return 0 }
+        return Int(value.value) ?? Int(Double(value.value) ?? 0)
+    }
+}

--- a/Sources/Providers/Sites.swift
+++ b/Sources/Providers/Sites.swift
@@ -95,8 +95,15 @@ enum Sites {
             const response = await fetch('/api/v0/users/get_user_summary', {
                 credentials: 'include', headers: { 'Accept': 'application/json', 'Authorization': token.startsWith('Bearer ') ? token : 'Bearer ' + token }
             });
-            return response.status >= 200 && response.status < 300;
-        } catch (_) { return false; }
+            if (response.status < 200 || response.status >= 300) {
+                return JSON.stringify({ authenticated: false });
+            }
+            const bytes = new TextEncoder().encode(token);
+            const digest = await crypto.subtle.digest('SHA-256', bytes);
+            const fingerprint = Array.from(new Uint8Array(digest))
+                .map(byte => byte.toString(16).padStart(2, '0')).join('');
+            return JSON.stringify({ authenticated: true, fingerprint });
+        } catch (_) { return JSON.stringify({ authenticated: false }); }
         """#,
         detailParse: DeepSeekUsage.detail(fromJSON:),
         parse: { json in

--- a/Sources/Providers/Sites.swift
+++ b/Sources/Providers/Sites.swift
@@ -22,4 +22,101 @@ enum Sites {
         parse: PerplexityUsage.windows(fromJSON:)
     )
 
+    static let deepSeek = WebSessionProvider.Site(
+        id: "deepseek",
+        displayName: "DeepSeek",
+        glyph: .deepseek,
+        origin: URL(string: "https://platform.deepseek.com/")!,
+        script: #"""
+        const readToken = () => {
+            const extract = (value) => {
+                if (typeof value === 'string' && value.trim()) return value.trim();
+                if (!value || typeof value !== 'object') return null;
+                for (const key of ['value', 'token', 'access_token', 'accessToken']) {
+                    const candidate = extract(value[key]);
+                    if (candidate) return candidate;
+                }
+                return null;
+            };
+            try {
+                const raw = localStorage.getItem('userToken');
+                if (!raw) return null;
+                return extract(JSON.parse(raw)) || raw.trim() || null;
+            } catch (_) {
+                const raw = localStorage.getItem('userToken');
+                return raw && raw.trim() ? raw.trim() : null;
+            }
+        };
+        const token = readToken();
+        const headers = { 'Accept': 'application/json', 'x-client-platform': 'web' };
+        if (token) headers.Authorization = token.startsWith('Bearer ') ? token : 'Bearer ' + token;
+        const now = new Date();
+        const today = new Date(now); today.setHours(0, 0, 0, 0);
+        const start = new Date(today); start.setDate(start.getDate() - 29);
+        const end = new Date(today); end.setDate(end.getDate() + 1);
+        const startSeconds = Math.floor(start.getTime() / 1000);
+        const endSeconds = Math.floor(end.getTime() / 1000);
+        const timeZoneSeconds = -now.getTimezoneOffset() * 60;
+        const query = 'start=' + startSeconds + '&end=' + endSeconds + '&tz=' + timeZoneSeconds;
+        const get = async (path) => {
+            const response = await fetch(path, { credentials: 'include', headers });
+            return { status: response.status, body: await response.text() };
+        };
+        const [summary, amount, cost] = await Promise.all([
+            get('/api/v0/users/get_user_summary'),
+            get('/api/v0/usage/by_api_key/amount?' + query),
+            get('/api/v0/usage/by_api_key/cost?' + query)
+        ]);
+        const failed = [summary, amount, cost].find(item => item.status < 200 || item.status >= 300);
+        return JSON.stringify({
+            status: failed ? failed.status : 200,
+            body: JSON.stringify({
+                summary: summary.body, amount: amount.body, cost: cost.body,
+                start: startSeconds, end: endSeconds, time_zone_seconds: timeZoneSeconds
+            })
+        });
+        """#,
+        fidelity: .derived,
+        authProbeScript: #"""
+        const extract = (value) => {
+            if (typeof value === 'string' && value.trim()) return value.trim();
+            if (!value || typeof value !== 'object') return null;
+            for (const key of ['value', 'token', 'access_token', 'accessToken']) {
+                const candidate = extract(value[key]);
+                if (candidate) return candidate;
+            }
+            return null;
+        };
+        try {
+            const raw = localStorage.getItem('userToken');
+            if (!raw) return false;
+            const token = extract(JSON.parse(raw)) || raw.trim();
+            if (!token) return false;
+            const response = await fetch('/api/v0/users/get_user_summary', {
+                credentials: 'include', headers: { 'Accept': 'application/json', 'Authorization': token.startsWith('Bearer ') ? token : 'Bearer ' + token }
+            });
+            return response.status >= 200 && response.status < 300;
+        } catch (_) { return false; }
+        """#,
+        detailParse: DeepSeekUsage.detail(fromJSON:),
+        parse: { json in
+            let payload = try DeepSeekUsage.payload(fromJSON: json)
+            let reading = try DeepSeekUsage.reading(fromJSON: payload.summary)
+            var windows = [LimitWindow(
+                id: "spend",
+                label: "Account usage (\(reading.currency))",
+                usedFraction: reading.usedFraction,
+                money: UsageMoneyBreakdown(currency: reading.currency,
+                                           spent: reading.spent,
+                                           remaining: reading.balance)
+            )]
+            if let availableTokens = reading.availableTokens {
+                windows.append(LimitWindow(id: "available-tokens",
+                                           label: "Available tokens (estimate)",
+                                           detail: "\(LimitWindow.compact(availableTokens)) available"))
+            }
+            return windows
+        }
+    )
+
 }

--- a/Sources/Providers/UsageProvider.swift
+++ b/Sources/Providers/UsageProvider.swift
@@ -39,6 +39,10 @@ protocol UsageProvider {
     /// route matters as much as this call. A requirement, not an extension
     /// member, for the reason spelled out above `account()`.
     func presentSignIn()
+    /// Open the provider's account-switch flow. Providers that do not own a
+    /// session have no special switching UI, so their normal sign-in action is
+    /// the honest fallback.
+    func presentAccountSwitch()
     /// Drop any credential held in memory, so the next read goes to the
     /// keychain for real.
     ///
@@ -55,6 +59,8 @@ protocol UsageProvider {
 }
 
 extension UsageProvider {
+    func presentAccountSwitch() { presentSignIn() }
+
     var isVisibleWhenAbsent: Bool { true }
 }
 

--- a/Sources/Providers/WebSessionProvider.swift
+++ b/Sources/Providers/WebSessionProvider.swift
@@ -24,11 +24,30 @@ final class WebSessionProvider: NSObject, UsageProvider {
         let displayName: String
         let glyph: ProviderGlyph
         let origin: URL
+        let fidelity: Fidelity
+        let authProbeScript: String?
         /// Runs in the page as an async function body. Must return a JSON string
         /// `{ "status": Int, "body": String }`.
         let script: String
         /// Turns the response body into windows, or throws if it cannot.
         let parse: (String) throws -> [LimitWindow]
+        let detailParse: ((String) throws -> ProviderUsageDetail?)?
+
+        init(id: String, displayName: String, glyph: ProviderGlyph, origin: URL,
+             script: String, fidelity: Fidelity = .official,
+             authProbeScript: String? = nil,
+             detailParse: ((String) throws -> ProviderUsageDetail?)? = nil,
+             parse: @escaping (String) throws -> [LimitWindow]) {
+            self.id = id
+            self.displayName = displayName
+            self.glyph = glyph
+            self.origin = origin
+            self.script = script
+            self.fidelity = fidelity
+            self.authProbeScript = authProbeScript
+            self.detailParse = detailParse
+            self.parse = parse
+        }
     }
 
     nonisolated let id: String
@@ -41,7 +60,10 @@ final class WebSessionProvider: NSObject, UsageProvider {
     private let site: Site
     private var webView: WKWebView?
     private var signInWindow: NSWindow?
+    private var signInProbeTask: Task<Void, Never>?
     private var isLoaded = false
+
+    var onAuthenticated: (() -> Void)?
 
     init(site: Site) {
         self.site = site
@@ -93,6 +115,7 @@ final class WebSessionProvider: NSObject, UsageProvider {
         ))
         let webView = WKWebView(frame: NSRect(x: 0, y: 0, width: 1100, height: 800),
                                 configuration: configuration)
+        webView.navigationDelegate = self
         self.webView = webView
         return webView
     }
@@ -152,7 +175,11 @@ final class WebSessionProvider: NSObject, UsageProvider {
         }
 
         // Recorded verbatim so a parser can be written against the real thing.
-        Log.usage.notice("\(self.site.id, privacy: .public) usage -> \(body.prefix(1200), privacy: .public)")
+        if site.id == "deepseek" {
+            Log.usage.notice("\(self.site.id, privacy: .public) usage response received")
+        } else {
+            Log.usage.notice("\(self.site.id, privacy: .public) usage -> \(body.prefix(1200), privacy: .public)")
+        }
         if let probes = envelope["probes"] as? String {
             Log.usage.notice("\(self.site.id, privacy: .public) probes -> \(probes.prefix(2600), privacy: .public)")
         }
@@ -161,9 +188,10 @@ final class WebSessionProvider: NSObject, UsageProvider {
             id: id,
             displayName: displayName,
             glyph: glyph,
-            fidelity: .official,
+            fidelity: site.fidelity,
             status: .ok,
-            windows: try site.parse(body)
+            windows: try site.parse(body),
+            usageDetail: try site.detailParse?(body)
         )
     }
 
@@ -202,6 +230,8 @@ final class WebSessionProvider: NSObject, UsageProvider {
     /// default store is shared, so clearing all of it would sign the user out of
     /// every other web provider at the same time.
     func signOut() async {
+        signInProbeTask?.cancel()
+        signInProbeTask = nil
         hasSignedIn = false
         isLoaded = false
 
@@ -224,6 +254,7 @@ final class WebSessionProvider: NSObject, UsageProvider {
         if let signInWindow {
             signInWindow.makeKeyAndOrderFront(nil)
             NSApp.activate(ignoringOtherApps: true)
+            watchForAuthentication()
             return
         }
         let window = NSWindow(
@@ -234,14 +265,57 @@ final class WebSessionProvider: NSObject, UsageProvider {
         )
         window.title = "Sign in to \(displayName)"
         window.contentView = webView
+        window.delegate = self
         window.center()
         window.isReleasedWhenClosed = false
         window.makeKeyAndOrderFront(nil)
         NSApp.activate(ignoringOtherApps: true)
         signInWindow = window
         webView.load(URLRequest(url: site.origin))
-        isLoaded = true
-        // Optimistic; the next refresh drops back to `needsAuth` if it did not take.
+        isLoaded = false
+        watchForAuthentication()
+    }
+
+    private func watchForAuthentication() {
+        guard signInWindow != nil, let probe = site.authProbeScript, let webView else { return }
+        signInProbeTask?.cancel()
+        signInProbeTask = Task { [weak self, weak webView] in
+            for _ in 0..<240 {
+                try? await Task.sleep(nanoseconds: 1_000_000_000)
+                guard !Task.isCancelled, let self, let webView else { return }
+                let result = try? await webView.callAsyncJavaScript(
+                    probe, arguments: [:], in: nil, contentWorld: .page
+                )
+                if result as? Bool == true {
+                    self.authenticationDidComplete()
+                    return
+                }
+            }
+        }
+    }
+
+    private func authenticationDidComplete() {
         hasSignedIn = true
+        signInProbeTask?.cancel()
+        signInProbeTask = nil
+        signInWindow?.close()
+        signInWindow = nil
+        isLoaded = false
+        onAuthenticated?()
+    }
+}
+
+extension WebSessionProvider: WKNavigationDelegate {
+    func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+        watchForAuthentication()
+    }
+}
+
+extension WebSessionProvider: NSWindowDelegate {
+    func windowWillClose(_ notification: Notification) {
+        guard let window = notification.object as? NSWindow, window === signInWindow else { return }
+        signInWindow = nil
+        signInProbeTask?.cancel()
+        signInProbeTask = nil
     }
 }

--- a/Sources/Providers/WebSessionProvider.swift
+++ b/Sources/Providers/WebSessionProvider.swift
@@ -2,6 +2,43 @@ import AppKit
 import WebKit
 import os
 
+/// Holds the only state a switch flow needs from the old session. The raw
+/// browser token never leaves JavaScript and its digest is kept in memory only.
+struct WebSessionAuthenticationGate: Equatable {
+    private(set) var baselineFingerprint: String?
+    private(set) var sawLogout = false
+    private var unauthenticatedSamples = 0
+
+    init(baselineFingerprint: String?) {
+        self.baselineFingerprint = baselineFingerprint
+    }
+
+    /// A switch commits only after a real logout/login transition. This keeps
+    /// an already-authenticated old page from being mistaken for the new
+    /// account and avoids false positives from one transient probe failure.
+    mutating func observe(authenticated: Bool, fingerprint: String?) -> Bool {
+        guard authenticated else {
+            unauthenticatedSamples += 1
+            if unauthenticatedSamples >= 2 { sawLogout = true }
+            return false
+        }
+
+        unauthenticatedSamples = 0
+        guard sawLogout else {
+            if baselineFingerprint == nil { baselineFingerprint = fingerprint }
+            return false
+        }
+
+        // Providers with no fingerprint can still use the explicit
+        // logout/login transition. DeepSeek supplies one, so the same-account
+        // re-login does not look like an account switch unless its session
+        // identity changed.
+        guard baselineFingerprint == nil || fingerprint == nil || fingerprint != baselineFingerprint
+        else { return false }
+        return true
+    }
+}
+
 /// Reads a provider's usage from the endpoint its own web app uses, by running
 /// the request *inside a browser the user signs into themselves*.
 ///
@@ -57,11 +94,27 @@ final class WebSessionProvider: NSObject, UsageProvider {
     /// the session lives in its own WebView, so it can open one and clear one.
     nonisolated var signInRoute: SignInRoute { .modal(name: displayName) }
 
+    /// A successful browser probe is the account identity this provider can
+    /// honestly expose. DeepSeek does not include an email or plan in the
+    /// usage payload we read, but the persisted session is enough to keep the
+    /// settings row in its signed-in state after the sheet is reopened.
+    nonisolated func account() -> ProviderAccount? {
+        guard UserDefaults.standard.bool(forKey: "\(id).signedIn") else { return nil }
+        return ProviderAccount(
+            label: nil,
+            plan: nil,
+            source: displayName,
+            manageURL: site.origin.appendingPathComponent("usage")
+        )
+    }
+
     private let site: Site
     private var webView: WKWebView?
     private var signInWindow: NSWindow?
     private var signInProbeTask: Task<Void, Never>?
     private var isLoaded = false
+    private var lastAuthFingerprint: String?
+    private var switchGate: WebSessionAuthenticationGate?
 
     var onAuthenticated: (() -> Void)?
 
@@ -168,6 +221,7 @@ final class WebSessionProvider: NSObject, UsageProvider {
 
         if status == 401 || status == 403 {
             // Not signed in, or a challenge wants a human. Same remedy either way.
+            hasSignedIn = false
             throw UsageProviderError.needsAuth
         }
         guard (200..<300).contains(status) else {
@@ -232,6 +286,8 @@ final class WebSessionProvider: NSObject, UsageProvider {
     func signOut() async {
         signInProbeTask?.cancel()
         signInProbeTask = nil
+        switchGate = nil
+        lastAuthFingerprint = nil
         hasSignedIn = false
         isLoaded = false
 
@@ -250,6 +306,17 @@ final class WebSessionProvider: NSObject, UsageProvider {
     }
 
     func presentSignIn() {
+        presentSignIn(switching: false)
+    }
+
+    func presentAccountSwitch() {
+        presentSignIn(switching: true)
+    }
+
+    private func presentSignIn(switching: Bool) {
+        switchGate = switching
+            ? WebSessionAuthenticationGate(baselineFingerprint: lastAuthFingerprint)
+            : nil
         let webView = makeWebViewIfNeeded()
         if let signInWindow {
             signInWindow.makeKeyAndOrderFront(nil)
@@ -286,16 +353,44 @@ final class WebSessionProvider: NSObject, UsageProvider {
                 let result = try? await webView.callAsyncJavaScript(
                     probe, arguments: [:], in: nil, contentWorld: .page
                 )
-                if result as? Bool == true {
+                guard let state = Self.authenticationState(from: result) else { continue }
+                if var gate = self.switchGate {
+                    if gate.observe(authenticated: state.authenticated, fingerprint: state.fingerprint) {
+                        self.switchGate = nil
+                        self.lastAuthFingerprint = state.fingerprint
+                        self.authenticationDidComplete()
+                    } else {
+                        self.switchGate = gate
+                    }
+                } else if state.authenticated {
+                    self.lastAuthFingerprint = state.fingerprint
                     self.authenticationDidComplete()
-                    return
                 }
             }
         }
     }
 
+    private struct AuthenticationState {
+        let authenticated: Bool
+        let fingerprint: String?
+    }
+
+    private static func authenticationState(from result: Any?) -> AuthenticationState? {
+        if let authenticated = result as? Bool {
+            return AuthenticationState(authenticated: authenticated, fingerprint: nil)
+        }
+        guard let text = result as? String,
+              let data = text.data(using: .utf8),
+              let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let authenticated = object["authenticated"] as? Bool
+        else { return nil }
+        return AuthenticationState(authenticated: authenticated,
+                                   fingerprint: object["fingerprint"] as? String)
+    }
+
     private func authenticationDidComplete() {
         hasSignedIn = true
+        switchGate = nil
         signInProbeTask?.cancel()
         signInProbeTask = nil
         signInWindow?.close()
@@ -317,5 +412,8 @@ extension WebSessionProvider: NSWindowDelegate {
         signInWindow = nil
         signInProbeTask?.cancel()
         signInProbeTask = nil
+        // Closing a switch window is a cancellation, not a successful account
+        // change. Leave the committed session and usage untouched.
+        switchGate = nil
     }
 }

--- a/Sources/Settings/SettingsView.swift
+++ b/Sources/Settings/SettingsView.swift
@@ -473,7 +473,7 @@ struct SettingsView: View {
                 }
                 // Beside the switches it explains, not stranded at the end of
                 // the page.
-                Text(L10n.t("Codenotch never signs in — each reading is borrowed from the tool that already holds the account. Signing out here stops the credential being read and forgets the numbers, but leaves you signed in to that tool. macOS asks once per tool the first time, and again whenever you sign in to a different account; Always Allow keeps it quiet."))
+                Text(L10n.t("Most readings are borrowed from a tool that already holds the account. DeepSeek is the exception: clicking Sign in opens its own Codenotch WebView, and signing out here clears only that session and its saved reading."))
                     .font(.caption)
                     .foregroundStyle(.tertiary)
                     .fixedSize(horizontal: false, vertical: true)

--- a/TASKS.md
+++ b/TASKS.md
@@ -65,6 +65,9 @@ Design spec in [`docs/specs/2026-08-28-usage-notch-design.md`](docs/specs/2026-0
       reports neither
 - [x] **`WebSessionProvider`** — the browser plumbing written once; `Sites`
       carries the per-site origin, script and parser
+- [x] **DeepSeek Platform** — explicit WebView login, account funded/spent
+      summary, aggregate tokens/cost/requests/API-key metrics, and 30-day
+      daily token/cost charts from the Platform usage endpoints
 - [x] **Cursor** via the same route, pinned by `CursorUsageTests`
 - [x] Cursor's glyph, flattened from its own SVG rather than traced from the
       design frame — exact at any size. See "Flattening an SVG" below
@@ -164,8 +167,9 @@ means work is happening. `CodexActivityMonitor` errs short: the ring stops eight
 seconds after the last write rather than claiming activity it cannot see. If
 Codex grows a real status field, that should replace this.
 
-Perplexity's adapter is kept but unregistered. `WebSessionProvider` is the
-working pattern for a site behind bot management, and re-registering is one line.
+Perplexity's adapter is kept but unregistered. DeepSeek is the first registered
+Platform-login site using `WebSessionProvider`; its login remains explicit and
+its account data stays in the provider's own WebView session.
 
 ### Cursor
 
@@ -843,8 +847,7 @@ credential, which is the same control under an honest name.
 - [x] `WebSessionProvider.signOut()` clears its own cookies — the one true
       logout in the app, because that session is the only one Codenotch created.
       Scoped to the site's host: the data store is shared, so emptying it would
-      sign the user out of every other web provider too. Nothing ships on this
-      path today, but the button would silently lie without it.
+      sign the user out of every other web provider too.
 - [x] Each row shows the account it reads (address and plan), with **Open** going
       to that vendor's own usage page.
 - [x] Every row states what signing out does *not* reach

--- a/Tests/DeepSeekUsageTests.swift
+++ b/Tests/DeepSeekUsageTests.swift
@@ -1,0 +1,82 @@
+import XCTest
+import SwiftUI
+@testable import Codenotch
+
+@MainActor
+final class DeepSeekUsageTests: XCTestCase {
+    func testPlatformSummaryBuildsMoneyWindow() throws {
+        let json = #"{"data":{"biz_data":{"normal_wallets":[{"currency":"CNY","balance":"10.87"}],"total_costs":[{"currency":"CNY","amount":"9.20"}],"total_available_token_estimation":"3300000"}}}"#
+        let reading = try DeepSeekUsage.reading(fromJSON: json)
+        XCTAssertEqual(reading.currency, "CNY")
+        XCTAssertEqual(reading.spent, 9.20, accuracy: 0.001)
+        XCTAssertEqual(reading.balance, 10.87, accuracy: 0.001)
+        XCTAssertEqual(reading.usedFraction, 9.20 / 20.07, accuracy: 0.001)
+        XCTAssertEqual(reading.availableTokens, 3_300_000)
+    }
+
+    func testAmountAndCostSeriesMergeByAPIKeyAndModel() throws {
+        let summary = #"{"data":{"biz_data":{"normal_wallets":[{"currency":"CNY","balance":"1"}],"total_costs":[]}}}"#
+        let amountObject: [String: Any] = ["data": ["biz_data": ["series": [[
+            "api_key": ["name": "main", "tracking_id": "key-1"],
+            "model": "deepseek-chat", "buckets": [[
+                "time": 1800000000,
+                "usage": ["PROMPT_CACHE_HIT_TOKEN": "100", "PROMPT_CACHE_MISS_TOKEN": 50,
+                           "RESPONSE_TOKEN": 25, "REQUEST": 2]
+            ]]
+        ]]]]]
+        let amount = String(data: try JSONSerialization.data(withJSONObject: amountObject), encoding: .utf8)!
+        let costObject: [String: Any] = ["data": ["biz_data": ["data": [[
+            "currency": "CNY", "series": [[
+                "api_key": ["name": "main", "tracking_id": "key-1"],
+                "model": "deepseek-chat", "buckets": [["time": 1800000000, "cost": "0.12"]]
+            ]]
+        ]]]]]
+        let cost = String(data: try JSONSerialization.data(withJSONObject: costObject), encoding: .utf8)!
+        let object: [String: Any] = ["summary": summary, "amount": amount, "cost": cost,
+                                      "start": 1800000000, "end": 1800086400,
+                                      "time_zone_seconds": 28800]
+        let payload = String(data: try JSONSerialization.data(withJSONObject: object), encoding: .utf8)!
+        let detail = try XCTUnwrap(DeepSeekUsage.detail(fromJSON: payload))
+        let group = try XCTUnwrap(detail.groups.first)
+        XCTAssertEqual(group.apiKeyLabel, "main")
+        XCTAssertEqual(group.model, "deepseek-chat")
+        XCTAssertEqual(group.totalTokens, 175)
+        XCTAssertEqual(group.requests, 2)
+        XCTAssertEqual(group.totalCost, 0.12, accuracy: 0.001)
+        XCTAssertEqual(detail.visibleAPIKeyCount, 1)
+        XCTAssertEqual(detail.totalTokens, 175)
+        XCTAssertEqual(detail.totalRequests, 2)
+    }
+
+    func testDeepSeekCardRendersMoneySummaryAndCharts() throws {
+        let detail = ProviderUsageDetail(
+            start: Date(timeIntervalSince1970: 1_800_000_000),
+            end: Date(timeIntervalSince1970: 1_800_086_400),
+            timeZoneSeconds: 28_800,
+            currency: "CNY",
+            groups: [UsageDetailGroup(apiKeyID: "key-1", apiKeyLabel: "main",
+                                      model: "deepseek-chat",
+                                      days: [UsageDetailDay(date: Date(timeIntervalSince1970: 1_800_000_000),
+                                                            cacheHitTokens: 100,
+                                                            cacheMissTokens: 50,
+                                                            outputTokens: 25,
+                                                            requests: 2,
+                                                            cost: 0.12)])]
+        )
+        let snapshot = ProviderSnapshot(
+            id: "deepseek", displayName: "DeepSeek", glyph: .deepseek,
+            fidelity: .derived, status: .ok,
+            windows: [LimitWindow(id: "spend", label: "Account usage (CNY)",
+                                  usedFraction: 9.20 / 20.07,
+                                  money: UsageMoneyBreakdown(currency: "CNY", spent: 9.20, remaining: 10.87))],
+            usageDetail: detail
+        )
+        let image = try XCTUnwrap(ImageRenderer(content: TooltipCard(snapshot: snapshot, now: Date())).nsImage)
+        XCTAssertGreaterThan(image.size.height, NotchLayout.cardHeight(windowCount: 1) + NotchLayout.usageDetailChartHeight)
+        if let path = ProcessInfo.processInfo.environment["DEEPSEEK_TOOLTIP_RENDER_PATH"],
+           let tiff = image.tiffRepresentation,
+           let png = NSBitmapImageRep(data: tiff)?.representation(using: .png, properties: [:]) {
+            try png.write(to: URL(fileURLWithPath: path))
+        }
+    }
+}

--- a/Tests/DeepSeekUsageTests.swift
+++ b/Tests/DeepSeekUsageTests.swift
@@ -4,6 +4,43 @@ import SwiftUI
 
 @MainActor
 final class DeepSeekUsageTests: XCTestCase {
+    func testSwitchGateIgnoresTheExistingSession() {
+        var gate = WebSessionAuthenticationGate(baselineFingerprint: "old")
+
+        XCTAssertFalse(gate.observe(authenticated: true, fingerprint: "old"))
+        XCTAssertFalse(gate.observe(authenticated: false, fingerprint: nil))
+        XCTAssertFalse(gate.observe(authenticated: true, fingerprint: "old"))
+        XCTAssertFalse(gate.observe(authenticated: true, fingerprint: "old"))
+    }
+
+    func testSwitchGateCommitsOnlyAfterLogoutAndANewSession() {
+        var gate = WebSessionAuthenticationGate(baselineFingerprint: "old")
+
+        XCTAssertFalse(gate.observe(authenticated: false, fingerprint: nil))
+        XCTAssertFalse(gate.observe(authenticated: false, fingerprint: nil))
+        XCTAssertTrue(gate.observe(authenticated: true, fingerprint: "new"))
+    }
+
+    func testSignedInSessionAppearsAsAnAccountInSettings() {
+        let key = "deepseek.signedIn"
+        let previous = UserDefaults.standard.object(forKey: key)
+        defer {
+            if let previous {
+                UserDefaults.standard.set(previous, forKey: key)
+            } else {
+                UserDefaults.standard.removeObject(forKey: key)
+            }
+        }
+
+        UserDefaults.standard.set(true, forKey: key)
+        let provider = WebSessionProvider(site: Sites.deepSeek)
+        let account = provider.account()
+
+        XCTAssertNotNil(account)
+        XCTAssertEqual(account?.source, "DeepSeek")
+        XCTAssertEqual(account?.manageURL?.absoluteString, "https://platform.deepseek.com/usage")
+    }
+
     func testPlatformSummaryBuildsMoneyWindow() throws {
         let json = #"{"data":{"biz_data":{"normal_wallets":[{"currency":"CNY","balance":"10.87"}],"total_costs":[{"currency":"CNY","amount":"9.20"}],"total_available_token_estimation":"3300000"}}}"#
         let reading = try DeepSeekUsage.reading(fromJSON: json)


### PR DESCRIPTION
## Summary

Adds a DeepSeek Platform usage card with account balance, spending, estimated available tokens, API-key/model token usage, cost details, and usage charts.

Also fixes the DeepSeek account-switching flow so an existing session is not mistaken for a newly authenticated account.

## Changes

- Add a DeepSeek Platform provider backed by the authenticated Platform WebView.
- Read account usage in CNY, including spent, remaining balance, and funded amount.
- Show usage details for tokens, cost, requests, and API keys.
- Add aggregate token usage and cost breakdowns by API key and model.
- Add daily usage charts following the existing Codex tooltip conventions.
- Preserve usage details and layout sizing for expanded model/API-key sections.
- Show DeepSeek as signed in on the Accounts page after authentication.
- Keep the existing account data when the user opens the switch flow but does not complete a switch.
- Confirm an account switch only after observing logout followed by a new authenticated session.
- Keep raw session tokens inside the WebView and use only an in-memory SHA-256 fingerprint for session-change detection.
- Clear the persisted session state when the Platform returns HTTP 401 or 403.

## Account switching behavior

1. Clicking `Switch...` opens the DeepSeek WebView without closing it immediately.
2. The current authenticated session is ignored as a completed switch.
3. The previous account must sign out first.
4. A new authenticated session must then be detected.
5. Only after confirmation does Codenotch close the WebView and refresh usage data.

Closing the window before completing the flow leaves the existing account and usage data unchanged.

## Privacy

Codenotch does not read credentials from Safari or Chrome. DeepSeek authentication is handled by the app-owned WKWebView. Raw tokens are not persisted, logged, or sent to Swift; only a temporary in-memory digest is used to distinguish sessions during account switching.

## Testing

- `make build` passed.
- `make test` passed.
- 1,254 tests passed.
- 3 tests skipped.
- Added DeepSeek parsing, rendering, signed-in account, and account-switching tests.

## Risk

The switching flow is intentionally conservative. Refreshing the page or keeping the existing account signed in will not replace the current usage data. A switch is committed only after a logout/login transition is detected.