### PR TITLE
fix: align the move handle with the camera notch corner

### DIFF
--- a/Sources/Notch/NotchViewModel.swift
+++ b/Sources/Notch/NotchViewModel.swift
@@ -327,9 +327,7 @@ final class NotchViewModel: ObservableObject {
     /// orb sits past `shapeLength`, so the pair stay symmetric about the notch
     /// at every size and on every edge.
     var moveAlong: CGFloat {
-        guard orbHugsCorner else { return 0 }
-        return cornerCentreAlong - shapeLength
-            + NotchLayout.orbCornerOffset(corner: drawnCornerRadius)
+        shapeLength - orbAlong
     }
 
     /// The mirror of `trailingExtent` at the near end — the room the move

--- a/Tests/NotchLayoutTests.swift
+++ b/Tests/NotchLayoutTests.swift
@@ -382,6 +382,20 @@ final class PointerStateTests: XCTestCase {
 /// resting arc follows that curve rather than merely sitting near it.
 @MainActor
 final class SettingsOrbTests: XCTestCase {
+    func testCameraNotchHandlesMirrorEachOther() {
+        let model = NotchViewModel()
+        model.edge = .top
+        model.hardwareNotch = HardwareNotch(width: 220, height: 37)
+
+        XCTAssertEqual(model.moveAlong + model.orbAlong, model.shapeLength, accuracy: 0.001,
+                       "The buttons must sit equally far from the two ends")
+        let moveArc = model.moveAlong + model.moveArcOffset.width
+        let settingsArc = model.orbAlong + model.orbArcOffset.width
+        XCTAssertEqual(moveArc + settingsArc, model.shapeLength, accuracy: 0.001,
+                       "The resting arcs must mirror around the notch's centre")
+        XCTAssertEqual(model.moveArcOffset.height, model.orbArcOffset.height, accuracy: 0.001)
+    }
+
     private func centre(_ count: Int) -> CGFloat {
         NotchLayout.orbCenterAlong(cellCount: count)
     }


### PR DESCRIPTION
When Codenotch joins the MacBook camera notch, the move handle crowds the left corner while the settings handle sits farther outside the right corner. The move position used the opposite sign from the reflection described by its comment.

Compute `moveAlong` as `shapeLength - orbAlong` so the buttons and their resting arcs mirror each other around the notch's centre. On edges without a hardware notch, this still evaluates to zero.

Adds a regression test for button symmetry, resting-arc symmetry, and matching arc heights on a camera notch.

Validation:
- The regression test failed on the original calculation and passes with the fix.
- `make test`: 1,265 tests executed, 3 skipped, zero failures.
- `make run`: build succeeded and the updated local app launched.
