### PR TITLE
feat: add Russian localization for macOS and Windows

### DIFF
--- a/Sources/Info.plist
+++ b/Sources/Info.plist
@@ -18,6 +18,7 @@
 		<string>fr</string>
 		<string>ja</string>
 		<string>pt-BR</string>
+		<string>ru</string>
 		<string>zh-Hans</string>
 	</array>
 	<key>CFBundleName</key>

--- a/Sources/Localizable.xcstrings
+++ b/Sources/Localizable.xcstrings
@@ -272,6 +272,12 @@
             "state": "translated",
             "value": "%@ 重置"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Сброс: %@"
+          }
         }
       }
     },
@@ -721,6 +727,12 @@
             "state": "translated",
             "value": "为某个编程工具配置 GLM Coding Plan 密钥以读取用量"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Настройте ключ GLM Coding Plan в инструменте разработки, чтобы читать использование"
+          }
         }
       }
     },
@@ -749,6 +761,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "在 OpenCode 中开通 Go 套餐以读取用量"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Подключите тариф Go в OpenCode, чтобы читать использование"
           }
         }
       }
@@ -814,6 +832,12 @@
             "state": "translated",
             "value": "Codenotch 未能读取 %@ 已保存的登录信息。点击这个圆环再试一次，并选择「始终允许」。"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Codenotch не получил доступ к сохранённому входу %@. Нажмите это кольцо, повторите запрос и выберите «Разрешать всегда»."
+          }
         }
       }
     },
@@ -842,6 +866,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "无法读取用量 — %@"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Не удалось прочитать использование — %@"
           }
         }
       }
@@ -977,6 +1007,12 @@
             "state": "translated",
             "value": "Opus"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Opus"
+          }
         }
       }
     },
@@ -1002,6 +1038,12 @@
           }
         },
         "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sonnet"
+          }
+        },
+        "ru": {
           "stringUnit": {
             "state": "translated",
             "value": "Sonnet"
@@ -1700,6 +1742,12 @@
             "state": "translated",
             "value": "Labs"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Labs"
+          }
         }
       }
     },
@@ -2180,6 +2228,12 @@
           }
         },
         "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VS Code"
+          }
+        },
+        "ru": {
           "stringUnit": {
             "state": "translated",
             "value": "VS Code"
@@ -2878,6 +2932,12 @@
             "state": "translated",
             "value": "沿右边缘，避开那一侧的程序坞。"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Вдоль правого края, не занимая место у Dock."
+          }
         }
       }
     },
@@ -2906,6 +2966,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "沿左边缘，避开那一侧的程序坞。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Вдоль левого края, не занимая место у Dock."
           }
         }
       }
@@ -2936,6 +3002,12 @@
             "state": "translated",
             "value": "顶部一条横栏，读数并排。有硬件刘海的 Mac 上会贴上去，看起来像同一块。"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Широкая панель сверху с показаниями рядом. На Mac с аппаратной выемкой она примыкает к ней, образуя единую форму."
+          }
         }
       }
     },
@@ -2964,6 +3036,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "一条横栏压在程序坞上方，读数并排。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Широкая панель над Dock с показаниями рядом."
           }
         }
       }
@@ -3379,6 +3457,12 @@
             "state": "translated",
             "value": "Codenotch 从不自己登录 — 每条读数都借自已经持有该账号的工具。在这里退出只会停止读取凭证并忘掉数字，你在那个工具里仍然是登录状态。macOS 每种工具第一次会问一次，换账号再登录时还会再问；选「始终允许」就不会再打扰。"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Codenotch не выполняет вход — каждое показание берётся из уже авторизованного инструмента. Выход здесь прекращает чтение учётных данных и удаляет числа, но не выполняет выход из инструмента. macOS спрашивает разрешение один раз для каждого инструмента и при смене аккаунта; «Разрешать всегда» отключает повторные запросы."
+          }
         }
       }
     },
@@ -3407,6 +3491,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Codenotch 读取这台 Mac 上已经登录的工具的用量 — 从不问你的密码。安装并登录 Claude Code（终端工具，不是 Claude 应用）、Cursor、Codex、Antigravity、GLM、Grok 或 OpenCode 中的任意一个，刘海里就会出现对应的圆环。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Codenotch читает использование из инструментов, уже авторизованных на этом Mac, и никогда не спрашивает пароль. Установите и авторизуйтесь в Claude Code (терминальном инструменте, не приложении Claude), Cursor, Codex, Antigravity, GLM, Grok или OpenCode — и кольцо появится на панели."
           }
         }
       }
@@ -3437,6 +3527,12 @@
             "state": "translated",
             "value": "macOS 会询问一次，是否允许读取 Claude Code 和 Antigravity 已保存的登录信息。请选「始终允许」— 只选「允许」的话，每次都会再问。"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macOS один раз запросит доступ к сохранённым входам Claude Code и Antigravity. Выберите «Разрешать всегда» — обычное «Разрешить» приводит к повторному запросу."
+          }
         }
       }
     },
@@ -3465,6 +3561,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "版本 %@。更新在后台安装，下次启动 Codenotch 时生效。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Версия %@. Обновления устанавливаются в фоне и применяются при следующем запуске Codenotch."
           }
         }
       }
@@ -3495,6 +3597,12 @@
             "state": "translated",
             "value": "已退出 — 不再读取，也不再保存读数。"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Выход выполнен — данные не читаются и не сохраняются."
+          }
         }
       }
     },
@@ -3523,6 +3631,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "允许访问…"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Разрешить доступ…"
           }
         }
       }
@@ -3553,6 +3667,12 @@
             "state": "translated",
             "value": "切换…"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Переключить…"
+          }
         }
       }
     },
@@ -3581,6 +3701,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "再次向 macOS 请求 %@ 已保存的登录信息。选「始终允许」就不会再问。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Повторно запрашивает у macOS сохранённый вход %@. Выберите «Разрешать всегда», чтобы больше не видеть этот запрос."
           }
         }
       }
@@ -3611,6 +3737,12 @@
             "state": "translated",
             "value": "关闭后停止读取 %@ 并忘掉它的读数。%@"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Выключите, чтобы прекратить чтение %@ и удалить его показания. %@"
+          }
         }
       }
     },
@@ -3639,6 +3771,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "打开以重新登录并读取 %@。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Включите, чтобы снова войти и читать %@."
           }
         }
       }
@@ -3669,6 +3807,12 @@
             "state": "translated",
             "value": "macOS 不让 Codenotch 读取 %@ 已保存的登录信息。点上面的「允许访问…」，然后选「始终允许」。"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macOS не разрешает Codenotch читать сохранённый вход %@. Выберите выше «Разрешить доступ…», затем «Разрешать всегда»."
+          }
         }
       }
     },
@@ -3697,6 +3841,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "打开 %@"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Открыть %@"
           }
         }
       }
@@ -3727,6 +3877,12 @@
             "state": "translated",
             "value": "打开 %@，这个账号就是在那里登录的。"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Открывает %@, где выполнен вход в этот аккаунт."
+          }
         }
       }
     },
@@ -3755,6 +3911,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "在浏览器打开 %@。那个网站有自己的登录，和这里读取的凭证不是一回事。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Открывает %@ в браузере. На этом сайте используется отдельный вход, не связанный с читаемыми здесь данными."
           }
         }
       }
@@ -3785,6 +3947,12 @@
             "state": "translated",
             "value": "Codenotch 设置"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Настройки Codenotch"
+          }
         }
       }
     },
@@ -3813,6 +3981,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "新变化"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Что нового"
           }
         }
       }
@@ -3843,6 +4017,12 @@
             "state": "translated",
             "value": "Codenotch 新变化"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Что нового в Codenotch"
+          }
         }
       }
     },
@@ -3871,6 +4051,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "版本 %@"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Версия %@"
           }
         }
       }
@@ -3901,6 +4087,12 @@
             "state": "translated",
             "value": "继续"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Продолжить"
+          }
         }
       }
     },
@@ -3930,6 +4122,12 @@
             "state": "translated",
             "value": "macOS 拒绝了 — 试着把 Codenotch 移到「应用程序」。"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macOS отказала — попробуйте переместить Codenotch в /Applications."
+          }
         }
       }
     },
@@ -3958,6 +4156,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "来自 %@"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "через %@"
           }
         }
       }
@@ -4268,6 +4472,12 @@
             "state": "translated",
             "value": "你在持有该账号的工具里仍然是登录状态。"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Вход в инструмент, которому принадлежит аккаунт, сохраняется."
+          }
         }
       }
     },
@@ -4367,6 +4577,12 @@
             "state": "translated",
             "value": "运行 grok login — 它会登录并刷新这里读取的令牌。"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Запустите grok login — команда выполнит вход и обновит читаемый токен."
+          }
         }
       }
     },
@@ -4395,6 +4611,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "用量走的是 OpenCode 登录时保存的 opencode-go 密钥 — 在 OpenCode 里接通 Go（`opencode auth login`），刘海就会读到。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Использование берётся из ключа opencode-go, который OpenCode сохраняет при входе — подключите Go в OpenCode (`opencode auth login`), и панель начнёт его читать."
           }
         }
       }
@@ -4425,6 +4647,12 @@
             "state": "translated",
             "value": "用量走的是某个编程工具里的 Z.ai GLM Coding Plan 密钥 — Claude Code 的 settings.json、ZCode 或 OpenCode。在那边配好，刘海就会读到。"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Использование берётся из ключа Z.ai GLM Coding Plan, который хранит инструмент разработки — settings.json Claude Code, ZCode или OpenCode. Настройте ключ там, и панель начнёт его читать."
+          }
         }
       }
     },
@@ -4453,6 +4681,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "先运行一次 `%@` — 它会登录并刷新这里读取的令牌。要换账号，在那里用 /login。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Один раз запустите `%@` — команда выполнит вход и обновит читаемый токен. Для смены аккаунта используйте там /login."
           }
         }
       }
@@ -4518,6 +4752,12 @@
             "state": "translated",
             "value": "%@ 套餐目前还没有可供 Cursor 计量的额度"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "В тарифе %@ пока нечего измерять для Cursor"
+          }
         }
       }
     },
@@ -4546,6 +4786,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Codex 没有返回任何用量窗口"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Codex не сообщил ни одного окна использования"
           }
         }
       }
@@ -4576,6 +4822,12 @@
             "state": "translated",
             "value": "这个密钥上没有 OpenCode Go 订阅"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Для этого ключа нет подписки OpenCode Go"
+          }
         }
       }
     },
@@ -4604,6 +4856,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "这个 Grok 账号目前没有可计量的额度"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Для этого аккаунта Grok пока нет измеряемого использования"
           }
         }
       }
@@ -4774,6 +5032,12 @@
             "state": "translated",
             "value": "Codenotch 已设为「始终显示」。请在设置里更改。"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Для Codenotch включён режим «Показывать всегда». Измените его в настройках."
+          }
         }
       }
     },
@@ -4908,6 +5172,12 @@
             "state": "translated",
             "value": "连不上更新服务器。Codenotch 会自己再试 — 这份安装没有问题。"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Не удалось связаться с сервером обновлений. Codenotch повторит попытку автоматически — с этой копией всё в порядке."
+          }
         }
       }
     },
@@ -4936,6 +5206,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "又多了两个服务，以及一个被悄悄丢掉的真实账号套餐。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Два новых провайдера и восстановленный аккаунт с активным тарифом."
           }
         }
       }
@@ -4966,6 +5242,12 @@
             "state": "translated",
             "value": "Grok 成了新的圆环"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Grok — новое кольцо"
+          }
         }
       }
     },
@@ -4994,6 +5276,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "SuperGrok 的每周 Grok Build 额度，读取 CLI 所用的同一个计费接口，会话来自 ~/.grok/auth.json。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Недельный лимит Grok Build в SuperGrok, читаемый из того же платёжного API, что использует CLI, с сессией из ~/.grok/auth.json."
           }
         }
       }
@@ -5024,6 +5312,12 @@
             "state": "translated",
             "value": "OpenCode 的 Go 套餐成了新的圆环"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Тариф Go в OpenCode — новое кольцо"
+          }
         }
       }
     },
@@ -5052,6 +5346,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "用 OpenCode 登录时自己存下的密钥读取 Go 套餐官方用量接口 — 不用再登一次。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Читает официальный API использования тарифа Go с ключом, который OpenCode сохраняет при входе — второй вход не нужен."
           }
         }
       }
@@ -5082,6 +5382,12 @@
             "state": "translated",
             "value": "一个真实的 Codex 账号变成了未计量"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Настоящий аккаунт Codex перестал считаться"
+          }
         }
       }
     },
@@ -5110,6 +5416,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Codex 的实时读数只认 5 小时和 7 天窗口。免费套餐账号真正的额度是 30 天，被悄悄漏掉，一个确实在计量的账号显示成没有可计量的额度。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Актуальное чтение Codex распознавало только окна на 5 часов и 7 дней. У бесплатного аккаунта настоящим был лимит на 30 дней, который незаметно пропускался, поэтому отслеживаемый аккаунт показывался без измеряемого использования."
           }
         }
       }
@@ -5140,6 +5452,12 @@
             "state": "translated",
             "value": "关掉某个服务现在真的会停掉"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Выключение провайдера теперь действительно останавливает его"
+          }
         }
       }
     },
@@ -5168,6 +5486,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "打开设置仍可能读取已关闭服务的账号，一次还在路上的回复也可能把你刚让它忘掉的读数加回来。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Открытие настроек всё ещё могло читать аккаунт выключенного провайдера, а уже выполнявшийся ответ мог вернуть только что удалённое показание."
           }
         }
       }
@@ -5198,6 +5522,12 @@
             "state": "translated",
             "value": "贡献者可以在没有证书的情况下构建"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Сборка для разработчиков работает без сертификата"
+          }
         }
       }
     },
@@ -5226,6 +5556,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "维护者的 Developer ID 不在时，make build 和 make test 会自动签名 — 参与开发不需要 Apple 账号。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "make build и make test теперь автоматически подписывают сборку, если Developer ID сопровождающего отсутствует — аккаунт Apple для работы над проектом не нужен."
           }
         }
       }
@@ -5256,6 +5592,12 @@
             "state": "translated",
             "value": "从睡眠唤醒不再抹掉读数。"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Выход из сна больше не удаляет показание."
+          }
         }
       }
     },
@@ -5284,6 +5626,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "唤醒 Mac 后圆环还在"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Кольцо переживает выход Mac из сна"
           }
         }
       }
@@ -5314,6 +5662,12 @@
             "state": "translated",
             "value": "刚睡醒的一小段时间里 macOS 还不允许钥匙串提示，这被误当成已退出 — 读数被抹掉，屏幕上只剩「正在等待首次读数」。现在会让数字变旧而不是扔掉，并自己恢复。"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Короткий период после сна, когда macOS ещё не разрешает запрос к связке ключей, ошибочно считался выходом из аккаунта — показание удалялось и на экране оставалось «ожидание первого показания». Теперь число помечается устаревшим и чтение возобновляется автоматически."
+          }
         }
       }
     },
@@ -5342,6 +5696,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "又多了两个账号，四个社区修复，以及诚实的重复项。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Два новых аккаунта, четыре исправления сообщества и корректная обработка дубликатов."
           }
         }
       }
@@ -5372,6 +5732,12 @@
             "state": "translated",
             "value": "多个 Claude Code 账号"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Несколько аккаунтов Claude Code"
+          }
         }
       }
     },
@@ -5400,6 +5766,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "用 CLAUDE_CONFIG_DIR 把工作登录分开？它现在有自己的圆环、自己的额度，以及设置里自己的一行，就在个人账号旁边。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Используете CLAUDE_CONFIG_DIR для рабочего входа? Теперь у него есть отдельное кольцо, лимиты и строка в настройках рядом с личным аккаунтом."
           }
         }
       }
@@ -5430,6 +5802,12 @@
             "state": "translated",
             "value": "加入了 GLM"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Добавлен GLM"
+          }
         }
       }
     },
@@ -5458,6 +5836,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Z.ai 的 Coding Plan 现在也实时读取，密钥借自已经持有它的那个工具。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Тариф Z.ai Coding Plan теперь тоже читается в реальном времени с ключом из уже авторизованного инструмента."
           }
         }
       }
@@ -5488,6 +5872,12 @@
             "state": "translated",
             "value": "卡住的 Claude 圆环会自己恢复"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Зависшее кольцо Claude восстанавливается само"
+          }
         }
       }
     },
@@ -5516,6 +5906,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "一次短暂失败 — 多半是 Mac 从睡眠唤醒 — 以前会把圆环锁死直到重启应用。现在下次检查会自己解开。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Кратковременная ошибка — чаще всего при выходе Mac из сна — раньше блокировала кольцо до перезапуска приложения. Теперь оно очищается при следующей проверке."
           }
         }
       }
@@ -5546,6 +5942,12 @@
             "state": "translated",
             "value": "Cursor 会话不再把已经结束的工作报成还在进行"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Сеансы Cursor перестают сообщать о завершённой работе"
+          }
         }
       }
     },
@@ -5574,6 +5976,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "崩溃或弃掉的对话可能一整天都显示「仍在工作」。现在会发现写入其实已经停了。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "После сбоя или оставленный чат мог считаться «всё ещё работающим» день и дольше. Теперь приложение замечает фактическое завершение работы."
           }
         }
       }
@@ -5604,6 +6012,12 @@
             "state": "translated",
             "value": "几个月前的重复项再也抢不赢"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Старая копия больше не может оказаться главной"
+          }
         }
       }
     },
@@ -5632,6 +6046,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Claude Code 每次轮换令牌都会写一条新的钥匙串。登录较久的账号可能随机拿到过期的那条，然后永远显示「正在等待首次读数」。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Claude Code создаёт новую запись в связке ключей при каждой смене токена. Давно авторизованный аккаунт мог случайно выбрать старую просроченную запись и навсегда показать «ожидание первого показания»."
           }
         }
       }
@@ -5662,6 +6082,12 @@
             "state": "translated",
             "value": "误点不再把刘海钉在展开状态"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Случайный щелчок больше не оставляет панель открытой"
+          }
         }
       }
     },
@@ -5690,6 +6116,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "刘海还没展开时点到屏幕边缘，可能让它卡在打开状态，屏幕上却没有任何解释。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Щелчок у края экрана до открытия панели мог оставить её открытой без объяснения на экране."
           }
         }
       }
@@ -5720,6 +6152,12 @@
             "state": "translated",
             "value": "Codex 改为实时读取，「始终显示」会保持打开。"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Codex читается в реальном времени, а «Показывать всегда» сохраняется."
+          }
         }
       }
     },
@@ -5748,6 +6186,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Codex 改为实时读取，而不再读日志"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Codex читается в реальном времени, а не из журнала"
           }
         }
       }
@@ -5778,6 +6222,12 @@
             "state": "translated",
             "value": "数字来自 Codex 在一轮对话里写的文件，所以有多旧取决于你上次用它是什么时候 — 有一次旧了三天。Codenotch 现在直接问 Codex，并与它自己的面板一致。"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Число бралась из файла, который Codex записывает во время хода, поэтому могло устареть на несколько дней. Теперь Codenotch спрашивает сам Codex и показывает данные его панели."
+          }
         }
       }
     },
@@ -5806,6 +6256,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Codex 圆环会注意到桌面应用"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Кольцо Codex видит настольное приложение"
           }
         }
       }
@@ -5836,6 +6292,12 @@
             "state": "translated",
             "value": "以前只盯 CLI 和 VS Code 扩展写的文件，桌面应用里的工作从不会让它转起来。"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Раньше отслеживались только файлы CLI и расширения VS Code, поэтому работа в настольном приложении не запускала вращение кольца."
+          }
         }
       }
     },
@@ -5864,6 +6326,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "「始终显示」不再自己关掉"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "«Показывать всегда» больше не выключается само"
           }
         }
       }
@@ -5894,6 +6362,12 @@
             "state": "translated",
             "value": "点击刘海会拨动设置用的同一个开关，一次误点就会悄悄变回悬停时显示。"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Щелчок по панели менял тот же флаг, что и настройка, поэтому случайный щелчок незаметно возвращал режим показа при наведении."
+          }
         }
       }
     },
@@ -5922,6 +6396,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "钥匙串提示少得多"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Гораздо меньше запросов связки ключей"
           }
         }
       }
@@ -5952,6 +6432,12 @@
             "state": "translated",
             "value": "令牌一过期，每次检查都回到钥匙串 — 一分钟弹一次。现在只在所属应用改过密钥时才读，并且不会按定时器重试一次拒绝。"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "После истечения токена каждая проверка обращалась к связке ключей и показывала запрос раз в минуту. Теперь секрет читается только после изменения владельцем, а отказ не повторяется по таймеру."
+          }
         }
       }
     },
@@ -5980,6 +6466,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "暂停的额度会显示为暂停"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Приостановленный лимит отображается как приостановленный"
           }
         }
       }
@@ -6010,6 +6502,12 @@
             "state": "translated",
             "value": "有些额度已经用尽，标题却还显示有余量。圆环会显示用完，并说明何时解除。"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Некоторые лимиты достигаются, хотя основной показатель ещё показывает запас. Кольцо теперь показывает расход и время снятия ограничения."
+          }
         }
       }
     },
@@ -6038,6 +6536,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "长消息不再被截断"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Длинные сообщения больше не обрезаются"
           }
         }
       }
@@ -6068,6 +6572,12 @@
             "state": "translated",
             "value": "有话要说的提示只给它留了一行，不管它写了多少。"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Подсказка с пояснением теперь выделяет под него строку независимо от длины текста."
+          }
         }
       }
     },
@@ -6096,6 +6606,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "每一个会话，以及一张能放进屏幕的提示卡。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Каждый сеанс и подсказка, помещающаяся на экране."
           }
         }
       }
@@ -6126,6 +6642,12 @@
             "state": "translated",
             "value": "提示卡不再被截断"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Подсказки больше не обрезаются"
+          }
         }
       }
     },
@@ -6154,6 +6676,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "卡片以所属圆环为中心，第一个和最后一个服务会把一半甩出面板 — 掉出去的还是标题。面板现在会给它留位置。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Карточка центрируется относительно своего кольца. Раньше у первого и последнего провайдера её половина выходила за край панели вместе с заголовком; теперь место резервируется."
           }
         }
       }
@@ -6184,6 +6712,12 @@
             "state": "translated",
             "value": "屏幕能放下多少会话就显示多少"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Столько сеансов, сколько помещается на экране"
+          }
         }
       }
     },
@@ -6212,6 +6746,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "不论你在跑什么，列表以前最多四条。现在按屏幕算：大屏幕十条，只有真的放不下时才出现「还有 N 个」。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Раньше список всегда ограничивался четырьмя пунктами. Теперь он подстраивается под экран: до десяти на большом, а «и ещё N» появляется только при нехватке места."
           }
         }
       }
@@ -6242,6 +6782,12 @@
             "state": "translated",
             "value": "需要你的排在前面"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Сначала показываются те, кому вы нужны"
+          }
         }
       }
     },
@@ -6270,6 +6816,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "等待中，然后工作中，然后空闲 — 被收进「还有 N 个」的，是最不要紧的。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Сначала ожидание, затем работа и простой — при сокращении списка исчезает наименее важное."
           }
         }
       }
@@ -6300,6 +6852,12 @@
             "state": "translated",
             "value": "Antigravity 的真实数字，以及一个会保持关闭的开关。"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Настоящие числа Antigravity и переключатель, который не включается обратно."
+          }
         }
       }
     },
@@ -6328,6 +6886,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Antigravity 显示真实配额"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Antigravity показывает настоящий лимит"
           }
         }
       }
@@ -6358,6 +6922,12 @@
             "state": "translated",
             "value": "Google 不会直接回答 Codenotch，所以改问 Antigravity 自己的语言服务器 — 也就是 Antigravity 用量面板取数字的地方。"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Google не отвечает Codenotch напрямую, поэтому приложение спрашивает языковой сервер Antigravity — тот же источник использует панель использования Antigravity."
+          }
         }
       }
     },
@@ -6386,6 +6956,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "用量从两头都能读懂"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Использование читается в обоих направлениях"
           }
         }
       }
@@ -6416,6 +6992,12 @@
             "state": "translated",
             "value": "「12% 已用 · 88% 剩余」，读数能对上供应商碰巧展示的那一端。"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "«Использовано 12% · осталось 88%», поэтому показание совпадает с тем, какую сторону показывает поставщик."
+          }
         }
       }
     },
@@ -6444,6 +7026,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "拒绝钥匙串提示之后还有退路"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Возможность повторить отклонённый запрос связки ключей"
           }
         }
       }
@@ -6474,6 +7062,12 @@
             "state": "translated",
             "value": "拒绝不再看起来像已退出，「允许访问…」会再问一次 macOS。"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Отказ больше не выглядит как выход из аккаунта, а «Разрешить доступ…» повторяет запрос macOS."
+          }
         }
       }
     },
@@ -6502,6 +7096,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "关掉某个服务现在会记住"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Выключение провайдера теперь сохраняется"
           }
         }
       }
@@ -6532,6 +7132,12 @@
             "state": "translated",
             "value": "不再读取，但上次读数还留着，所以下次启动圆环又回来了。"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Чтение прекращается, а последнее показание сохраняется, поэтому кольцо возвращается при следующем запуске."
+          }
         }
       }
     },
@@ -6560,6 +7166,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "很远的重置会显示日期"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Далёкий сброс показывает дату"
           }
         }
       }
@@ -6590,6 +7202,12 @@
             "state": "translated",
             "value": "四周后才更新的额度以前写「Mon」，读起来像本周一。现在写「9月28日」。"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Для лимита, обновляющегося через четыре недели, показывалось «Пн», что выглядело как ближайший понедельник. Теперь показывается «28 сен»."
+          }
         }
       }
     },
@@ -6618,6 +7236,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "首个版本。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Первый выпуск."
           }
         }
       }
@@ -6648,6 +7272,12 @@
             "state": "translated",
             "value": "刘海可以放在任意一边"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Разместите панель где угодно"
+          }
         }
       }
     },
@@ -6676,6 +7306,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "右、左、上或下。会避开程序坞和菜单栏，程序坞移动时跟着走。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Справа, слева, сверху или снизу. Панель не перекрывает Dock и строку меню и перемещается вместе с Dock."
           }
         }
       }
@@ -6706,6 +7342,12 @@
             "state": "translated",
             "value": "它会接上 Mac 自己的刘海"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Она объединяется с выемкой Mac"
+          }
         }
       }
     },
@@ -6734,6 +7376,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "放在顶部时会采用硬件的形状，两者读起来是一块，而不是停在下面的一条。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "У верхнего края она повторяет форму аппаратной выемки, поэтому выглядит единым элементом, а не панелью под ней."
           }
         }
       }
@@ -6764,6 +7412,12 @@
             "state": "translated",
             "value": "Claude、Cursor、Codex 和 Gemini"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Claude, Cursor, Codex и Gemini"
+          }
         }
       }
     },
@@ -6792,6 +7446,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "各自读取这台 Mac 上已经登录的工具。Codenotch 从不问密码。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Данные читаются из уже авторизованного на этом Mac инструмента. Codenotch никогда не спрашивает пароль."
           }
         }
       }
@@ -6822,6 +7482,12 @@
             "state": "translated",
             "value": "选择 Codenotch 出现在哪里"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Выберите, где показывать Codenotch"
+          }
         }
       }
     },
@@ -6851,6 +7517,12 @@
             "state": "translated",
             "value": "在程序坞、在菜单栏，或者哪里都不出现。"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "В Dock, в строке меню или нигде."
+          }
         }
       }
     },
@@ -6876,6 +7548,12 @@
           }
         },
         "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Codenotch"
+          }
+        },
+        "ru": {
           "stringUnit": {
             "state": "translated",
             "value": "Codenotch"
@@ -6909,6 +7587,12 @@
             "state": "translated",
             "value": "%@%% 已用 · %@%% 剩余"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Использовано %@%% · осталось %@%%"
+          }
         }
       }
     },
@@ -6937,6 +7621,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "剩余 %@"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "осталось %@"
           }
         }
       }
@@ -6967,6 +7657,12 @@
             "state": "translated",
             "value": "已用 %@"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "использовано %@"
+          }
         }
       }
     },
@@ -6995,6 +7691,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "用 GitHub CLI 登录以读取 Copilot 用量"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Войдите через GitHub CLI, чтобы читать использование Copilot"
           }
         }
       }
@@ -7025,6 +7727,12 @@
             "state": "translated",
             "value": "用 `gh auth login` 登录 GitHub CLI，然后启用 GitHub Copilot。"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Выполните вход через GitHub CLI командой `gh auth login`, затем включите GitHub Copilot."
+          }
         }
       }
     },
@@ -7053,6 +7761,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "GitHub Copilot 没有返回可计量的配额"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GitHub Copilot не сообщил измеряемых квот"
           }
         }
       }
@@ -7083,6 +7797,12 @@
             "state": "translated",
             "value": "没有需要登录的地方：次数是从 Gemini CLI、OpenCode 和 Hermes 自己记录的调用加总的。不会读取你的 API 密钥。"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Вход не требуется: показатель складывается из данных о собственных вызовах Gemini CLI, OpenCode и Hermes. Ваш API-ключ никогда не читается."
+          }
         }
       }
     },
@@ -7111,6 +7831,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "没有找到 Gemini CLI、OpenCode 或 Hermes 会话"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Сеансы Gemini CLI, OpenCode или Hermes не найдены"
           }
         }
       }
@@ -7141,6 +7867,12 @@
             "state": "translated",
             "value": "先运行一次 `%@` — 它会登录，读数就来自那里。要换账号，在那里用 /login。"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Один раз запустите `%@` — команда выполнит вход и станет источником этих показаний. Для смены аккаунта используйте там /login."
+          }
         }
       }
     },
@@ -7169,6 +7901,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "限定范围"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ограниченное"
           }
         }
       }
@@ -7199,6 +7937,12 @@
             "state": "translated",
             "value": "Auto 用量"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Автоматическое использование"
+          }
         }
       }
     },
@@ -7227,6 +7971,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "团队按需用量"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Команда по запросу"
           }
         }
       }
@@ -7362,6 +8112,12 @@
             "state": "translated",
             "value": "不足一小时显示分钟；否则显示重置日期和时间。"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Минуты, если до сброса меньше часа; иначе дата и время сброса."
+          }
         }
       }
     },
@@ -7390,6 +8146,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "距离用量重置还有多久，例如 3 Days 3h 或 3h 20m。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Время до сброса использования, например 3 дня 3 ч или 3 ч 20 мин."
           }
         }
       }
@@ -7420,6 +8182,12 @@
             "state": "translated",
             "value": "%lld 天 %lld 小时后重置"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Сброс через %lld дн. %lld ч"
+          }
         }
       }
     },
@@ -7448,6 +8216,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "%lld 天 %lld 小时后重置"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Сброс через %lld дн. %lld ч"
           }
         }
       }
@@ -7478,6 +8252,12 @@
             "state": "translated",
             "value": "%lld 小时 %lld 分钟后重置"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Сброс через %lld ч %lld мин"
+          }
         }
       }
     },
@@ -7506,6 +8286,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "屏幕上什么都没有。应用图标选「菜单栏」时，读数仍在菜单栏菜单里。否则，从「应用程序」再打开 Codenotch，才能回到这些设置。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "На экране ничего нет. Если значок приложения находится в строке меню, показания остаются в её меню. Иначе снова откройте Codenotch из папки «Программы», чтобы вернуть эти настройки."
           }
         }
       }
@@ -7606,6 +8392,12 @@
             "state": "translated",
             "value": "刘海只出现在有菜单栏的显示器上。"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Панель появляется только на дисплее со строкой меню."
+          }
         }
       }
     },
@@ -7634,6 +8426,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "每个显示器各有一个刘海，悬停只会打开那一个。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "На каждом дисплее есть своя панель, и наведение открывает только её."
           }
         }
       }
@@ -7769,6 +8567,12 @@
             "state": "translated",
             "value": "够注意到，也够被忽略。"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Достаточно долго, чтобы заметить, и достаточно коротко, чтобы не мешать."
+          }
         }
       }
     },
@@ -7797,6 +8601,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "够读完会话名称并伸手过去。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Достаточно долго, чтобы прочитать название сеанса и открыть его."
           }
         }
       }
@@ -7827,6 +8637,12 @@
             "state": "translated",
             "value": "会一直留到你有机会抬头看。"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Остаётся открытой, пока вы не успеете на неё посмотреть."
+          }
         }
       }
     },
@@ -7855,6 +8671,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "设备强调色"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Акцентный цвет устройства"
           }
         }
       }
@@ -7885,6 +8707,12 @@
             "state": "translated",
             "value": "已连接"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Подключён"
+          }
         }
       }
     },
@@ -7913,6 +8741,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "未连接"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Не подключён"
           }
         }
       }
@@ -7943,6 +8777,12 @@
             "state": "translated",
             "value": "账号"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Аккаунты"
+          }
         }
       }
     },
@@ -7971,6 +8811,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "通知"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Уведомления"
           }
         }
       }
@@ -8001,6 +8847,12 @@
             "state": "translated",
             "value": "没有已连接的服务，刘海里没有圆环可画。"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ничего не подключено, поэтому панели нечего отображать."
+          }
         }
       }
     },
@@ -8029,6 +8881,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "刘海按这个顺序画。拖动一行的手柄即可改顺序。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Панель отображает эти кольца в таком порядке. Перетащите кольцо за маркер, чтобы изменить порядок."
           }
         }
       }
@@ -8059,6 +8917,12 @@
             "state": "translated",
             "value": "这些没有圆环可放。打开其中一个，它会接到上面列表的末尾。"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "У этих провайдеров нет кольца. Включите один, и он добавится в конец списка выше."
+          }
         }
       }
     },
@@ -8087,6 +8951,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "刘海"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Панель"
           }
         }
       }
@@ -8117,6 +8987,12 @@
             "state": "translated",
             "value": "重置时间"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Время сброса"
+          }
         }
       }
     },
@@ -8145,6 +9021,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "显示器"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Дисплеи"
           }
         }
       }
@@ -8175,6 +9057,12 @@
             "state": "translated",
             "value": "显示器"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Дисплей"
+          }
         }
       }
     },
@@ -8203,6 +9091,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "跟随活动窗口"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Следовать за активным окном"
           }
         }
       }
@@ -8233,6 +9127,12 @@
             "state": "translated",
             "value": "不可用的显示器"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Недоступный дисплей"
+          }
         }
       }
     },
@@ -8261,6 +9161,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "应用"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Приложение"
           }
         }
       }
@@ -8291,6 +9197,12 @@
             "state": "translated",
             "value": "强调色"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Акцентный цвет"
+          }
         }
       }
     },
@@ -8319,6 +9231,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "会话结束时"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "При завершении сеанса"
           }
         }
       }
@@ -8349,6 +9267,12 @@
             "state": "translated",
             "value": "短暂打开刘海"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ненадолго открыть панель"
+          }
         }
       }
     },
@@ -8377,6 +9301,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "持续"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "На"
           }
         }
       }
@@ -8407,6 +9337,12 @@
             "state": "translated",
             "value": "播放声音"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Воспроизводить звук"
+          }
         }
       }
     },
@@ -8435,6 +9371,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "已完成"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Завершено"
           }
         }
       }
@@ -8465,6 +9407,12 @@
             "state": "translated",
             "value": "在等你"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ожидает вас"
+          }
         }
       }
     },
@@ -8493,6 +9441,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "额度提醒"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Оповещения о порогах"
           }
         }
       }
@@ -8523,6 +9477,12 @@
             "state": "translated",
             "value": "隐藏边栏"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Скрыть боковую панель"
+          }
         }
       }
     },
@@ -8551,6 +9511,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "显示边栏"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Показать боковую панель"
           }
         }
       }
@@ -8581,6 +9547,12 @@
             "state": "translated",
             "value": "已选中"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Выбрано"
+          }
         }
       }
     },
@@ -8609,6 +9581,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "未选中"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Не выбрано"
           }
         }
       }
@@ -8639,6 +9617,12 @@
             "state": "translated",
             "value": "%@（缺失）"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ (отсутствует)"
+          }
         }
       }
     },
@@ -8667,6 +9651,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "播放 %@"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Воспроизвести %@"
           }
         }
       }
@@ -8697,6 +9687,12 @@
             "state": "translated",
             "value": "每月预算"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Месячный бюджет"
+          }
         }
       }
     },
@@ -8725,6 +9721,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "无"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Нет"
           }
         }
       }
@@ -8755,6 +9757,12 @@
             "state": "translated",
             "value": "token"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "токенов"
+          }
         }
       }
     },
@@ -8783,6 +9791,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "%@ 额度已用尽"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Достигнут лимит %@"
           }
         }
       }
@@ -8813,6 +9827,12 @@
             "state": "translated",
             "value": "%@ 已用 %lld%%"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Использование %@ — %lld%%"
+          }
         }
       }
     },
@@ -8842,6 +9862,12 @@
             "state": "translated",
             "value": "它的 %@ 额度已用完。"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Лимит %@ исчерпан."
+          }
         }
       }
     },
@@ -8870,6 +9896,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "它的 %@ 额度已用完 — %@ 重置"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Лимит %@ исчерпан — сброс %@"
           }
         }
       }
@@ -8935,6 +9967,12 @@
             "state": "translated",
             "value": "移到正在接收键盘输入的窗口所在的显示器。"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Перемещается на дисплей с окном, получающим ввод с клавиатуры."
+          }
         }
       }
     },
@@ -8963,6 +10001,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "固定在 %@。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Закреплено на %@."
           }
         }
       }
@@ -8993,6 +10037,12 @@
             "state": "translated",
             "value": "那台显示器已断开。Codenotch 会跟随活动窗口，直到它回来。"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Этот дисплей отключён. Codenotch следует за активным окном, пока дисплей не вернётся."
+          }
         }
       }
     },
@@ -9021,6 +10071,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "拖动以改顺序。刘海按这个顺序画圆环。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Перетащите, чтобы изменить порядок. Панель отображает кольца в этом порядке."
           }
         }
       }
@@ -9051,6 +10107,12 @@
             "state": "translated",
             "value": "打开后，刘海里会出现它的圆环。"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Включите, чтобы добавить провайдеру кольцо на панели."
+          }
         }
       }
     },
@@ -9079,6 +10141,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "%@ 的提醒已静音。点击取消静音。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Оповещения для %@ отключены. Нажмите, чтобы включить их."
           }
         }
       }
@@ -9109,6 +10177,12 @@
             "state": "translated",
             "value": "当 %@ 的额度越过 80% 和 100% 时提醒。"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Оповещать, когда %@ достигает 80% и 100% лимита."
+          }
         }
       }
     },
@@ -9137,6 +10211,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "按你设定的上限填充圆环；Google 不为 API 密钥公布额度。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Заполняет кольцо до выбранного предела; Google не публикует предел для API-ключа."
           }
         }
       }
@@ -9167,6 +10247,12 @@
             "state": "translated",
             "value": "Codenotch 读取这台 Mac 上已经登录的工具的用量 — 从不问你的密码。安装并登录 Claude Code（终端工具，不是 Claude 应用）、Cursor（编辑器或 cursor-agent）、Codex、Antigravity、GLM、Grok、OpenCode、GitHub Copilot 或 Gemini API 密钥（经由 Gemini CLI、OpenCode 或 Hermes）中的任意一个，刘海里就会出现对应的圆环。"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Codenotch читает использование из инструментов, уже авторизованных на этом Mac, и никогда не спрашивает пароль. Установите и авторизуйтесь в Claude Code (терминальном инструменте, не приложении Claude), Cursor (редакторе или cursor-agent), Codex, Antigravity, GLM, Grok, OpenCode, GitHub Copilot или Gemini API через Gemini CLI, OpenCode или Hermes — и кольцо появится на панели."
+          }
         }
       }
     },
@@ -9195,6 +10281,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "macOS 会询问一次，是否允许读取 Claude Code、Antigravity 和 cursor-agent 已保存的登录信息。请选「始终允许」— 只选「允许」的话，每次都会再问。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macOS один раз запросит доступ к сохранённым входам Claude Code, Antigravity и cursor-agent. Выберите «Разрешать всегда» — обычное «Разрешить» приводит к повторному запросу."
           }
         }
       }
@@ -9225,6 +10317,12 @@
             "state": "translated",
             "value": "可以重排圆环、选择显示器，额度快用尽时会通知你。"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Меняйте порядок колец, выбирайте дисплей и получайте уведомления о приближении лимита."
+          }
         }
       }
     },
@@ -9253,6 +10351,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "拖动以重排圆环"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Перетащите, чтобы изменить порядок колец"
           }
         }
       }
@@ -9283,6 +10387,12 @@
             "state": "translated",
             "value": "设置分成「已连接」和「未连接」；拖动已连接行的手柄，即可改变刘海绘制顺序。"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Настройки разделены на «Подключённые» и «Не подключённые»; перетащите подключённую строку за маркер, чтобы изменить порядок на панели."
+          }
         }
       }
     },
@@ -9311,6 +10421,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "把刘海钉在一台显示器上，或在每一台上显示"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Закрепите панель на одном дисплее или показывайте её на всех"
           }
         }
       }
@@ -9341,6 +10457,12 @@
             "state": "translated",
             "value": "外观里的「显示器」可选主显示器或全部；第二个选择器把单个刘海钉在指定屏幕上。"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Выбор дисплея в разделе «Внешний вид» предлагает основной дисплей или все дисплеи; второй выбор закрепляет панель на указанном экране."
+          }
         }
       }
     },
@@ -9369,6 +10491,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "圆环越过 80% 和 100% 时会说明"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Кольцо сообщает о достижении 80% и 100%"
           }
         }
       }
@@ -9399,6 +10527,12 @@
             "state": "translated",
             "value": "每次越过发一条系统通知，可在该服务自己的设置行里静音。"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Системное уведомление при каждом пересечении порога; для каждого провайдера его можно отключить в строке настроек."
+          }
         }
       }
     },
@@ -9427,6 +10561,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "GitHub Copilot 成了新的圆环"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GitHub Copilot — новое кольцо"
           }
         }
       }
@@ -9457,6 +10597,12 @@
             "state": "translated",
             "value": "用这台 Mac 上已有的 GitHub CLI 会话读取 Copilot 配额接口。"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Читает квоту Copilot через API GitHub, используя уже существующую сессию GitHub CLI на Mac."
+          }
         }
       }
     },
@@ -9485,6 +10631,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "会话结束时会告诉你"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Сообщать о завершении сеанса"
           }
         }
       }
@@ -9515,6 +10667,12 @@
             "state": "translated",
             "value": "助手停止工作或开始等你时，刘海会自己打开几秒并响一声；点击会跳过去。"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Панель открывается на несколько секунд и издаёт сигнал, когда агент завершает работу или начинает ждать вас; щелчок открывает сеанс."
+          }
         }
       }
     },
@@ -9543,6 +10701,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "按住 ⌥ 沿边缘拖动胶囊"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Перетаскивайте панель вдоль края с ⌥"
           }
         }
       }
@@ -9573,6 +10737,12 @@
             "state": "translated",
             "value": "把它挪开，避开钉在同一位置的其他菜单栏应用；按边缘记住。"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Сдвиньте её, чтобы освободить место для другого приложения в строке меню; положение запоминается для каждого края."
+          }
         }
       }
     },
@@ -9601,6 +10771,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "选择强调色"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Выберите акцентный цвет"
           }
         }
       }
@@ -9631,6 +10807,12 @@
             "state": "translated",
             "value": "默认用设备强调色，也可以给圆环的正常状态固定一个颜色 — 琥珀和红色警告色始终不变。"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "По умолчанию используется акцент устройства или фиксированный цвет положительного состояния кольца; янтарный и красный цвета предупреждений не меняются."
+          }
         }
       }
     },
@@ -9659,6 +10841,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "用倒计时代替重置日期"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Обратный отсчёт вместо даты сброса"
           }
         }
       }
@@ -9689,6 +10877,12 @@
             "state": "translated",
             "value": "外观里的「重置时间」可以显示「3 小时 20 分钟后重置」，而不是日期和时间。"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "В выборе времени сброса в разделе «Внешний вид» можно показывать «Сброс через 3 ч 20 мин» вместо даты и времени."
+          }
         }
       }
     },
@@ -9717,6 +10911,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "可以从 cursor-agent 读取 Cursor，企业套餐也能读对"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Корректное чтение Cursor через cursor-agent и корпоративных тарифов"
           }
         }
       }
@@ -9747,6 +10947,12 @@
             "state": "translated",
             "value": "只用 CLI 登录的 Cursor 现在也有圆环；企业/团队套餐会读到真实用量，而不再显示没有可计量的额度。"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Вход в Cursor только через CLI теперь получает кольцо, а корпоративные и командные тарифы показывают настоящее использование."
+          }
         }
       }
     },
@@ -9775,6 +10981,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Claude 和 Antigravity 的钥匙串提示更少"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Меньше запросов связки ключей для Claude и Antigravity"
           }
         }
       }
@@ -9805,6 +11017,12 @@
             "state": "translated",
             "value": "Claude 先读自己 CLI 的 /usage，只有退路才碰钥匙串；Antigravity 会先问它的语言服务器。"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Claude сначала читает /usage собственного CLI и обращается к связке ключей только как к запасному варианту; Antigravity сначала опрашивает языковой сервер."
+          }
         }
       }
     },
@@ -9833,6 +11051,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "不到 1% 的用量不再显示成 0%"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Использование меньше 1% больше не отображается как 0%"
           }
         }
       }
@@ -9863,6 +11087,12 @@
             "state": "translated",
             "value": "不到百分之一的读数会显示到十分位（「<0.1%」），而不是四舍五入成没有。"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Показание меньше одного процента отображается с десятичной долей («<0,1%»), а не округляется до нуля."
+          }
         }
       }
     },
@@ -9892,6 +11122,12 @@
             "state": "translated",
             "value": "贡献者可以在没有 Xcode 签名的情况下构建"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Разработчики могут собирать без подписи Xcode"
+          }
         }
       }
     },
@@ -9920,6 +11156,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "维护者证书不在时，make build 和 make test 会自动签名；CI 现在会在每次 push 和 pull request 上跑测试套件。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "make build и make test автоматически подписывают сборку при отсутствии сертификата сопровождающего, а CI запускает тесты при каждом push и pull request."
           }
         }
       }
@@ -10090,6 +11332,12 @@
             "state": "translated",
             "value": "显示用量节奏"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Показывать темп использования"
+          }
         }
       }
     },
@@ -10118,6 +11366,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "把每段有时限的额度与距离重置的时间比较，显示透支还是留有余量。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Сравнивает каждый лимит по времени с оставшимся до сброса временем и показывает дефицит или запас квоты."
           }
         }
       }
@@ -10148,6 +11402,12 @@
             "state": "translated",
             "value": "大小"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Размер"
+          }
         }
       }
     },
@@ -10176,6 +11436,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "小"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Маленький"
           }
         }
       }
@@ -10206,6 +11472,12 @@
             "state": "translated",
             "value": "中"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Средний"
+          }
         }
       }
     },
@@ -10234,6 +11506,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "大"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Большой"
           }
         }
       }
@@ -10264,6 +11542,12 @@
             "state": "translated",
             "value": "边缘上占得最少。能读，但隔着桌子就不行。"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Занимает минимум места у края. Читается вблизи, но не издалека."
+          }
         }
       }
     },
@@ -10292,6 +11576,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "刘海绘制时的尺寸。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Размер, для которого была отрисована панель."
           }
         }
       }
@@ -10322,6 +11612,12 @@
             "state": "translated",
             "value": "一眼更好读，也更难忽视。"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Легче читать одним взглядом, но сложнее не заметить."
+          }
         }
       }
     },
@@ -10350,6 +11646,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "按住 ⌥ 拖动刘海，沿边缘滑动。每条边都会记住你放的位置。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Удерживайте ⌥ и перетаскивайте панель вдоль края. Для каждого края запоминается последнее положение."
           }
         }
       }
@@ -10415,6 +11717,12 @@
             "state": "translated",
             "value": "%@% 透支"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "дефицит %@%"
+          }
         }
       }
     },
@@ -10443,6 +11751,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "%@% 预留"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "резерв %@%"
           }
         }
       }
@@ -10508,6 +11822,12 @@
             "state": "translated",
             "value": "在 ~/.codex-%@ 登录 Codex 以读取用量"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Войдите в Codex в ~/.codex-%@, чтобы читать использование"
+          }
         }
       }
     },
@@ -10536,6 +11856,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "用 Command Code 应用登录以读取用量"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Войдите через приложение Command Code, чтобы читать использование"
           }
         }
       }
@@ -10566,6 +11892,12 @@
             "state": "translated",
             "value": "在设置里填写 Ollama API 密钥，或导出 OLLAMA_API_KEY"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Введите API-ключ Ollama в настройках или экспортируйте OLLAMA_API_KEY"
+          }
         }
       }
     },
@@ -10594,6 +11926,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "启动 Ollama 以监视本地模型"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Запустите Ollama, чтобы отслеживать локальные модели"
           }
         }
       }
@@ -10624,6 +11962,12 @@
             "state": "translated",
             "value": "在下方填写 Ollama API 密钥，或在 shell 里导出 OLLAMA_API_KEY。"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Введите API-ключ Ollama ниже или экспортируйте OLLAMA_API_KEY в оболочке."
+          }
         }
       }
     },
@@ -10652,6 +11996,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "用 Command Code 应用登录 — 它会写入 ~/.commandcode/auth.json，刘海会读它。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Войдите через приложение Command Code — оно записывает ~/.commandcode/auth.json, откуда панель читает данные."
           }
         }
       }
@@ -10682,6 +12032,12 @@
             "state": "translated",
             "value": "这个 Command Code 账号目前没有可计量的额度"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Для этого аккаунта Command Code пока нет измеряемого использования"
+          }
         }
       }
     },
@@ -10710,6 +12066,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "每月用量"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Месячное использование"
           }
         }
       }
@@ -10740,6 +12102,12 @@
             "state": "translated",
             "value": "会话用量"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Использование сеанса"
+          }
         }
       }
     },
@@ -10768,6 +12136,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "每周用量"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Недельное использование"
           }
         }
       }
@@ -10798,6 +12172,12 @@
             "state": "translated",
             "value": "本地模型"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Локальные модели"
+          }
         }
       }
     },
@@ -10826,6 +12206,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "本机"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Локальный компьютер"
           }
         }
       }
@@ -10856,6 +12242,12 @@
             "state": "translated",
             "value": "Codenotch 读取这台 Mac 上已经登录的工具的用量 — 从不问你的密码。安装并登录 Claude Code（终端工具，不是 Claude 应用）、Cursor（编辑器或 cursor-agent）、Codex、Antigravity、GLM、Grok、OpenCode、Command Code、GitHub Copilot 或 Gemini API 密钥（经由 Gemini CLI、OpenCode 或 Hermes）中的任意一个，刘海里就会出现对应的圆环。"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Codenotch читает использование из инструментов, уже авторизованных на этом Mac, и никогда не спрашивает пароль. Установите и авторизуйтесь в Claude Code (терминальном инструменте, не приложении Claude), Cursor (редакторе или cursor-agent), Codex, Antigravity, GLM, Grok, OpenCode, Command Code, GitHub Copilot или Gemini API через Gemini CLI, OpenCode или Hermes — и кольцо появится на панели."
+          }
         }
       }
     },
@@ -10872,6 +12264,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "已完成"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "завершено"
           }
         }
       }
@@ -10936,6 +12334,12 @@
             "state": "translated",
             "value": "本地会话"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Локальный сеанс"
+          }
         }
       }
     },
@@ -10975,6 +12379,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "请先运行 Antigravity IDE，才能读取此账号。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Убедитесь, что Antigravity IDE запущена, чтобы читать этот аккаунт."
           }
         }
       }
@@ -11016,6 +12426,12 @@
             "state": "translated",
             "value": "5 小时额度"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Лимит на 5 часов"
+          }
         }
       }
     },
@@ -11032,6 +12448,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "每周额度"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Недельный лимит"
           }
         }
       }
@@ -11050,6 +12472,12 @@
             "state": "translated",
             "value": "液态玻璃"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Жидкое стекло"
+          }
         }
       }
     },
@@ -11066,6 +12494,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "纯黑"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Сплошной чёрный"
           }
         }
       }
@@ -11084,6 +12518,12 @@
             "state": "translated",
             "value": "系统液态玻璃。跟随这台 Mac 的外观设置，包括通透或着色玻璃，以及浅色或深色模式。"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Системное жидкое стекло. Следует настройкам внешнего вида Mac, включая прозрачное или тонированное стекло и светлый или тёмный режим."
+          }
         }
       }
     },
@@ -11100,6 +12540,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "原来的不透明黑刘海。无论 Mac 外观如何，始终是深色。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Исходная непрозрачная чёрная панель. Всегда тёмная независимо от внешнего вида Mac."
           }
         }
       }
@@ -11118,6 +12564,12 @@
             "state": "translated",
             "value": "周额度有了自己的圆环，液态玻璃，法语，以及直接从 Claude Desktop 自己的缓存读取用量。"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Второе недельное кольцо, Liquid Glass, французский язык и Claude Desktop читаются напрямую из собственного кэша."
+          }
         }
       }
     },
@@ -11134,6 +12586,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "周额度有了自己的圆环"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Неделя получает отдельное кольцо"
           }
         }
       }
@@ -11152,6 +12610,12 @@
             "state": "translated",
             "value": "第二条弧，画在主环内侧或外侧，给同时公布每周额度和会话额度的服务。默认关闭；外观里有开关。"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Вторая дуга внутри основного кольца или снаружи для провайдеров с недельным и сеансовым лимитами. По умолчанию выключена; переключатель находится во «Внешнем виде»."
+          }
         }
       }
     },
@@ -11169,6 +12633,12 @@
             "state": "translated",
             "value": "展开的刘海、提示卡和设置圆球用上系统自己的玻璃表面，折射背后的内容，而不是盖在上面。「降低透明度」会变成实心。"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Открытая панель, её подсказка и кнопка настроек используют системную стеклянную поверхность и преломляют фон. При уменьшении прозрачности они становятся сплошными."
+          }
         }
       }
     },
@@ -11182,6 +12652,12 @@
           }
         },
         "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Français"
+          }
+        },
+        "ru": {
           "stringUnit": {
             "state": "translated",
             "value": "Français"
@@ -11203,6 +12679,12 @@
             "state": "translated",
             "value": "外观里第三种语言，与 English 和 简体中文并列。"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Третий язык во «Внешнем виде» наряду с английским и 简体中文."
+          }
         }
       }
     },
@@ -11219,6 +12701,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Claude Desktop 用量，从它自己的缓存读取"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Использование Claude Desktop из собственного кэша"
           }
         }
       }
@@ -11237,6 +12725,12 @@
             "state": "translated",
             "value": "读取 Claude 账号的第三条路径，在 CLI 和令牌答不上来时使用。什么都不会发出去：缓存就在这台 Mac 上，只做解压。"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Третий способ читать аккаунт Claude, когда CLI и токен не отвечают. Данные никуда не отправляются: кэш находится на этом Mac и только распаковывается."
+          }
         }
       }
     },
@@ -11253,6 +12747,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "能找到 npm 安装的 Claude Code"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Claude Code найден там, куда его установил npm"
           }
         }
       }
@@ -11271,6 +12771,12 @@
             "state": "translated",
             "value": "nvm、Volta 或 pnpm 下的安装也会被找到，这些安装的后台登录续期也一并恢复。"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Установки через nvm, Volta или pnpm обнаруживаются так же, как остальные, и для них снова работает фоновое обновление входа."
+          }
         }
       }
     },
@@ -11287,6 +12793,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "不再留下 transcript 文件夹"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Больше никаких папок с расшифровками"
           }
         }
       }
@@ -11305,6 +12817,12 @@
             "state": "translated",
             "value": "以前每次轮询 Claude 用量都在一个新目录里跑，Claude Code 会给每一次建一个 transcript 文件夹。现在固定在一处、以 print 模式运行，不再写任何会话。"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Раньше чтение Claude запускалось в новой папке при каждой проверке, а Claude Code создавал там папку расшифровки. Теперь используется одно место и режим печати без записи сеанса."
+          }
         }
       }
     },
@@ -11321,6 +12839,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "重置时间跟随 Mac 的时钟"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Время сброса следует часам Mac"
           }
         }
       }
@@ -11339,6 +12863,12 @@
             "state": "translated",
             "value": "24 小时制的 Mac 会显示 24 小时制的重置时间，而不是上午、下午。"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "На Mac с 24-часовым форматом время сброса показывается в 24-часовом формате, без AM и PM."
+          }
         }
       }
     },
@@ -11355,6 +12885,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "结束的会话会标明"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Завершённый сеанс отображается как завершённый"
           }
         }
       }
@@ -11373,6 +12909,12 @@
             "state": "translated",
             "value": "助手会话带有完成状态，已经跑完的和还在进行的看起来不一样。"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Сеансы агентов содержат состояние успеха, поэтому завершённый запуск отличается от текущего."
+          }
         }
       }
     },
@@ -11389,6 +12931,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Antigravity：选择哪项额度打头"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Antigravity: выбор основного лимита"
           }
         }
       }
@@ -11407,6 +12955,12 @@
             "state": "translated",
             "value": "主圆环可以跟着指定的额度走，而不一定是最紧的那项；只有 CLI 的安装也算真实账号。"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Основное кольцо может следовать выбранному лимиту, а не самому строгому, и установка только через CLI считается полноценным аккаунтом."
+          }
         }
       }
     },
@@ -11423,6 +12977,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "只有硬件刘海才会唤醒贴上去的刘海"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Панель, объединённая с выемкой, просыпается только от аппаратной выемки"
           }
         }
       }
@@ -11441,6 +13001,12 @@
             "state": "translated",
             "value": "和摄像头凹槽合在一起的刘海，不再被整条上边缘任意位置的指针唤醒。"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Панель, объединённая с камерой, больше не просыпается от указателя в любой точке верхнего края."
+          }
         }
       }
     },
@@ -11457,6 +13023,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "每周圆环"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Недельное кольцо"
           }
         }
       }
@@ -11475,6 +13047,12 @@
             "state": "translated",
             "value": "表面"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Поверхность"
+          }
         }
       }
     },
@@ -11492,6 +13070,12 @@
             "state": "translated",
             "value": "刘海显示"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Показания панели"
+          }
         }
       }
     },
@@ -11508,6 +13092,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "选择 Antigravity 在主刘海里显示哪项额度。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Выберите лимит, который отображается на основной панели Antigravity."
           }
         }
       }
@@ -11595,6 +13185,12 @@
             "state": "translated",
             "value": "每个服务一个圆环，显示主额度。每周额度仍在提示卡里。"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Одно кольцо на провайдера с основным лимитом. Недельная квота остаётся в карточке при наведении."
+          }
         }
       }
     },
@@ -11611,6 +13207,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "一条更细的每周额度圆环，画在主环内侧。和工作指示共用那个空隙。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Тонкое кольцо недельного лимита внутри основного. Оно делит зазор с индикатором работы."
           }
         }
       }
@@ -11629,6 +13231,12 @@
             "state": "translated",
             "value": "一条更细的每周额度圆环，画在主环外侧，圆环和刘海边缘之间的空隙里。"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Тонкое кольцо недельного лимита вокруг основного, в промежутке между кольцом и краем панели."
+          }
         }
       }
     },
@@ -11645,6 +13253,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "在终端运行 %@ 以登录 %@。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Запустите %@ в Терминале, чтобы войти в %@."
           }
         }
       }
@@ -11663,6 +13277,12 @@
             "state": "translated",
             "value": "今日请求 · 上次使用 %@"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Запросов сегодня · последний запуск %@"
+          }
         }
       }
     },
@@ -11679,6 +13299,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "昨天"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "вчера"
           }
         }
       }
@@ -11697,6 +13323,12 @@
             "state": "translated",
             "value": "%lld 天前"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld дн. назад"
+          }
         }
       }
     },
@@ -11713,6 +13345,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "个人"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Личный"
           }
         }
       }
@@ -11731,6 +13369,12 @@
             "state": "translated",
             "value": "Gemini 模型"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Модели Gemini"
+          }
         }
       }
     },
@@ -11747,6 +13391,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "5 小时额度"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Лимит на 5 часов"
           }
         }
       }
@@ -11765,6 +13415,12 @@
             "state": "translated",
             "value": "Claude 和 GPT 模型"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Модели Claude и GPT"
+          }
         }
       }
     },
@@ -11781,6 +13437,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "提问"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Вопрос"
           }
         }
       }
@@ -11799,6 +13461,12 @@
             "state": "translated",
             "value": "批准"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Подтверждение"
+          }
         }
       }
     },
@@ -11815,6 +13483,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "权限"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Разрешение"
           }
         }
       }
@@ -11833,6 +13507,12 @@
             "state": "translated",
             "value": "需要你的输入"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "требуется ваш ответ"
+          }
         }
       }
     },
@@ -11849,6 +13529,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "正在 %@ 中工作"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Работает в %@"
           }
         }
       }
@@ -11867,6 +13553,12 @@
             "state": "translated",
             "value": "连接"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Подключение"
+          }
         }
       }
     },
@@ -11883,6 +13575,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "预设"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Предустановка"
           }
         }
       }
@@ -11901,6 +13599,12 @@
             "state": "translated",
             "value": "自定"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Пользовательский"
+          }
         }
       }
     },
@@ -11917,6 +13621,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "预设大小"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Размер предустановки"
           }
         }
       }
@@ -11935,6 +13645,12 @@
             "state": "translated",
             "value": "整体缩放表面 — 圆环、文字和提示卡一起变，比例保持原样。100% 是刘海设计时的尺寸。"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Масштабирует всю поверхность — кольца, текст и подсказку — сохраняя пропорции. 100% — исходный размер панели."
+          }
         }
       }
     },
@@ -11952,6 +13668,12 @@
             "state": "translated",
             "value": "Ollama API 密钥"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API-ключ Ollama"
+          }
         }
       }
     },
@@ -11968,6 +13690,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "粘贴密钥"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Вставьте ключ"
           }
         }
       }
@@ -12032,6 +13760,12 @@
             "state": "translated",
             "value": "%@ 用量需要重新登录 — 在终端里运行一次 `claude`。"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Для использования %@ нужно обновить вход — один раз запустите `claude` в терминале."
+          }
         }
       }
     },
@@ -12048,6 +13782,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "%@ %@ · 来自 Ollama"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ %@ · через Ollama"
           }
         }
       }
@@ -12066,6 +13806,12 @@
             "state": "translated",
             "value": "已从刘海隐藏 · 仍加载在 Ollama"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Скрыто на панели · Загружено в Ollama"
+          }
         }
       }
     },
@@ -12082,6 +13828,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "在刘海里显示或隐藏此模型。它仍加载在 Ollama 中。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Показывать или скрывать эту модель на панели. В Ollama она остаётся загруженной."
           }
         }
       }
@@ -12100,6 +13852,12 @@
             "state": "translated",
             "value": "思考中"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Размышление"
+          }
         }
       }
     },
@@ -12116,6 +13874,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "%@ · 本地"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ · Локально"
           }
         }
       }
@@ -12134,6 +13898,12 @@
             "state": "translated",
             "value": "这段时间还没有 Ollama 用量记录。"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "За этот период использование Ollama ещё не записано."
+          }
         }
       }
     },
@@ -12150,6 +13920,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "未使用重置"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Неиспользованные сбросы"
           }
         }
       }
@@ -12168,6 +13944,12 @@
             "state": "translated",
             "value": "暂无未使用重置"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Нет неиспользованных сбросов"
+          }
         }
       }
     },
@@ -12184,6 +13966,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "1 次未使用重置"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 неиспользованный сброс"
           }
         }
       }
@@ -12202,6 +13990,12 @@
             "state": "translated",
             "value": "%lld 次未使用重置"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld неиспользованных сбросов"
+          }
         }
       }
     },
@@ -12219,6 +14013,12 @@
             "state": "translated",
             "value": "%@ 到期"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Истекает %@"
+          }
         }
       }
     },
@@ -12235,6 +14035,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "下次 %@ 到期"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Следующий истекает %@"
           }
         }
       }

--- a/Sources/Localizable.xcstrings
+++ b/Sources/Localizable.xcstrings
@@ -4,6 +4,12 @@
     "just now": {
       "extractionState": "manual",
       "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "только что"
+          }
+        },
         "fr": {
           "stringUnit": {
             "state": "translated",
@@ -33,6 +39,12 @@
     "%lld min": {
       "extractionState": "manual",
       "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld мин"
+          }
+        },
         "fr": {
           "stringUnit": {
             "state": "translated",
@@ -62,6 +74,12 @@
     "%lld hr": {
       "extractionState": "manual",
       "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld ч"
+          }
+        },
         "fr": {
           "stringUnit": {
             "state": "translated",
@@ -91,6 +109,12 @@
     "%lld hr %lld min": {
       "extractionState": "manual",
       "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld ч %lld мин"
+          }
+        },
         "fr": {
           "stringUnit": {
             "state": "translated",
@@ -120,6 +144,12 @@
     "%@ ago": {
       "extractionState": "manual",
       "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ назад"
+          }
+        },
         "fr": {
           "stringUnit": {
             "state": "translated",
@@ -149,6 +179,12 @@
     "Resetting…": {
       "extractionState": "manual",
       "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Сброс…"
+          }
+        },
         "fr": {
           "stringUnit": {
             "state": "translated",
@@ -178,6 +214,12 @@
     "Resets in %lld min": {
       "extractionState": "manual",
       "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Сброс через %lld мин"
+          }
+        },
         "fr": {
           "stringUnit": {
             "state": "translated",
@@ -236,6 +278,12 @@
     "%lld%% Used · %lld%% left": {
       "extractionState": "manual",
       "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Использовано %lld%% · осталось %lld%%"
+          }
+        },
         "fr": {
           "stringUnit": {
             "state": "translated",
@@ -265,6 +313,12 @@
     "1 left": {
       "extractionState": "manual",
       "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Остался 1"
+          }
+        },
         "fr": {
           "stringUnit": {
             "state": "translated",
@@ -294,6 +348,12 @@
     "%lld left": {
       "extractionState": "manual",
       "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Осталось %lld"
+          }
+        },
         "fr": {
           "stringUnit": {
             "state": "translated",
@@ -323,6 +383,12 @@
     "1 used": {
       "extractionState": "manual",
       "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Использован 1"
+          }
+        },
         "fr": {
           "stringUnit": {
             "state": "translated",
@@ -352,6 +418,12 @@
     "%lld used": {
       "extractionState": "manual",
       "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Использовано %lld"
+          }
+        },
         "fr": {
           "stringUnit": {
             "state": "translated",
@@ -381,6 +453,12 @@
     "No reading": {
       "extractionState": "manual",
       "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Нет данных"
+          }
+        },
         "fr": {
           "stringUnit": {
             "state": "translated",
@@ -410,6 +488,12 @@
     "%@ until %@": {
       "extractionState": "manual",
       "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ до %@"
+          }
+        },
         "fr": {
           "stringUnit": {
             "state": "translated",
@@ -439,6 +523,12 @@
     "Sign in to Claude Code to read your usage": {
       "extractionState": "manual",
       "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Войдите в Claude Code, чтобы увидеть использование"
+          }
+        },
         "fr": {
           "stringUnit": {
             "state": "translated",
@@ -468,6 +558,12 @@
     "Sign in to Claude Code in ~/.claude-%@ to read your usage": {
       "extractionState": "manual",
       "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Войдите в Claude Code в ~/.claude-%@, чтобы увидеть использование"
+          }
+        },
         "fr": {
           "stringUnit": {
             "state": "translated",
@@ -497,6 +593,12 @@
     "Sign in to Cursor in the editor": {
       "extractionState": "manual",
       "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Войдите в Cursor в редакторе"
+          }
+        },
         "fr": {
           "stringUnit": {
             "state": "translated",
@@ -526,6 +628,12 @@
     "Sign in to Codex to read your usage": {
       "extractionState": "manual",
       "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Войдите в Codex, чтобы увидеть использование"
+          }
+        },
         "fr": {
           "stringUnit": {
             "state": "translated",
@@ -555,6 +663,12 @@
     "Sign in to Antigravity to read your usage": {
       "extractionState": "manual",
       "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Войдите в Antigravity, чтобы увидеть использование"
+          }
+        },
         "fr": {
           "stringUnit": {
             "state": "translated",
@@ -642,6 +756,12 @@
     "Sign in to %@ to read your usage": {
       "extractionState": "manual",
       "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Войдите в %@, чтобы увидеть использование"
+          }
+        },
         "fr": {
           "stringUnit": {
             "state": "translated",
@@ -729,6 +849,12 @@
     "Waiting for the first reading…": {
       "extractionState": "manual",
       "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ожидание первых данных…"
+          }
+        },
         "fr": {
           "stringUnit": {
             "state": "translated",
@@ -758,6 +884,12 @@
     "Current session": {
       "extractionState": "manual",
       "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Текущая сессия"
+          }
+        },
         "fr": {
           "stringUnit": {
             "state": "translated",
@@ -787,6 +919,12 @@
     "All models": {
       "extractionState": "manual",
       "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Все модели"
+          }
+        },
         "fr": {
           "stringUnit": {
             "state": "translated",
@@ -874,6 +1012,12 @@
     "Included usage": {
       "extractionState": "manual",
       "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Включённый объём"
+          }
+        },
         "fr": {
           "stringUnit": {
             "state": "translated",
@@ -903,6 +1047,12 @@
     "API usage": {
       "extractionState": "manual",
       "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Использование API"
+          }
+        },
         "fr": {
           "stringUnit": {
             "state": "translated",
@@ -932,6 +1082,12 @@
     "On demand": {
       "extractionState": "manual",
       "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "По запросу"
+          }
+        },
         "fr": {
           "stringUnit": {
             "state": "translated",
@@ -961,6 +1117,12 @@
     "5h limit": {
       "extractionState": "manual",
       "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Лимит на 5 ч"
+          }
+        },
         "fr": {
           "stringUnit": {
             "state": "translated",
@@ -990,6 +1152,12 @@
     "Weekly limit": {
       "extractionState": "manual",
       "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Недельный лимит"
+          }
+        },
         "fr": {
           "stringUnit": {
             "state": "translated",
@@ -1019,6 +1187,12 @@
     "Monthly limit": {
       "extractionState": "manual",
       "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Месячный лимит"
+          }
+        },
         "fr": {
           "stringUnit": {
             "state": "translated",
@@ -1048,6 +1222,12 @@
     "Daily quota": {
       "extractionState": "manual",
       "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Суточная квота"
+          }
+        },
         "fr": {
           "stringUnit": {
             "state": "translated",
@@ -1077,6 +1257,12 @@
     "Longer window": {
       "extractionState": "manual",
       "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Более длинное окно"
+          }
+        },
         "fr": {
           "stringUnit": {
             "state": "translated",
@@ -1106,6 +1292,12 @@
     "%lldm limit": {
       "extractionState": "manual",
       "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Лимит на %lld мин"
+          }
+        },
         "fr": {
           "stringUnit": {
             "state": "translated",
@@ -1135,6 +1327,12 @@
     "%lldh limit": {
       "extractionState": "manual",
       "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Лимит на %lld ч"
+          }
+        },
         "fr": {
           "stringUnit": {
             "state": "translated",
@@ -1164,6 +1362,12 @@
     "%lldd limit": {
       "extractionState": "manual",
       "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Лимит на %lld дн"
+          }
+        },
         "fr": {
           "stringUnit": {
             "state": "translated",
@@ -1193,6 +1397,12 @@
     "Weekly": {
       "extractionState": "manual",
       "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Недельный"
+          }
+        },
         "fr": {
           "stringUnit": {
             "state": "translated",
@@ -1222,6 +1432,12 @@
     "MCP (1 month)": {
       "extractionState": "manual",
       "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MCP (1 месяц)"
+          }
+        },
         "fr": {
           "stringUnit": {
             "state": "translated",
@@ -1251,6 +1467,12 @@
     "Usage (%lld h)": {
       "extractionState": "manual",
       "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Использование (%lld ч)"
+          }
+        },
         "fr": {
           "stringUnit": {
             "state": "translated",
@@ -1280,6 +1502,12 @@
     "Usage (%lld wk)": {
       "extractionState": "manual",
       "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Использование (%lld нед.)"
+          }
+        },
         "fr": {
           "stringUnit": {
             "state": "translated",
@@ -1309,6 +1537,12 @@
     "Usage": {
       "extractionState": "manual",
       "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Использование"
+          }
+        },
         "fr": {
           "stringUnit": {
             "state": "translated",
@@ -1338,6 +1572,12 @@
     "Pro searches": {
       "extractionState": "manual",
       "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Поиски Pro"
+          }
+        },
         "fr": {
           "stringUnit": {
             "state": "translated",
@@ -1367,6 +1607,12 @@
     "Research": {
       "extractionState": "manual",
       "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Исследования"
+          }
+        },
         "fr": {
           "stringUnit": {
             "state": "translated",
@@ -1396,6 +1642,12 @@
     "Agentic research": {
       "extractionState": "manual",
       "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Агентные исследования"
+          }
+        },
         "fr": {
           "stringUnit": {
             "state": "translated",
@@ -1454,6 +1706,12 @@
     "Free queries": {
       "extractionState": "manual",
       "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Бесплатные запросы"
+          }
+        },
         "fr": {
           "stringUnit": {
             "state": "translated",
@@ -1483,6 +1741,12 @@
     "Requests today · no limit published": {
       "extractionState": "manual",
       "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Запросы сегодня · лимит не указан"
+          }
+        },
         "fr": {
           "stringUnit": {
             "state": "translated",
@@ -1512,6 +1776,12 @@
     "no requests today": {
       "extractionState": "manual",
       "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "сегодня запросов нет"
+          }
+        },
         "fr": {
           "stringUnit": {
             "state": "translated",
@@ -1541,6 +1811,12 @@
     "~%lld request today": {
       "extractionState": "manual",
       "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "сегодня ~%lld запрос"
+          }
+        },
         "fr": {
           "stringUnit": {
             "state": "translated",
@@ -1570,6 +1846,12 @@
     "~%lld requests today": {
       "extractionState": "manual",
       "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "сегодня ~%lld запросов"
+          }
+        },
         "fr": {
           "stringUnit": {
             "state": "translated",
@@ -1599,6 +1881,12 @@
     "Grok Build": {
       "extractionState": "manual",
       "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Grok Build"
+          }
+        },
         "fr": {
           "stringUnit": {
             "state": "translated",
@@ -1628,6 +1916,12 @@
     "%@ Usage": {
       "extractionState": "manual",
       "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Использование %@"
+          }
+        },
         "fr": {
           "stringUnit": {
             "state": "translated",
@@ -1657,6 +1951,12 @@
     "and %lld more": {
       "extractionState": "manual",
       "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "и ещё %lld"
+          }
+        },
         "fr": {
           "stringUnit": {
             "state": "translated",
@@ -1686,6 +1986,12 @@
     "working": {
       "extractionState": "manual",
       "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "работает"
+          }
+        },
         "fr": {
           "stringUnit": {
             "state": "translated",
@@ -1715,6 +2021,12 @@
     "waiting": {
       "extractionState": "manual",
       "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ожидает"
+          }
+        },
         "fr": {
           "stringUnit": {
             "state": "translated",
@@ -1744,6 +2056,12 @@
     "idle": {
       "extractionState": "manual",
       "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "бездействует"
+          }
+        },
         "fr": {
           "stringUnit": {
             "state": "translated",
@@ -1773,6 +2091,12 @@
     "Working": {
       "extractionState": "manual",
       "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Работа"
+          }
+        },
         "fr": {
           "stringUnit": {
             "state": "translated",
@@ -1802,6 +2126,12 @@
     "Desktop": {
       "extractionState": "manual",
       "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Рабочий стол"
+          }
+        },
         "fr": {
           "stringUnit": {
             "state": "translated",
@@ -1860,6 +2190,12 @@
     "Agent": {
       "extractionState": "manual",
       "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Агент"
+          }
+        },
         "fr": {
           "stringUnit": {
             "state": "translated",
@@ -1889,6 +2225,12 @@
     "Terminal": {
       "extractionState": "manual",
       "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Терминал"
+          }
+        },
         "fr": {
           "stringUnit": {
             "state": "translated",
@@ -1918,6 +2260,12 @@
     "Untitled chat": {
       "extractionState": "manual",
       "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Чат без названия"
+          }
+        },
         "fr": {
           "stringUnit": {
             "state": "translated",
@@ -1947,6 +2295,12 @@
     "Always show": {
       "extractionState": "manual",
       "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Всегда показывать"
+          }
+        },
         "fr": {
           "stringUnit": {
             "state": "translated",
@@ -1976,6 +2330,12 @@
     "Show on hover": {
       "extractionState": "manual",
       "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Показывать при наведении"
+          }
+        },
         "fr": {
           "stringUnit": {
             "state": "translated",
@@ -2005,6 +2365,12 @@
     "Hide": {
       "extractionState": "manual",
       "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Скрыть"
+          }
+        },
         "fr": {
           "stringUnit": {
             "state": "translated",
@@ -2034,6 +2400,12 @@
     "The notch stays open with every reading visible.": {
       "extractionState": "manual",
       "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Выемка остаётся открытой, и все данные видны."
+          }
+        },
         "fr": {
           "stringUnit": {
             "state": "translated",
@@ -2063,6 +2435,12 @@
     "A small pill at the screen edge that opens when you reach it.": {
       "extractionState": "manual",
       "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Небольшая панель у края экрана, которая открывается при наведении."
+          }
+        },
         "fr": {
           "stringUnit": {
             "state": "translated",
@@ -2092,6 +2470,12 @@
     "Nothing on screen. Open Codenotch again from Applications to bring these settings back.": {
       "extractionState": "manual",
       "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ничего не показывать. Откройте Codenotch снова из Программ, чтобы вернуть эти настройки."
+          }
+        },
         "fr": {
           "stringUnit": {
             "state": "translated",
@@ -2121,6 +2505,12 @@
     "Dock": {
       "extractionState": "manual",
       "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dock"
+          }
+        },
         "fr": {
           "stringUnit": {
             "state": "translated",
@@ -2150,6 +2540,12 @@
     "Menu bar": {
       "extractionState": "manual",
       "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Строка меню"
+          }
+        },
         "fr": {
           "stringUnit": {
             "state": "translated",
@@ -2179,6 +2575,12 @@
     "Neither": {
       "extractionState": "manual",
       "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ни то ни другое"
+          }
+        },
         "fr": {
           "stringUnit": {
             "state": "translated",
@@ -2208,6 +2610,12 @@
     "A normal app icon in the Dock while Codenotch is running.": {
       "extractionState": "manual",
       "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Обычный значок приложения в Dock во время работы Codenotch."
+          }
+        },
         "fr": {
           "stringUnit": {
             "state": "translated",
@@ -2237,6 +2645,12 @@
     "A small icon in the menu bar instead, and nothing in the Dock.": {
       "extractionState": "manual",
       "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Небольшой значок в строке меню вместо значка в Dock."
+          }
+        },
         "fr": {
           "stringUnit": {
             "state": "translated",
@@ -2266,6 +2680,12 @@
     "No icon anywhere. Open Codenotch again from Applications to bring these settings back.": {
       "extractionState": "manual",
       "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ни одного значка. Откройте Codenotch снова из Программ, чтобы вернуть эти настройки."
+          }
+        },
         "fr": {
           "stringUnit": {
             "state": "translated",
@@ -2295,6 +2715,12 @@
     "Right": {
       "extractionState": "manual",
       "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Справа"
+          }
+        },
         "fr": {
           "stringUnit": {
             "state": "translated",
@@ -2324,6 +2750,12 @@
     "Left": {
       "extractionState": "manual",
       "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Слева"
+          }
+        },
         "fr": {
           "stringUnit": {
             "state": "translated",
@@ -2353,6 +2785,12 @@
     "Top": {
       "extractionState": "manual",
       "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Сверху"
+          }
+        },
         "fr": {
           "stringUnit": {
             "state": "translated",
@@ -2382,6 +2820,12 @@
     "Bottom": {
       "extractionState": "manual",
       "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Снизу"
+          }
+        },
         "fr": {
           "stringUnit": {
             "state": "translated",
@@ -2527,6 +2971,12 @@
     "Integrations": {
       "extractionState": "manual",
       "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Интеграции"
+          }
+        },
         "fr": {
           "stringUnit": {
             "state": "translated",
@@ -2556,6 +3006,12 @@
     "Appearance": {
       "extractionState": "manual",
       "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Внешний вид"
+          }
+        },
         "fr": {
           "stringUnit": {
             "state": "translated",
@@ -2585,6 +3041,12 @@
     "General": {
       "extractionState": "manual",
       "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Общие"
+          }
+        },
         "fr": {
           "stringUnit": {
             "state": "translated",
@@ -2614,6 +3076,12 @@
     "Show": {
       "extractionState": "manual",
       "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Показывать"
+          }
+        },
         "fr": {
           "stringUnit": {
             "state": "translated",
@@ -2643,6 +3111,12 @@
     "Edge": {
       "extractionState": "manual",
       "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Край"
+          }
+        },
         "fr": {
           "stringUnit": {
             "state": "translated",
@@ -2672,6 +3146,12 @@
     "App icon": {
       "extractionState": "manual",
       "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Значок приложения"
+          }
+        },
         "fr": {
           "stringUnit": {
             "state": "translated",
@@ -2701,6 +3181,12 @@
     "Open Codenotch at login": {
       "extractionState": "manual",
       "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Открывать Codenotch при входе"
+          }
+        },
         "fr": {
           "stringUnit": {
             "state": "translated",
@@ -2730,6 +3216,12 @@
     "Install updates automatically": {
       "extractionState": "manual",
       "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Устанавливать обновления автоматически"
+          }
+        },
         "fr": {
           "stringUnit": {
             "state": "translated",
@@ -2759,6 +3251,12 @@
     "Check now": {
       "extractionState": "manual",
       "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Проверить сейчас"
+          }
+        },
         "fr": {
           "stringUnit": {
             "state": "translated",
@@ -2788,6 +3286,12 @@
     "App designed and developed by": {
       "extractionState": "manual",
       "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Приложение разработал"
+          }
+        },
         "fr": {
           "stringUnit": {
             "state": "translated",
@@ -2817,6 +3321,12 @@
     "Connect an assistant to get started": {
       "extractionState": "manual",
       "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Подключите ассистента, чтобы начать"
+          }
+        },
         "fr": {
           "stringUnit": {
             "state": "translated",
@@ -3455,6 +3965,12 @@
     "Sign in to %@": {
       "extractionState": "manual",
       "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Войти в %@"
+          }
+        },
         "fr": {
           "stringUnit": {
             "state": "translated",
@@ -3484,6 +4000,12 @@
     "Sign in to %@ to read this account.": {
       "extractionState": "manual",
       "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Войдите в %@, чтобы использовать этот аккаунт."
+          }
+        },
         "fr": {
           "stringUnit": {
             "state": "translated",
@@ -3513,6 +4035,12 @@
     "Sign in with %@ to read this account.": {
       "extractionState": "manual",
       "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Войдите через %@, чтобы использовать этот аккаунт."
+          }
+        },
         "fr": {
           "stringUnit": {
             "state": "translated",
@@ -3542,6 +4070,12 @@
     "Sign out in the %@ window to use another account.": {
       "extractionState": "manual",
       "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Выйдите из аккаунта в окне %@, чтобы использовать другой."
+          }
+        },
         "fr": {
           "stringUnit": {
             "state": "translated",
@@ -3571,6 +4105,12 @@
     "Switch accounts in %@; the notch follows.": {
       "extractionState": "manual",
       "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Смените аккаунт в %@ — выемка обновится."
+          }
+        },
         "fr": {
           "stringUnit": {
             "state": "translated",
@@ -3600,6 +4140,12 @@
     "Switch accounts in the tool that owns it; the notch follows.": {
       "extractionState": "manual",
       "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Смените аккаунт в приложении, которому он принадлежит — выемка обновится."
+          }
+        },
         "fr": {
           "stringUnit": {
             "state": "translated",
@@ -3629,6 +4175,12 @@
     "Signs out of %@ — the session belongs to Codenotch.": {
       "extractionState": "manual",
       "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Выход из %@ — сессия принадлежит Codenotch."
+          }
+        },
         "fr": {
           "stringUnit": {
             "state": "translated",
@@ -3658,6 +4210,12 @@
     "You stay signed in to %@ — end that session in %@ itself.": {
       "extractionState": "manual",
       "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Вы останетесь вошли в %@ — завершите сессию непосредственно в %@."
+          }
+        },
         "fr": {
           "stringUnit": {
             "state": "translated",
@@ -3716,6 +4274,12 @@
     "Sign in with the tool that owns this account.": {
       "extractionState": "manual",
       "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Войдите через приложение, которому принадлежит этот аккаунт."
+          }
+        },
         "fr": {
           "stringUnit": {
             "state": "translated",
@@ -3745,6 +4309,12 @@
     "Sign in to %@…": {
       "extractionState": "manual",
       "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Войти в %@…"
+          }
+        },
         "fr": {
           "stringUnit": {
             "state": "translated",
@@ -3890,6 +4460,12 @@
     "Unlimited on the %@ plan — nothing to meter": {
       "extractionState": "manual",
       "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Тариф %@ без ограничений — нечего измерять"
+          }
+        },
         "fr": {
           "stringUnit": {
             "state": "translated",
@@ -4035,6 +4611,12 @@
     "Settings…": {
       "extractionState": "manual",
       "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Настройки…"
+          }
+        },
         "fr": {
           "stringUnit": {
             "state": "translated",
@@ -4064,6 +4646,12 @@
     "Quit Codenotch": {
       "extractionState": "manual",
       "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Выйти из Codenotch"
+          }
+        },
         "fr": {
           "stringUnit": {
             "state": "translated",
@@ -4093,6 +4681,12 @@
     "Keep open": {
       "extractionState": "manual",
       "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Оставить открытым"
+          }
+        },
         "fr": {
           "stringUnit": {
             "state": "translated",
@@ -4122,6 +4716,12 @@
     "Refresh now": {
       "extractionState": "manual",
       "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Обновить сейчас"
+          }
+        },
         "fr": {
           "stringUnit": {
             "state": "translated",
@@ -4180,6 +4780,12 @@
     "Checking…": {
       "extractionState": "manual",
       "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Проверка…"
+          }
+        },
         "fr": {
           "stringUnit": {
             "state": "translated",
@@ -4209,6 +4815,12 @@
     "Codenotch is up to date.": {
       "extractionState": "manual",
       "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Codenotch обновлён."
+          }
+        },
         "fr": {
           "stringUnit": {
             "state": "translated",
@@ -4238,6 +4850,12 @@
     "Version %@ is available and will install shortly.": {
       "extractionState": "manual",
       "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Доступна версия %@; она скоро установится."
+          }
+        },
         "fr": {
           "stringUnit": {
             "state": "translated",
@@ -6616,6 +7234,12 @@
     "Refresh all": {
       "extractionState": "manual",
       "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Обновить всё"
+          }
+        },
         "fr": {
           "stringUnit": {
             "state": "translated",
@@ -6645,6 +7269,12 @@
     "Reset date": {
       "extractionState": "manual",
       "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Дата сброса"
+          }
+        },
         "fr": {
           "stringUnit": {
             "state": "translated",
@@ -6674,6 +7304,12 @@
     "Time remaining": {
       "extractionState": "manual",
       "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Оставшееся время"
+          }
+        },
         "fr": {
           "stringUnit": {
             "state": "translated",
@@ -6877,6 +7513,12 @@
     "Main display": {
       "extractionState": "manual",
       "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Основной дисплей"
+          }
+        },
         "fr": {
           "stringUnit": {
             "state": "translated",
@@ -6906,6 +7548,12 @@
     "All displays": {
       "extractionState": "manual",
       "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Все дисплеи"
+          }
+        },
         "fr": {
           "stringUnit": {
             "state": "translated",
@@ -6993,6 +7641,12 @@
     "3 seconds": {
       "extractionState": "manual",
       "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "3 секунды"
+          }
+        },
         "fr": {
           "stringUnit": {
             "state": "translated",
@@ -7022,6 +7676,12 @@
     "5 seconds": {
       "extractionState": "manual",
       "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "5 секунд"
+          }
+        },
         "fr": {
           "stringUnit": {
             "state": "translated",
@@ -7051,6 +7711,12 @@
     "10 seconds": {
       "extractionState": "manual",
       "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "10 секунд"
+          }
+        },
         "fr": {
           "stringUnit": {
             "state": "translated",
@@ -8211,6 +8877,12 @@
     "%lld%% of its %@ limit used.": {
       "extractionState": "manual",
       "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Использовано %lld%% от лимита «%@»."
+          }
+        },
         "fr": {
           "stringUnit": {
             "state": "translated",
@@ -9255,6 +9927,12 @@
     "Follow System": {
       "extractionState": "manual",
       "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Как в системе"
+          }
+        },
         "fr": {
           "stringUnit": {
             "state": "translated",
@@ -9284,6 +9962,12 @@
     "Matches the Mac's preferred language.": {
       "extractionState": "manual",
       "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Соответствует предпочитаемому языку Mac."
+          }
+        },
         "fr": {
           "stringUnit": {
             "state": "translated",
@@ -9313,6 +9997,12 @@
     "Codenotch uses this language even if the Mac does not.": {
       "extractionState": "manual",
       "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Codenotch использует этот язык независимо от языка Mac."
+          }
+        },
         "fr": {
           "stringUnit": {
             "state": "translated",
@@ -9342,6 +10032,12 @@
     "Language": {
       "extractionState": "manual",
       "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Язык"
+          }
+        },
         "fr": {
           "stringUnit": {
             "state": "translated",
@@ -9661,6 +10357,12 @@
     "Recentre": {
       "extractionState": "manual",
       "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "По центру"
+          }
+        },
         "fr": {
           "stringUnit": {
             "state": "translated",
@@ -9748,6 +10450,12 @@
     "Idle": {
       "extractionState": "manual",
       "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Бездействие"
+          }
+        },
         "fr": {
           "stringUnit": {
             "state": "translated",
@@ -10171,6 +10879,12 @@
     "Complete": {
       "extractionState": "manual",
       "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Завершено"
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -10188,6 +10902,12 @@
     "Waiting": {
       "extractionState": "manual",
       "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ожидание"
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -10222,6 +10942,12 @@
     "Active": {
       "extractionState": "manual",
       "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Активно"
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -10256,6 +10982,12 @@
     "Automatic": {
       "extractionState": "manual",
       "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Автоматически"
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -10783,6 +11515,12 @@
     "Off": {
       "extractionState": "manual",
       "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Выкл."
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -10800,6 +11538,12 @@
     "Inside": {
       "extractionState": "manual",
       "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Внутри"
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -10817,6 +11561,12 @@
     "Outside": {
       "extractionState": "manual",
       "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Снаружи"
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -11225,6 +11975,12 @@
     "Save": {
       "extractionState": "manual",
       "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Сохранить"
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -11242,6 +11998,12 @@
     "Saved": {
       "extractionState": "manual",
       "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Сохранено"
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",

--- a/Sources/Settings/AppLanguage.swift
+++ b/Sources/Settings/AppLanguage.swift
@@ -11,6 +11,7 @@ enum AppLanguage: String, CaseIterable, Identifiable {
     case french = "fr"
     case japanese = "ja"
     case brazilianPortuguese = "pt-BR"
+    case russian = "ru"
     case simplifiedChinese = "zh-Hans"
 
     var id: String { rawValue }
@@ -28,11 +29,12 @@ enum AppLanguage: String, CaseIterable, Identifiable {
         case .french:              return Locale(identifier: "fr")
         case .japanese:            return Locale(identifier: "ja")
         case .brazilianPortuguese: return Locale(identifier: "pt-BR")
+        case .russian:             return Locale(identifier: "ru")
         case .simplifiedChinese:   return Locale(identifier: "zh-Hans")
         }
     }
 
-    /// English, Français, 日本語, Português (Brasil) and 简体中文 stay in their
+    /// English, Français, 日本語, Português (Brasil), Русский and 简体中文 stay in their
     /// own language so the row is recognizable when the rest of Settings is in
     /// another one.
     var title: String {
@@ -42,6 +44,7 @@ enum AppLanguage: String, CaseIterable, Identifiable {
         case .french:              return "Français"
         case .japanese:            return "日本語"
         case .brazilianPortuguese: return "Português (Brasil)"
+        case .russian:             return "Русский"
         case .simplifiedChinese:   return "简体中文"
         }
     }
@@ -50,7 +53,7 @@ enum AppLanguage: String, CaseIterable, Identifiable {
         switch self {
         case .system:
             return L10n.t("Matches the Mac's preferred language.")
-        case .english, .french, .japanese, .brazilianPortuguese, .simplifiedChinese:
+        case .english, .french, .japanese, .brazilianPortuguese, .russian, .simplifiedChinese:
             return L10n.t("Codenotch uses this language even if the Mac does not.")
         }
     }

--- a/Tests/AppLanguageTests.swift
+++ b/Tests/AppLanguageTests.swift
@@ -77,4 +77,16 @@ final class AppLanguageTests: XCTestCase {
         L10n.testLocale = nil
         XCTAssertEqual(L10n.locale.identifier, "ja")
     }
+
+    func testRussianIsOfferedAndMapsToRu() {
+        XCTAssertTrue(AppLanguage.allCases.contains(.russian))
+        XCTAssertEqual(AppLanguage.russian.title, "Русский")
+        XCTAssertEqual(AppLanguage.russian.locale?.identifier, "ru")
+    }
+
+    func testApplyRussianStoresTheOverride() {
+        L10n.apply(.russian)
+        L10n.testLocale = nil
+        XCTAssertEqual(L10n.locale.identifier, "ru")
+    }
 }

--- a/Tests/CatalogCoverageTests.swift
+++ b/Tests/CatalogCoverageTests.swift
@@ -19,6 +19,27 @@ final class CatalogCoverageTests: XCTestCase {
         )
     }
 
+    func testRussianCoreCopyIsTranslated() throws {
+        let catalog = try loadCatalog().json
+        let expected = [
+            "just now": "только что",
+            "Resets in %lld min": "Сброс через %lld мин",
+            "%lld%% Used · %lld%% left": "Использовано %lld%% · осталось %lld%%",
+            "Always show": "Всегда показывать",
+            "Settings…": "Настройки…",
+            "Sign in to %@": "Войти в %@",
+            "%lld%% of its %@ limit used.": "Использовано %lld%% от лимита «%@»."
+        ]
+
+        for (key, value) in expected {
+            XCTAssertEqual(
+                catalog.strings[key]?.localizations?["ru"]?.stringUnit?.value,
+                value,
+                "missing Russian translation for \(key)"
+            )
+        }
+    }
+
     // MARK: - Loading
 
     /// Repo `Tests/`, so the catalog is `../Sources/Localizable.xcstrings`.

--- a/Tests/CatalogCoverageTests.swift
+++ b/Tests/CatalogCoverageTests.swift
@@ -40,6 +40,22 @@ final class CatalogCoverageTests: XCTestCase {
         }
     }
 
+    func testRussianCatalogCoversEverySourceKey() throws {
+        let catalog = try loadCatalog().json
+        let missing = catalog.strings.compactMap { key, entry in
+            guard let unit = entry.localizations?["ru"]?.stringUnit,
+                  unit.state == "translated",
+                  let value = unit.value,
+                  !value.isEmpty else { return key }
+            return nil
+        }
+
+        XCTAssertTrue(
+            missing.isEmpty,
+            "missing Russian translations for: \(missing.joined(separator: ", "))"
+        )
+    }
+
     // MARK: - Loading
 
     /// Repo `Tests/`, so the catalog is `../Sources/Localizable.xcstrings`.
@@ -75,5 +91,6 @@ private struct CatalogLocalization: Decodable {
 }
 
 private struct CatalogStringUnit: Decodable {
+    var state: String?
     var value: String?
 }

--- a/Tests/LocalizationTests.swift
+++ b/Tests/LocalizationTests.swift
@@ -8,6 +8,7 @@ final class LocalizationTests: XCTestCase {
     private let zhHans = Locale(identifier: "zh-Hans")
     private let french = Locale(identifier: "fr")
     private let japanese = Locale(identifier: "ja")
+    private let russian = Locale(identifier: "ru")
     private let brazilianPortuguese = Locale(identifier: "pt-BR")
     private let english = Locale(identifier: "en")
     private let now = Date(timeIntervalSince1970: 1_787_900_000)
@@ -383,13 +384,43 @@ final class LocalizationTests: XCTestCase {
         )
     }
 
+    // MARK: - Russian
+
+    func testCoreCopyInRussian() {
+        XCTAssertEqual(
+            ElapsedCopy.text(since: now.addingTimeInterval(-5), now: now, locale: russian),
+            "только что"
+        )
+        XCTAssertEqual(
+            ResetCopy.text(for: resetNow.addingTimeInterval(51 * 60), now: resetNow, locale: russian),
+            "Сброс через 51 мин"
+        )
+        XCTAssertEqual(
+            percentWindow(0.12).summary(locale: russian),
+            "12% использовано · 88% осталось"
+        )
+        XCTAssertEqual(L10n.t("Always show", locale: russian), "Всегда показывать")
+        XCTAssertEqual(L10n.t("Settings…", locale: russian), "Настройки…")
+        XCTAssertEqual(
+            L10n.t("Sign in to \("Perplexity")", locale: russian),
+            "Войти в Perplexity"
+        )
+    }
+
+    func testRussianThresholdAlertKeepsArgumentOrder() {
+        XCTAssertEqual(
+            L10n.t("\(80)% of its \("weekly") limit used.", locale: russian),
+            "Использовано 80% от лимита «weekly»."
+        )
+    }
+
     /// Every language the picker offers must resolve to a locale the catalog
     /// is filed under — a region-qualified or unshipped identifier silently
     /// serves another language instead.
     func testEveryOfferedLanguageResolves() {
         XCTAssertEqual(
             AppLanguage.allCases.map(\.rawValue),
-            ["system", "en", "fr", "ja", "pt-BR", "zh-Hans"]
+            ["system", "en", "fr", "ja", "pt-BR", "ru", "zh-Hans"]
         )
         XCTAssertNil(AppLanguage.system.locale)
         for language in AppLanguage.allCases where language != .system {

--- a/project.yml
+++ b/project.yml
@@ -76,6 +76,7 @@ targets:
           - fr
           - ja
           - pt-BR
+          - ru
           - zh-Hans
         LSMinimumSystemVersion: "15.0"
         # Sources/Info.plist is *generated* from this block, so editing that

--- a/windows/codenotch/src/config.rs
+++ b/windows/codenotch/src/config.rs
@@ -21,7 +21,7 @@ pub struct TraySlot {
 pub struct Config {
     #[serde(default = "default_port")]
     pub port: u16,
-    /// "auto" | "zh" | "en" | "ja" | "ko"
+    /// "auto" | "zh" | "en" | "ja" | "ko" | "ru"
     #[serde(default = "default_lang")]
     pub lang: String,
     #[serde(default)]

--- a/windows/codenotch/src/i18n.rs
+++ b/windows/codenotch/src/i18n.rs
@@ -17,6 +17,9 @@ pub fn resolve_auto() -> &'static str {
             if name.starts_with("ko") {
                 return "ko";
             }
+            if name.starts_with("ru") {
+                return "ru";
+            }
         }
     }
     "en"
@@ -39,6 +42,7 @@ pub fn tr(lang: &str, key: &str) -> &'static str {
         ("zh", "open_data") => "打开数据文件夹（日志 / 图标）",
         ("ja", "open_data") => "データフォルダを開く（ログ / アイコン）",
         ("ko", "open_data") => "데이터 폴더 열기 (로그 / 아이콘)",
+        ("ru", "open_data") => "Открыть папку данных (журналы / значки)",
         (_, "open_data") => "Open data folder (logs / icons)",
         ("ja", "refresh") => "使用量を今すぐ更新",
         ("ko", "refresh") => "사용량 지금 새로고침",
@@ -56,6 +60,15 @@ pub fn tr(lang: &str, key: &str) -> &'static str {
         ("ko", "reset_pos") => "바 위치 초기화",
         ("ko", "quit") => "종료",
         ("ko", "hooks_missing") => "후크 미설치: 트레이 우클릭 → 후크 설치 (데스크톱판은 자동 폴백)",
+        ("ru", "install") => "Установить хуки Claude Code",
+        ("ru", "uninstall") => "Удалить хуки",
+        ("ru", "language") => "Язык",
+        ("ru", "lang_auto") => "Как в системе",
+        ("ru", "reset_pos") => "Сбросить положение панели",
+        ("ru", "quit") => "Выйти",
+        ("ru", "hooks_missing") => "Хуки не установлены: нажмите правой кнопкой по значку в трее → Установить хуки Claude Code (для настольной версии используется автоматический резервный режим)",
+        ("ru", "autostart") => "Запускать с Windows (в фоне)",
+        ("ru", "refresh") => "Обновить использование",
         (_, "install") => "Install Claude Code hooks",
         (_, "uninstall") => "Uninstall hooks",
         (_, "language") => "Language",
@@ -68,33 +81,80 @@ pub fn tr(lang: &str, key: &str) -> &'static str {
         ("zh", "settings") => "设置…",
         ("ja", "settings") => "設定…",
         ("ko", "settings") => "설정…",
+        ("ru", "settings") => "Настройки…",
         (_, "settings") => "Settings…",
 
         ("zh", "tray_icon") => "托盘图标",
         ("ja", "tray_icon") => "トレイアイコン",
         ("ko", "tray_icon") => "트레이 아이콘",
+        ("ru", "tray_icon") => "Значок в трее",
         (_, "tray_icon") => "Tray icon",
 
         ("zh", "tray_off") => "默认图标",
         ("ja", "tray_off") => "既定のアイコン",
         ("ko", "tray_off") => "기본 아이콘",
+        ("ru", "tray_off") => "Обычный значок",
         (_, "tray_off") => "Plain icon",
 
         ("zh", "tray_numbers") => "数字（最多两项）",
         ("ja", "tray_numbers") => "数字（最大2件）",
         ("ko", "tray_numbers") => "숫자 (최대 2개)",
+        ("ru", "tray_numbers") => "Числа (до 2)",
         (_, "tray_numbers") => "Numbers (up to 2)",
 
         ("zh", "tray_bars") => "条形图（多项）",
         ("ja", "tray_bars") => "バー（複数可）",
         ("ko", "tray_bars") => "막대 (여러 개)",
+        ("ru", "tray_bars") => "Полосы (больше 2)",
         (_, "tray_bars") => "Bars (more than 2)",
 
         ("zh", "tray_which") => "显示哪些",
         ("ja", "tray_which") => "対象",
         ("ko", "tray_which") => "표시 대상",
+        ("ru", "tray_which") => "Какие провайдеры",
         (_, "tray_which") => "Which providers",
 
         _ => "?",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::tr;
+
+    const RUSSIAN_KEYS: &[(&str, &str)] = &[
+        ("settings", "Настройки…"),
+        ("refresh", "Обновить использование"),
+        ("quit", "Выйти"),
+        ("install", "Установить хуки Claude Code"),
+        ("uninstall", "Удалить хуки"),
+        ("language", "Язык"),
+        ("lang_auto", "Как в системе"),
+        ("reset_pos", "Сбросить положение панели"),
+        ("hooks_missing", "Хуки не установлены: нажмите правой кнопкой по значку в трее → Установить хуки Claude Code (для настольной версии используется автоматический резервный режим)"),
+        ("autostart", "Запускать с Windows (в фоне)"),
+        ("open_data", "Открыть папку данных (журналы / значки)"),
+        ("tray_icon", "Значок в трее"),
+        ("tray_off", "Обычный значок"),
+        ("tray_numbers", "Числа (до 2)"),
+        ("tray_bars", "Полосы (больше 2)"),
+        ("tray_which", "Какие провайдеры"),
+    ];
+
+    #[test]
+    fn russian_translates_every_known_key() {
+        for (key, value) in RUSSIAN_KEYS {
+            assert_eq!(
+                tr("ru", key),
+                *value,
+                "missing Russian translation for {key}"
+            );
+            assert_ne!(tr("ru", key), "?", "unknown Russian key {key}");
+        }
+    }
+
+    #[test]
+    fn unknown_language_keeps_the_english_fallback() {
+        assert_eq!(tr("xx", "settings"), "Settings…");
     }
 }

--- a/windows/codenotch/src/main.rs
+++ b/windows/codenotch/src/main.rs
@@ -819,6 +819,15 @@ fn get_lang(app: AppHandle) -> String {
     c.lang.clone()
 }
 
+/// The settings WebView must use the same Windows locale as the tray. WebView2's
+/// navigator.language can describe the browser runtime rather than the user locale.
+#[tauri::command]
+fn get_lang_resolved(app: AppHandle) -> String {
+    let st = app.state::<AppState>();
+    let c = st.cfg.lock().unwrap();
+    resolved_lang(&c.lang)
+}
+
 #[tauri::command]
 fn get_autostart() -> bool {
     autostart::is_enabled()
@@ -1086,6 +1095,7 @@ fn main() {
             get_ui_flags,
             set_ui_flags,
             get_lang,
+            get_lang_resolved,
             get_autostart,
             set_autostart,
             get_hooks_installed,

--- a/windows/codenotch/ui/notch.html
+++ b/windows/codenotch/ui/notch.html
@@ -133,15 +133,27 @@ const RU_TEXT={
   'API usage':'Использование API',
   'On demand':'По запросу',
   'Usage':'Использование',
+  'Current session':'Текущий сеанс',
+  'Weekly (all models)':'Недельный (все модели)',
+  'Weekly (Opus)':'Недельный (Opus)',
+  'Weekly (model-scoped)':'Недельный (для выбранной модели)',
+  'Weekly limit':'Недельный лимит',
   'Weekly Limit':'Недельный лимит',
   '5-Hour Limit':'Лимит на 5 часов',
+  'Monthly limit':'Месячный лимит',
   'Monthly Limit':'Месячный лимит',
+  'Longer window':'Более длительный период',
   'Requests today · no limit published':'Запросы сегодня · лимит не опубликован',
   'Updated':'Обновлено',
   'Resetting…':'Сброс…',
   'Resets at':'Сброс в',
   'Resets':'Сброс',
   'Used':'Использовано',
+  'Working':'Работа',
+  'Waiting':'Ожидание',
+  'Streaming (network)':'Потоковая передача (сеть)',
+  'Rate limited, retrying in':'Превышен лимит, повтор через',
+  'Rate limited — retrying in':'Превышен лимит — повтор через',
   'request today':'запрос сегодня',
   'requests today':'запросов сегодня',
   'no requests today':'сегодня запросов нет',
@@ -159,13 +171,39 @@ function textCopy(value){
   if(uiLang!=='ru') return value;
   if(RU_TEXT[value]) return RU_TEXT[value];
   return String(value)
+    .replace(/^(\d+)m limit$/,'Лимит на $1 мин')
+    .replace(/^(\d+)h limit$/,'Лимит на $1 ч')
+    .replace(/^(\d+)d limit$/,'Лимит на $1 дн.')
+    .replace(/^Rate limited, retrying in (\d+)s$/,'Превышен лимит, повтор через $1 с')
+    .replace(/^Rate limited — retrying in (\d+)s$/,'Превышен лимит — повтор через $1 с')
+    .replace(/^Unlimited on the (.+) plan — nothing to meter$/,'Безлимитный тариф $1 — нечего измерять')
+    .replace(/^The (.+) plan has nothing for Cursor to meter yet$/,'В тарифе $1 пока нечего измерять Cursor')
+    .replace(/^(.+) · Google publishes no quota for this account$/,'$1 · Google не публикует лимит для этого аккаунта')
+    .replace(/^Live read failed \((.+)\)$/,'Ошибка чтения онлайн-данных ($1)')
+    .replace(/Weekly \(all models\)/g,'Недельный (все модели)')
+    .replace(/Weekly \(Opus\)/g,'Недельный (Opus)')
+    .replace(/Weekly \(model-scoped\)/g,'Недельный (для выбранной модели)')
+    .replace(/Weekly limit/g,'Недельный лимит')
+    .replace(/Monthly limit/g,'Месячный лимит')
+    .replace(/\bWeekly\b/g,'Недельный')
+    .replace(/\bMonthly\b/g,'Месячный')
     .replace(/ · via /g,' · через ')
     .replace(/needs your input/g,'требуется ваш ответ')
     .replace(/^Working in /,'Работает в ')
-    .replace(/No Claude Code credential found/g,'Учётные данные Claude Code не найдены')
     .replace(/via Antigravity CLI/g,'через CLI Antigravity')
     .replace(/via Antigravity/g,'через Antigravity')
     .replace(/via Google/g,'через Google')
+    .replace(/No Claude Code credential found/g,'Учётные данные Claude Code не найдены')
+    .replace(/Credential expired — run any claude command \(or chat with Claude\) to refresh it/g,'Учётные данные истекли — выполните любую команду claude (или начните чат с Claude), чтобы обновить их')
+    .replace(/Credential rejected \(switched accounts\?\)/g,'Учётные данные отклонены (вы сменили аккаунт?)')
+    .replace(/Codex sign-in expired — open Codex once to refresh it/g,'Срок входа в Codex истёк — откройте Codex для обновления')
+    .replace(/Codex rejected its sign-in — sign in to Codex again/g,'Codex отклонил вход — войдите в Codex снова')
+    .replace(/Codex reported no usage windows/g,'Codex не сообщил окна использования')
+    .replace(/Codex has not recorded a usage snapshot yet/g,'Codex ещё не записал снимок использования')
+    .replace(/from last Codex run/g,'из последнего запуска Codex')
+    .replace(/Waiting for Antigravity CLI quota/g,'Ожидание квоты Antigravity CLI')
+    .replace(/Open Antigravity to read its quota/g,'Откройте Antigravity, чтобы получить квоту')
+    .replace(/Antigravity's Google session was rejected — sign in again in Antigravity/g,'Сеанс Google в Antigravity отклонён — войдите в Antigravity снова')
     .replace(/Antigravity is closed — last reading kept/g,'Antigravity закрыт — сохранено последнее показание')
     .replace(/Sign in to Cursor \(the editor\) to see usage\./g,'Войдите в Cursor (редактор), чтобы увидеть использование.')
     .replace(/Cursor session was rejected — sign in again in the editor/g,'Сеанс Cursor отклонён — снова войдите в редакторе');

--- a/windows/codenotch/ui/notch.html
+++ b/windows/codenotch/ui/notch.html
@@ -127,6 +127,56 @@ let cursorSnap={status:'absent',windows:[],fetched_at:0,note:''};
 let agSnap={status:'absent',windows:[],fetched_at:0,note:''};
 let glyphs={}; // id → {kind:'mark'|'appicon', url}
 let activity=[]; // working state of the non-Claude providers: {provider,state:'busy'|'waiting',name,detail,since}
+let uiLang='en';
+const RU_TEXT={
+  'Included usage':'Включённое использование',
+  'API usage':'Использование API',
+  'On demand':'По запросу',
+  'Usage':'Использование',
+  'Weekly Limit':'Недельный лимит',
+  '5-Hour Limit':'Лимит на 5 часов',
+  'Monthly Limit':'Месячный лимит',
+  'Requests today · no limit published':'Запросы сегодня · лимит не опубликован',
+  'Updated':'Обновлено',
+  'Resetting…':'Сброс…',
+  'Resets at':'Сброс в',
+  'Resets':'Сброс',
+  'Used':'Использовано',
+  'request today':'запрос сегодня',
+  'requests today':'запросов сегодня',
+  'no requests today':'сегодня запросов нет',
+  'Waiting for first reading…':'Ожидание первого показания…',
+  'Sign in to Claude Code to see usage.':'Войдите в Claude Code, чтобы увидеть использование.',
+  'Sign in to Cursor to see usage.':'Войдите в Cursor, чтобы увидеть использование.',
+  'Sign in to Codex to see usage.':'Войдите в Codex, чтобы увидеть использование.',
+  'Sign in to Antigravity to see usage.':'Войдите в Antigravity, чтобы увидеть использование.',
+  'needs your input':'требуется ваш ответ',
+  'Working in':'Работает в',
+  'Notch size':'Размер панели'
+};
+function textCopy(value){
+  if(!value) return '';
+  if(uiLang!=='ru') return value;
+  if(RU_TEXT[value]) return RU_TEXT[value];
+  return String(value)
+    .replace(/ · via /g,' · через ')
+    .replace(/needs your input/g,'требуется ваш ответ')
+    .replace(/^Working in /,'Работает в ')
+    .replace(/No Claude Code credential found/g,'Учётные данные Claude Code не найдены')
+    .replace(/via Antigravity CLI/g,'через CLI Antigravity')
+    .replace(/via Antigravity/g,'через Antigravity')
+    .replace(/via Google/g,'через Google')
+    .replace(/Antigravity is closed — last reading kept/g,'Antigravity закрыт — сохранено последнее показание')
+    .replace(/Sign in to Cursor \(the editor\) to see usage\./g,'Войдите в Cursor (редактор), чтобы увидеть использование.')
+    .replace(/Cursor session was rejected — sign in again in the editor/g,'Сеанс Cursor отклонён — снова войдите в редакторе');
+}
+function setUiLanguage(lang){
+  const next=lang==='ru'?'ru':'en';
+  if(uiLang===next) return;
+  uiLang=next;
+  renderRing();
+  if(card&&card.classList.contains('show')) renderCard();
+}
 // Notch size, as a percentage (40…100). Declared here with the rest of the page state so the card
 // renderer can never reference it before it exists.
 let scalePct=100, scaleDragging=false, scaleT=null, scaleSaveT=null;
@@ -241,16 +291,20 @@ function renderRing(){
 function resetCopy(ms){
   if(!ms) return '';
   const diff=ms-Date.now();
-  if(diff<=0) return 'Resetting…';
-  if(diff<60*60*1000) return `Resets in ${Math.max(1,Math.round(diff/60000))} min`;
+  if(diff<=0) return uiLang==='ru'?'Сброс…':'Resetting…';
+  if(diff<60*60*1000) return uiLang==='ru'
+    ? `Сброс через ${Math.max(1,Math.round(diff/60000))} мин`
+    : `Resets in ${Math.max(1,Math.round(diff/60000))} min`;
   const d=new Date(ms);
-  const t=d.toLocaleTimeString('en-US',{hour:'numeric',minute:'2-digit'});
-  if(diff<24*60*60*1000) return `Resets at ${t}`;
-  return `Resets ${d.toLocaleDateString('en-US',{weekday:'short'})} ${t}`;
+  const locale=uiLang==='ru'?'ru-RU':'en-US';
+  const t=d.toLocaleTimeString(locale,{hour:'numeric',minute:'2-digit'});
+  if(diff<24*60*60*1000) return `${uiLang==='ru'?'Сброс в':'Resets at'} ${t}`;
+  return `${uiLang==='ru'?'Сброс':'Resets'} ${d.toLocaleDateString(locale,{weekday:'short'})} ${t}`;
 }
 
 function ago(ms){
   const m=Math.round((Date.now()-ms)/60000);
+  if(uiLang==='ru') return m<60?`${m} мин назад`:`${Math.round(m/60)} ч назад`;
   return m<60?`${m}m ago`:`${Math.round(m/60)}h ago`;
 }
 
@@ -262,27 +316,27 @@ function renderCard(){
   const p=providers().find(x=>x.id===hoverId)||providers()[0];
   const snap=p.snap;
   const headIcon=glyphHtml(p,true);
-  let html=`<div class="c-head">${headIcon}<span class="c-title">${p.name} Usage</span></div>`;
-  if(staleOf(snap)&&snap.fetched_at) html+=`<div class="c-sub">Updated ${ago(snap.fetched_at)}</div>`;
+  let html=`<div class="c-head">${headIcon}<span class="c-title">${uiLang==='ru'?'Использование '+p.name:p.name+' Usage'}</span></div>`;
+  if(staleOf(snap)&&snap.fetched_at) html+=`<div class="c-sub">${textCopy('Updated')} ${ago(snap.fetched_at)}</div>`;
   if(snap.status==='needsAuth'){
     const who={claude:'Sign in to Claude Code to see usage.',cursor:'Sign in to Cursor to see usage.',codex:'Sign in to Codex to see usage.',gemini:'Sign in to Antigravity to see usage.'}[p.id]||'';
-    html+=`<div class="c-note">${who}<br>${snap.note||''}</div>`;
+    html+=`<div class="c-note">${textCopy(who)}<br>${esc(textCopy(snap.note||''))}</div>`;
   }else if(!snap.windows.length){
-    html+=`<div class="c-note">${snap.note||'Waiting for first reading…'}</div>`;
+    html+=`<div class="c-note">${esc(textCopy(snap.note||'Waiting for first reading…'))}</div>`;
   }else{
     for(const w of snap.windows){
       if(w.count!=null){
-        html+=`<div class="win"><div class="w-row"><span class="w-label">${w.label}</span></div>
-          <div class="w-used">${w.count>0?`~${w.count} request${w.count===1?'':'s'} today`:'no requests today'}</div></div>`;
+        html+=`<div class="win"><div class="w-row"><span class="w-label">${esc(textCopy(w.label))}</span></div>
+          <div class="w-used">${w.count>0?`~${w.count} ${textCopy(w.count===1?'request today':'requests today')}`:textCopy('no requests today')}</div></div>`;
         continue;
       }
       html+=`<div class="win">
-        <div class="w-row"><span class="w-label">${w.label}</span><span class="w-reset">${resetCopy(w.resets_at)}</span></div>
+        <div class="w-row"><span class="w-label">${esc(textCopy(w.label))}</span><span class="w-reset">${resetCopy(w.resets_at)}</span></div>
         <div class="w-track"><div class="w-fill" style="width:${(Math.min(w.used,1)*100).toFixed(0)}%;background:${tone(w.used)}"></div></div>
-        <div class="w-used">${w.derived?'~':''}${Math.round(w.used*100)}% Used</div>
+        <div class="w-used">${w.derived?'~':''}${Math.round(w.used*100)}% ${textCopy('Used')}</div>
       </div>`;
     }
-    if(snap.note) html+=`<div class="c-note">${snap.note}</div>`;
+    if(snap.note) html+=`<div class="c-note">${esc(textCopy(snap.note))}</div>`;
   }
   if(p.id==='claude'){ // live sessions (a full list with jump-to-session is a follow-up)
     const act=stateSnap.sessions.filter(s=>s.state!=='idle');
@@ -299,12 +353,12 @@ function renderCard(){
       html+=`<div class="c-sessions">`;
       for(const a of acts.slice(0,5)){
         const col=a.state==='waiting'?AMBER:RUNGREEN;
-        html+=`<div class="s-row"><span class="s-dot" style="background:${col}"></span>${esc(a.name)}<span style="color:#808080;margin-left:auto">${esc(a.detail)}</span></div>`;
+        html+=`<div class="s-row"><span class="s-dot" style="background:${col}"></span>${esc(a.name)}<span style="color:#808080;margin-left:auto">${esc(textCopy(a.detail))}</span></div>`;
       }
       html+=`</div>`;
     }
   }
-  html+=`<div class="c-scale"><input id="scale-range" type="range" min="40" max="100" step="5" value="${scalePct}" aria-label="Notch size" title="Notch size"><span class="c-scale-val" id="scale-val">${scalePct}%</span></div>`;
+  html+=`<div class="c-scale"><input id="scale-range" type="range" min="40" max="100" step="5" value="${scalePct}" aria-label="${textCopy('Notch size')}" title="${textCopy('Notch size')}"><span class="c-scale-val" id="scale-val">${scalePct}%</span></div>`;
   c.innerHTML=html;
   wireScaleRow();
   placeCard();
@@ -471,7 +525,7 @@ function notice(msg){
 
 listen('usage',e=>{usage=e.payload||usage;renderRing();if(card.classList.contains('show'))renderCard();})
   .catch(e=>notice('listen(usage) failed: '+e));
-listen('state',e=>{stateSnap=e.payload||stateSnap;renderRing();if(card.classList.contains('show'))renderCard();})
+listen('state',e=>{stateSnap=e.payload||stateSnap;setUiLanguage(stateSnap.lang_resolved);renderRing();if(card.classList.contains('show'))renderCard();})
   .catch(e=>notice('listen(state) failed: '+e));
 listen('notice',e=>notice(e.payload)).catch(()=>{});
 listen('codex',e=>{codexSnap=e.payload||codexSnap;renderRing();if(card.classList.contains('show'))renderCard();}).catch(()=>{});
@@ -492,7 +546,7 @@ invoke('get_activity').then(a=>{activity=a||activity;renderRing();}).catch(()=>{
 invoke('get_glyphs').then(g=>{glyphs=g||glyphs;renderRing();}).catch(()=>{});
 invoke('get_codex').then(u=>{codexSnap=u||codexSnap;renderRing();}).catch(()=>{});
 invoke('get_usage').then(u=>{usage=u||usage;renderRing();}).catch(e=>notice('get_usage failed: '+e));
-invoke('get_state').then(s=>{stateSnap=s||stateSnap;renderRing();}).catch(()=>{});
+invoke('get_state').then(s=>{stateSnap=s||stateSnap;setUiLanguage(stateSnap.lang_resolved);renderRing();}).catch(()=>{});
 setInterval(renderRing,30_000); // stale state and reset copy move with time
 </script>
 </body>

--- a/windows/codenotch/ui/settings.html
+++ b/windows/codenotch/ui/settings.html
@@ -373,7 +373,7 @@
         <div class="row">
           <div class="r-text">
             <div class="r-name">Words used by Codenotch</div>
-            <div class="r-why">Sets the language of the taskbar icon&#39;s right-click menu, which is the only part of Codenotch that is translated: its three items. The notch, its hover card and this settings window are English only. &quot;Follow system&quot; uses whatever language Windows itself is set to.</div>
+            <div class="r-why">Sets the language used by Codenotch. “Follow system” uses the language Windows itself is set to.</div>
           </div>
           <div class="r-ctl">
             <select id="lang" aria-label="Language">
@@ -492,10 +492,101 @@ function band(p){ return p < 50 ? '#4ade80' : p < 80 ? '#facc15' : '#f87171'; }
 /* Fallback names, used only until get_tray_options answers (or if it never does). */
 const ORDER = ['claude', 'codex', 'cursor', 'gemini'];
 const FALLBACK_LABEL = { claude:'Claude', codex:'Codex', cursor:'Cursor', gemini:'Antigravity' };
-const STATUS_TEXT = {
-  ok:'', stale:'last reading is old', needsAuth:'not signed in',
-  absent:'not installed', none:'nothing to report', error:'not reachable'
+const RU_STATIC = {
+  'Settings sections':'Разделы настроек', 'Appearance':'Внешний вид', 'Taskbar icon':'Значок в панели задач',
+  'Notch':'Панель', 'General':'Общие', 'Behaviour':'Поведение', 'Claude Code':'Claude Code', 'About':'О программе',
+  'The small icon down by the clock. Codenotch draws your usage straight into it — 32 pixels square. Pick a layout, then click a part of the picture to choose what that part shows.':'Небольшой значок рядом с часами. Codenotch показывает в нём использование — 32 пикселя. Выберите макет и нажмите на часть изображения, чтобы настроить её.',
+  'Layout':'Макет', 'What gets drawn into those 32 pixels.':'Что отображается в этих 32 пикселях.',
+  'The plain Codenotch logo is used.':'Используется обычный логотип Codenotch.', 'No numbers are drawn.':'Числа не отображаются.',
+  'Actual size':'Фактический размер', 'This is how big it really is in the taskbar.':'Такой размер значок имеет в панели задач.',
+  'Windows picks one of these depending on the display. If a number is unreadable here, it will be unreadable in the taskbar.':'Windows выбирает один из вариантов в зависимости от масштаба экрана. Если число не читается здесь, в панели задач оно тоже не будет читаться.',
+  'What each part shows':'Что показывает каждая часть', 'Pick the tool, then the usage window you want drawn there.':'Выберите инструмент, затем окно использования для этой части.',
+  'The small black pill that floats against the right-hand edge of the screen. Each tool you tick gets one ring on it.':'Небольшая чёрная панель у правого края экрана. Каждый выбранный инструмент получает на ней своё кольцо.',
+  'What appears on the pill':'Что отображается на панели', 'Click a name to switch its ring on or off. The list underneath each name chooses which usage window that ring counts.':'Нажмите на название, чтобы включить или выключить кольцо. В списке под названием выбирается окно использования для этого кольца.',
+  'Size':'Размер', 'How big the pill is drawn. The same slider sits at the foot of the pill\'s hover card, so it can be changed from either place.':'Размер панели. Такой же ползунок находится внизу карточки при наведении на панель.',
+  'Whether the pill is on screen at all is a separate switch, under General → Behaviour.':'Видимость панели переключается отдельно в разделе «Общие → Поведение».',
+  'When Codenotch runs, and what it puts on your screen.':'Когда запускается Codenotch и что он показывает на экране.',
+  'Starting up':'Запуск', 'Start with Windows':'Запускать вместе с Windows',
+  'Codenotch opens by itself every time you sign in to this computer, and waits quietly in the background until a coding session starts. Turn it off and you have to open Codenotch yourself.':'Codenotch запускается при входе в систему и тихо работает в фоне до начала сеанса разработки. Если выключить эту настройку, Codenotch нужно запускать вручную.',
+  'What is on screen':'Что отображается на экране', 'Show the notch':'Показывать панель', 'Show the taskbar icon':'Показывать значок в панели задач',
+  'Language':'Язык', 'Words used by Codenotch':'Язык Codenotch', 'Follow system':'Как в системе', 'English':'English', 'Русский':'Русский',
+  'Claude Code can tell Codenotch the moment something happens in a session, instead of Codenotch having to guess from files on disk.':'Claude Code может сразу сообщать Codenotch о событиях сеанса, вместо того чтобы Codenotch угадывал их по файлам на диске.',
+  'Session messages':'Сообщения сеанса', 'Let Claude Code notify Codenotch':'Разрешить Claude Code уведомлять Codenotch',
+  'What this copy of Codenotch is, and where it keeps its files.':'Что это за копия Codenotch и где хранятся её файлы.', 'Version':'Версия',
+  'Files':'Файлы', 'Data folder':'Папка данных', 'Open folder':'Открыть папку', 'If something looks wrong':'Если что-то работает неправильно',
+  'Put the notch back':'Вернуть панель', 'Reset position':'Сбросить положение', 'Saved':'Сохранено',
+  'Numbers':'Числа', 'two readings':'два показания', 'Bars':'Полосы', '1 to 5 columns':'от 1 до 5 столбцов', 'Plain icon':'Обычный значок', 'just the logo':'только логотип',
+  'Whichever is fullest':'Самое заполненное', 'No windows reported':'Нет доступных окон', 'kept':'оставлено', 'Showing':'Показывается', 'Showing in':'Показывается в',
+  '"Whichever is fullest" starts working as soon as it reports one.':'«Самое заполненное» начнёт работать, как только появится окно использования.',
+  '"%@" is no longer available':'«%@» больше недоступен', '%@ no longer reports "%@"':'%@ больше не сообщает «%@»', '%@ — that slot now shows whichever window is fullest.':'%@ — теперь слот показывает самое заполненное окно.',
+  'One provider always stays ticked, so the pill is never empty.':'Хотя бы один провайдер всегда выбран, поэтому панель не бывает пустой.',
+  'The taskbar icon shows the plain Codenotch logo.':'Значок в панели задач показывает обычный логотип Codenotch.',
+  'Choose Numbers or Bars above to draw your usage into it.':'Выберите выше «Числа» или «Полосы», чтобы показывать в нём использование.',
+  'What is on screen':'Что отображается на экране', 'Show the notch':'Показывать панель', 'Show the taskbar icon':'Показывать значок в панели задач',
+  'Open the notch for a moment':'Ненадолго открыть панель', 'At least one provider stays on the notch':'На панели должен остаться хотя бы один провайдер',
+  'The notch is back in the middle':'Панель возвращена в центр', 'Remove this column':'Удалить этот столбец', 'Add column':'Добавить столбец',
+  'The taskbar icon has been kept on. With the notch hidden it is the only way left to open this window or to quit Codenotch, so Codenotch will not let both of them be switched off at the same time.':'Значок в панели задач оставлен включённым. При скрытой панели это единственный способ открыть окно или завершить работу Codenotch, поэтому оба элемента нельзя выключить одновременно.',
+  'One of these two always stays on. If you hide the notch, the taskbar icon is held on for you, because with both of them gone there would be nothing left to click and no way back to this window.':'Один из этих элементов всегда остаётся включённым. Если скрыть панель, значок в панели задач останется включённым, иначе Codenotch будет неоткуда открыть.',
+  'The black pill against the right-hand edge of the screen, with one ring per tool. Turn it off and the pill disappears; Codenotch keeps counting your usage either way.':'Чёрная панель у правого края экрана с отдельным кольцом для каждого инструмента. При выключении панель исчезает, но Codenotch продолжает считать использование.',
+  'The small icon down by the clock. Right-clicking it opens this window, refreshes the readings, or quits Codenotch.':'Небольшой значок рядом с часами. Щелчок правой кнопкой открывает это окно, обновляет данные или завершает работу Codenotch.',
+  'Held on: the notch is hidden, so this icon is the only way left to reach Codenotch. Switch the notch back on first if you want to hide it.':'Оставлен включённым: панель скрыта, поэтому этот значок — единственный способ открыть Codenotch. Сначала включите панель, если хотите скрыть значок.',
+  'Sets the language used by Codenotch. “Follow system” uses the language Windows itself is set to.':'Задаёт язык Codenotch. Вариант «Как в системе» использует язык Windows.',
+  'The small icon down by the clock. Codenotch draws your usage straight into it — 32 pixels square. Pick a layout, then click a part of the picture to choose what that part shows.':'Небольшой значок рядом с часами. Codenotch показывает в нём использование — 32 пикселя. Выберите макет и нажмите на часть изображения, чтобы настроить её.',
+  'Turning this on adds a few lines to your Claude Code settings file so that Claude Code sends Codenotch a short message when a session starts, when it is working, when it is waiting for your answer, and when it finishes. That is what makes the ring spin and the amber ring pulse.':'При включении в файл настроек Claude Code добавляются строки, чтобы он сообщал Codenotch о начале работы, процессе, ожидании ответа и завершении сеанса. Благодаря этому кольцо вращается, а янтарное кольцо пульсирует.',
+  'The file being changed is':'Изменяемый файл —',
+  'in your user folder. A dated copy of it is saved before anything is written, and turning this switch off takes the lines out again. Any hooks you added yourself are left alone.':'в вашей папке пользователя. Перед изменением сохраняется копия с датой, а при выключении настройки добавленные строки удаляются. Ваши собственные хуки не затрагиваются.',
+  'Shows how much of your Claude, Codex, Cursor and Antigravity allowance you have used, in the taskbar icon and in a pill at the edge of the screen.':'Показывает использование Claude, Codex, Cursor и Antigravity в значке панели задач и на панели у края экрана.',
+  'Everything Codenotch remembers lives in one folder: your settings, its log file, and the "glyphs" folder where you can drop your own icons. Opens in File Explorer.':'Все данные Codenotch хранятся в одной папке: настройки, журнал и папка «glyphs» для собственных значков. Открывается в Проводнике.',
+  'The pill can be dragged up and down the right-hand edge. If it has ended up somewhere you cannot see it — off the bottom of a screen you have unplugged, say — this drops it back into the middle of the edge.':'Панель можно перетаскивать вверх и вниз вдоль правого края. Если она оказалась за пределами экрана, эта кнопка возвращает её в середину края.',
+  'The plain Codenotch logo is used.':'Используется обычный логотип Codenotch.', 'No numbers are drawn.':'Числа не отображаются.',
+  'This is how big it really is in the taskbar.':'Такой размер значок имеет в панели задач.',
+  'Windows picks one of these depending on the display. If a number is unreadable here, it will be unreadable in the taskbar.':'Windows выбирает один из вариантов в зависимости от масштаба экрана. Если число не читается здесь, в панели задач оно тоже не будет читаться.',
+  'Notch size':'Размер панели', 'Codenotch':'Codenotch', 'Tray icon preview':'Предпросмотр значка', 'Codenotch logo':'Логотип Codenotch', 'Tray icon at':'Значок размером', 'pixels':'пикселей',
+  'Down the right-hand edge':'У правого края', 'Down the left-hand edge':'У левого края', 'Top half':'Верхняя половина', 'Bottom half':'Нижняя половина', 'Column':'Столбец', 'Remove column':'Удалить столбец'
 };
+const STATUS_TEXT = {
+  en:{ ok:'', stale:'last reading is old', needsAuth:'not signed in', absent:'not installed', none:'nothing to report', error:'not reachable' },
+  ru:{ ok:'', stale:'данные устарели', needsAuth:'не выполнен вход', absent:'не установлен', none:'нет данных', error:'недоступен' }
+};
+let uiLang = 'en';
+function ui(key, fallback){ return uiLang === 'ru' ? (RU_STATIC[key] || fallback) : fallback; }
+function applyStaticUi(){
+  const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT);
+  const nodes = [];
+  while(walker.nextNode()) nodes.push(walker.currentNode);
+  for(const node of nodes){
+    if(node.parentElement && ['SCRIPT','STYLE'].indexOf(node.parentElement.tagName) >= 0) continue;
+    if(node.__enText === undefined) node.__enText = node.nodeValue;
+    const raw = node.__enText;
+    const key = raw.trim();
+    if(!key) continue;
+    const translated = uiLang === 'ru' ? RU_STATIC[key] : null;
+    node.nodeValue = raw.replace(key, translated || key);
+  }
+  for(const el of document.querySelectorAll('[aria-label],[title],[alt]')){
+    for(const attr of ['aria-label','title','alt']){
+      if(!el.hasAttribute(attr)) continue;
+      const marker = '__en_' + attr.replace('-', '_');
+      if(el[marker] === undefined) el[marker] = el.getAttribute(attr);
+      const original = el[marker];
+      el.setAttribute(attr, uiLang === 'ru' ? (RU_STATIC[original] || original) : original);
+    }
+  }
+}
+function setUiLanguage(lang){
+  uiLang = lang === 'ru' || (lang === 'auto' && /^ru(?:-|$)/i.test(navigator.language || '')) ? 'ru' : 'en';
+  applyStaticUi();
+  render();
+}
+function setUiLanguageFromRaw(raw){
+  if(raw !== 'auto'){
+    setUiLanguage(raw);
+    return Promise.resolve();
+  }
+  return call('get_lang_resolved', undefined, 'en').then(resolved => {
+    setUiLanguage(typeof resolved === 'string' ? resolved : 'en');
+  });
+}
 const MAX_BARS = 5, NUMBER_SLOTS = 2;
 
 let options = [];                        // [{id,label,status,windows:[{id,label,used}]}]
@@ -624,7 +715,7 @@ function winsOf(id){
   return (p && Array.isArray(p.windows)) ? p.windows : [];
 }
 function winLabel(pid, wid){
-  if(!wid) return 'Whichever is fullest';
+  if(!wid) return ui('Whichever is fullest', 'Whichever is fullest');
   const w = winsOf(pid).find(x => x.id === wid);
   return w ? w.label : wid;
 }
@@ -638,7 +729,8 @@ function providerList(){
 }
 /* The one place a status code turns into words ("not signed in"), shared for the same reason. */
 function statusText(p){
-  return STATUS_TEXT[p.status] !== undefined ? STATUS_TEXT[p.status] : String((p && p.status) || '');
+  const words = STATUS_TEXT[uiLang] || STATUS_TEXT.en;
+  return words[p.status] !== undefined ? words[p.status] : String((p && p.status) || '');
 }
 
 /* Which provider to reach for when a slot has to be invented or repaired: one that is actually
@@ -671,12 +763,12 @@ function fixSlot(s, notes){
   const provider = s.provider;
   let win = typeof s.window === 'string' ? s.window : '';   // not named `window`: that is the global
   if(options.length && !provOf(provider)){
-    notes.push('"' + provider + '" is no longer available');
+    notes.push(ui('"%@" is no longer available', '"%@" is no longer available').replace('%@', provider));
     return { provider: pickProvider([]), window: '' };
   }
   const wins = winsOf(provider);
   if(win && win !== 'top' && wins.length && !wins.some(w => w.id === win)){
-    notes.push(provLabel(provider) + ' no longer reports "' + win + '"');
+    notes.push(ui('%@ no longer reports "%@"', '%@ no longer reports "%@"').replace('%@', provLabel(provider)).replace('%@', win));
     win = '';
   }
   if(win === 'top') win = '';   // the Rust side treats "top" as "fullest"; store the plain form
@@ -696,7 +788,7 @@ function normalize(){
   cfg.slots = slots;
   if(sel >= cfg.slots.length) sel = cfg.slots.length - 1;
   if(sel < 0) sel = 0;
-  repairNote = notes.length ? notes[0] + ' — that slot now shows whichever window is fullest.' : '';
+  repairNote = notes.length ? ui('%@ — that slot now shows whichever window is fullest.', '%@ — that slot now shows whichever window is fullest.').replace('%@', notes[0]) : '';
 }
 
 /* ---- saving ------------------------------------------------------------ */
@@ -705,7 +797,7 @@ function payload(){
 }
 function persist(quiet){
   invoke('set_tray_config', { cfg: payload() })
-    .then(() => { if(!quiet) toast('Saved'); })
+    .then(() => { if(!quiet) toast(ui('Saved', 'Saved')); })
     .catch(e => strip('set_tray_config failed: ' + errText(e)));
 }
 
@@ -766,8 +858,8 @@ function regionBoxes(){
   return [];
 }
 function slotName(i){
-  if(cfg.mode === 'numbers') return i === 0 ? 'Top half' : 'Bottom half';
-  return 'Column ' + (i + 1);
+  if(cfg.mode === 'numbers') return i === 0 ? ui('Top half', 'Top half') : ui('Bottom half', 'Bottom half');
+  return ui('Column', 'Column') + ' ' + (i + 1);
 }
 
 function renderRegions(){
@@ -793,7 +885,7 @@ const MODES = [
 function renderModes(){
   document.getElementById('modes').innerHTML = MODES.map(m =>
     '<button class="mode' + (cfg.mode === m.id ? ' on' : '') + '" data-m="' + m.id + '">'
-    + esc(m.name) + '<span class="mode-sub">' + esc(m.sub) + '</span></button>'
+    + esc(ui(m.name, m.name)) + '<span class="mode-sub">' + esc(ui(m.sub, m.sub)) + '</span></button>'
   ).join('');
 }
 function setMode(mode){
@@ -816,12 +908,12 @@ function renderChips(){
       + '<button class="chip-pick" data-chip="' + i + '" aria-pressed="' + (i === sel) + '">'
       + '<b>' + esc(slotName(i)) + '</b><span class="ctext">' + esc(text) + '</span></button>'
       + (cfg.mode === 'bars' && cfg.slots.length > 1
-        ? '<button class="chip-x" data-del="' + i + '" title="Remove this column" aria-label="Remove column ' + (i + 1) + '">&times;</button>'
+        ? '<button class="chip-x" data-del="' + i + '" title="' + esc(ui('Remove this column', 'Remove this column')) + '" aria-label="' + esc(ui('Remove column', 'Remove column')) + ' ' + (i + 1) + '">&times;</button>'
         : '')
       + '</span>';
   });
   if(cfg.mode === 'bars' && cfg.slots.length < MAX_BARS){
-    html += '<button class="chip chip-add" data-add="1">+ Add column</button>';
+    html += '<button class="chip chip-add" data-add="1">+ ' + esc(ui('Add column', 'Add column')) + '</button>';
   }
   host.innerHTML = html;
 }
@@ -830,12 +922,12 @@ function renderChips(){
 function renderPicker(){
   const host = document.getElementById('picker');
   if(cfg.mode === 'off'){
-    host.innerHTML = '<div class="c-note dim">The taskbar icon shows the plain Codenotch logo. '
-      + 'Choose Numbers or Bars above to draw your usage into it.</div>';
+    host.innerHTML = '<div class="c-note dim">' + esc(ui('The taskbar icon shows the plain Codenotch logo.', 'The taskbar icon shows the plain Codenotch logo.')) + ' '
+      + esc(ui('Choose Numbers or Bars above to draw your usage into it.', 'Choose Numbers or Bars above to draw your usage into it.')) + '</div>';
     return;
   }
   const cur = cfg.slots[sel] || { provider:'', window:'' };
-  let html = '<div class="p-head">Showing in <b>' + esc(slotName(sel)) + '</b>: '
+  let html = '<div class="p-head">' + esc(ui('Showing in', 'Showing in')) + ' <b>' + esc(slotName(sel)) + '</b>: '
     + esc(provLabel(cur.provider) + ' — ' + winLabel(cur.provider, cur.window)) + '</div>';
   if(repairNote) html += '<div class="c-note dim" style="margin-bottom:8px">' + esc(repairNote) + '</div>';
 
@@ -850,13 +942,13 @@ function renderPicker(){
     const anyOn = cur.provider === p.id && !cur.window;
     html += '<button class="p-item' + (anyOn ? ' on' : '') + '" data-p="' + esc(p.id) + '" data-w="">'
       + '<span class="p-tick">' + (anyOn ? '&#10003;' : '') + '</span>'
-      + '<span class="p-label p-any">Whichever is fullest</span></button>';
+      + '<span class="p-label p-any">' + esc(ui('Whichever is fullest', 'Whichever is fullest')) + '</span></button>';
 
     const wins = Array.isArray(p.windows) ? p.windows : [];
     if(!wins.length){
-      html += '<div class="p-empty">No windows reported'
+      html += '<div class="p-empty">' + esc(ui('No windows reported', 'No windows reported'))
         + (st ? ' — ' + esc(st) + '.' : '.')
-        + ' "Whichever is fullest" starts working as soon as it reports one.</div>';
+        + ' ' + esc(ui('"Whichever is fullest" starts working as soon as it reports one.', '"Whichever is fullest" starts working as soon as it reports one.')) + '</div>';
     }
     for(const w of wins){
       const on = cur.provider === p.id && cur.window === w.id;
@@ -973,7 +1065,7 @@ function renderNotch(){
       + (only ? '<span class="np-lock">kept</span>' : '')
       + '</span></button>';
     // The window picker only means anything for a ring that is actually drawn
-    let opts = '<option value="">' + esc('Whichever is fullest') + '</option>';
+    let opts = '<option value="">' + esc(ui('Whichever is fullest', 'Whichever is fullest')) + '</option>';
     for(const w of winsOf(p.id)){
       const selAttr = (ticked && sl.window === w.id) ? ' selected' : '';
       const pct = (w.used === null || w.used === undefined) ? '' : '  ' + w.used + '%';
@@ -984,8 +1076,8 @@ function renderNotch(){
   }
   host.innerHTML = html;
   const shown = on.map(sl => provLabel(sl.provider) + ' · ' + winLabel(sl.provider, sl.window));
-  note.textContent = 'Showing ' + shown.join('   |   ')
-    + '.  One provider always stays ticked, so the pill is never empty.';
+  note.textContent = ui('Showing', 'Showing') + ' ' + shown.join('   |   ')
+    + '.  ' + ui('One provider always stays ticked, so the pill is never empty.', 'One provider always stays ticked, so the pill is never empty.');
 }
 
 /* Everything ticked AND every window left on "fullest" is stored as an EMPTY list, not as four
@@ -999,7 +1091,7 @@ function saveNotch(next){
   notchSlots = store;
   renderNotch();
   invoke('set_notch_slots', { slots: store.map(sl => ({ provider:sl.provider, window:sl.window || '' })) })
-    .then(() => toast('Saved'))
+    .then(() => toast(ui('Saved', 'Saved')))
     .catch(e => {
       notchSlots = prev;     // nothing was saved, so put it back rather than show a lie
       renderNotch();
@@ -1016,7 +1108,7 @@ function toggleNotch(id){
     /* Unticking the last one is refused rather than saved. An empty list means "all" everywhere
        below this window, so saving one would switch every provider back on — the opposite of what
        the click asked for. Holding the last tick is the only unambiguous answer. */
-    if(on.length <= 1){ toast('At least one provider stays on the notch'); return; }
+    if(on.length <= 1){ toast(ui('At least one provider stays on the notch', 'At least one provider stays on the notch')); return; }
     on.splice(at, 1);
   } else {
     on.push({ provider:id, window:'' });
@@ -1053,7 +1145,7 @@ function clampPct(v){
     clearTimeout(scaleTimer);        // one save when the drag settles, not one per pixel
     scaleTimer = setTimeout(() => {
       invoke('set_scale', { scale: scalePct / 100 })
-        .then(() => toast('Saved'))
+        .then(() => toast(ui('Saved', 'Saved')))
         .catch(e => strip('set_scale failed: ' + errText(e)));
     }, 150);
   });
@@ -1062,7 +1154,7 @@ function clampPct(v){
 /* ---- the truth strip (built once) -------------------------------------- */
 (function buildTruth(){
   document.getElementById('truthstrip').innerHTML = [16, 20, 24].map(px =>
-    '<div class="truthcell"><img width="' + px + '" height="' + px + '" alt="Tray icon at ' + px + ' pixels">'
+    '<div class="truthcell"><img width="' + px + '" height="' + px + '" alt="' + esc(ui('Tray icon at', 'Tray icon at')) + ' ' + px + ' ' + esc(ui('pixels', 'pixels')) + '">'
     + '<span>' + px + ' px</span></div>'
   ).join('');
 })();
@@ -1112,12 +1204,13 @@ function saveFlags(wantNotch, wantTray){
       if(fix){
         fix.hidden = !corrected;
         if(corrected){
-          fix.textContent = 'The taskbar icon has been kept on. With the notch hidden it is the '
+          fix.textContent = ui('The taskbar icon has been kept on. With the notch hidden it is the '
             + 'only way left to open this window or to quit Codenotch, so Codenotch will not let '
-            + 'both of them be switched off at the same time.';
+            + 'both of them be switched off at the same time.',
+            'The taskbar icon has been kept on. With the notch hidden it is the only way left to open this window or to quit Codenotch, so Codenotch will not let both of them be switched off at the same time.');
         }
       }
-      toast('Saved');
+      toast(ui('Saved', 'Saved'));
     })
     .catch(e => strip('set_ui_flags failed: ' + errText(e)))   // flags untouched: the switches spring back
     .then(() => { flagsBusy = false; renderFlags(); });
@@ -1157,7 +1250,7 @@ function remoteSwitch(id, getCmd, setCmd, label){
     invoke(setCmd, { on: want })
       .catch(e => strip(label + ' could not be changed: ' + errText(e)))
       .then(() => { busy = false; return refresh(); })
-      .then(() => { if(value === want) toast('Saved'); });
+      .then(() => { if(value === want) toast(ui('Saved', 'Saved')); });
   });
   return { refresh: refresh };
 }
@@ -1167,10 +1260,17 @@ const hooksSwitch = remoteSwitch('sw-hooks', 'get_hooks_installed', 'set_hooks_i
 /* ---- language ----------------------------------------------------------- */
 const LANGS = ['auto', 'en', 'zh', 'ja', 'ko', 'ru'];
 document.getElementById('lang').addEventListener('change', e => {
+  const previous = e.target.dataset.previous || 'auto';
   const v = LANGS.indexOf(e.target.value) >= 0 ? e.target.value : 'auto';
   invoke('set_lang', { lang: v })
-    .then(() => toast('Saved'))
-    .catch(err => strip('set_lang failed: ' + errText(err)));
+    .then(() => {
+      e.target.dataset.previous = v;
+      return setUiLanguageFromRaw(v).then(() => toast(ui('Saved', 'Saved')));
+    })
+    .catch(err => {
+      e.target.value = previous;
+      setUiLanguageFromRaw(previous).then(() => strip('set_lang failed: ' + errText(err)));
+    });
 });
 
 /* ---- about --------------------------------------------------------------- */
@@ -1179,7 +1279,7 @@ document.getElementById('btn-data').addEventListener('click', () => {
 });
 document.getElementById('btn-resetpos').addEventListener('click', () => {
   invoke('reset_notch_position')
-    .then(() => toast('The notch is back in the middle'))
+    .then(() => toast(ui('The notch is back in the middle', 'The notch is back in the middle')))
     .catch(e => strip('reset_notch_position failed: ' + errText(e)));
 });
 /* The number printed above is the one in tauri.conf.json, kept here so the page works with no
@@ -1197,6 +1297,7 @@ document.getElementById('btn-resetpos').addEventListener('click', () => {
 
 /* ---- start ------------------------------------------------------------- */
 function boot(){
+  setUiLanguage('auto');
   showTab(savedTab());
   render();   // draw something immediately, even if every command below fails
 
@@ -1237,9 +1338,15 @@ function boot(){
     renderFlags();
   });
 
-  call('get_lang', undefined, null).then(v => {
-    const l = (typeof v === 'string' && LANGS.indexOf(v) >= 0) ? v : 'auto';
+  Promise.all([
+    call('get_lang', undefined, 'auto'),
+    call('get_lang_resolved', undefined, 'en')
+  ]).then(([raw, resolved]) => {
+    const l = (typeof raw === 'string' && LANGS.indexOf(raw) >= 0) ? raw : 'auto';
+    const effective = l === 'auto' && typeof resolved === 'string' ? resolved : l;
     document.getElementById('lang').value = l;
+    document.getElementById('lang').dataset.previous = l;
+    setUiLanguage(effective);
   });
 
   autoSwitch.refresh();

--- a/windows/codenotch/ui/settings.html
+++ b/windows/codenotch/ui/settings.html
@@ -382,6 +382,7 @@
               <option value="zh">&#20013;&#25991;</option>
               <option value="ja">&#26085;&#26412;&#35486;</option>
               <option value="ko">&#54620;&#44397;&#50612;</option>
+              <option value="ru">Русский</option>
             </select>
           </div>
         </div>
@@ -1164,7 +1165,7 @@ const autoSwitch = remoteSwitch('sw-autostart', 'get_autostart', 'set_autostart'
 const hooksSwitch = remoteSwitch('sw-hooks', 'get_hooks_installed', 'set_hooks_installed', 'The Claude Code messages');
 
 /* ---- language ----------------------------------------------------------- */
-const LANGS = ['auto', 'en', 'zh', 'ja', 'ko'];
+const LANGS = ['auto', 'en', 'zh', 'ja', 'ko', 'ru'];
 document.getElementById('lang').addEventListener('change', e => {
   const v = LANGS.indexOf(e.target.value) >= 0 ? e.target.value : 'auto';
   invoke('set_lang', { lang: v })


### PR DESCRIPTION
## Summary

- Add Russian (`ru`) to the macOS language picker, bundle metadata, and localization catalog.
- Complete the macOS Russian catalog for all 428 source keys while preserving format arguments.
- Add Russian Windows tray strings, system-locale detection, and a localized settings window.
- Keep Windows “Follow system” consistent with the Rust locale resolver, including live language switching and rollback on save failure.
- Add coverage tests for the Russian catalog and Windows tray translations.

## Verification

- `cargo test --manifest-path windows/codenotch/Cargo.toml` — 26 passed, 1 ignored.
- JSON/catalog validation — 428/428 Russian entries, all marked translated, no `%@`/`%lld`/`%%` mismatches.
- Windows settings JavaScript syntax check passed.
- `git diff --check` passed.

Native macOS XCTest/build verification was not run because this PR was prepared on Windows; `swift` and `xcodebuild` are unavailable on this host.
