### PR TITLE
Add quit action to settings sidebar

### DIFF
--- a/Sources/App/AppDelegate.swift
+++ b/Sources/App/AppDelegate.swift
@@ -239,6 +239,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                     preferences?.setOffset(0, for: preferences?.notchEdge ?? .right)
                     fleet?.apply(alongOffset: 0)
                 },
+                quit: { NSApp.terminate(nil) },
                 usageStore: store, ollamaRelay: relay, lmstudioMetrics: lmstudio
             )
             // The gear toggles; everything else that opens settings opens it.

--- a/Sources/Settings/SettingsView.swift
+++ b/Sources/Settings/SettingsView.swift
@@ -171,6 +171,7 @@ struct SettingsView: View {
     /// nothing would tell the notch to move, and the setting would only take
     /// effect the next time the edge changed.
     let resetPosition: () -> Void
+    let quit: () -> Void
     @ObservedObject var updater: Updater
     var ollamaRelay: OllamaActivityRelay? = nil
     var lmstudioMetrics: LMStudioMetrics? = nil
@@ -301,6 +302,22 @@ struct SettingsView: View {
             }
             .padding(.trailing, 14)
             .frame(height: SettingsView.headerHeight - SettingsView.sidebarInset)
+        }
+        .safeAreaInset(edge: .bottom, spacing: 0) {
+            Button(role: .destructive, action: quit) {
+                Label {
+                    Text(L10n.t("Quit Codenotch"))
+                } icon: {
+                    SidebarIcon(systemName: "power", tint: .red)
+                }
+                .padding(.horizontal, 8)
+                .padding(.vertical, 4)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .padding(.horizontal, 10)
+            .padding(.bottom, 10)
         }
         .frame(width: SettingsView.sidebarWidth)
         // Liquid Glass, the way System Settings draws its own floating

--- a/Sources/Settings/SettingsWindowController.swift
+++ b/Sources/Settings/SettingsWindowController.swift
@@ -23,6 +23,7 @@ final class SettingsWindowController: NSObject, NSWindowDelegate {
     private let lmstudioMetrics: LMStudioMetrics?
     private let usageStore: UsageStore?
     private let resetPosition: () -> Void
+    private let quit: () -> Void
 
     init(preferences: Preferences,
          providers: @escaping () -> [ProviderSummary],
@@ -32,6 +33,7 @@ final class SettingsWindowController: NSObject, NSWindowDelegate {
          switchAccount: @escaping (String) -> Bool,
          retry: @escaping (String) -> Void,
          resetPosition: @escaping () -> Void,
+         quit: @escaping () -> Void,
          usageStore: UsageStore? = nil,
          ollamaRelay: OllamaActivityRelay? = nil,
          lmstudioMetrics: LMStudioMetrics? = nil) {
@@ -39,6 +41,7 @@ final class SettingsWindowController: NSObject, NSWindowDelegate {
         self.lmstudioMetrics = lmstudioMetrics
         self.usageStore = usageStore
         self.resetPosition = resetPosition
+        self.quit = quit
         self.switchAccount = switchAccount
         self.retry = retry
         self.updater = updater
@@ -176,6 +179,7 @@ final class SettingsWindowController: NSObject, NSWindowDelegate {
                                    switchAccount: switchAccount,
                                    retry: retry,
                                    resetPosition: resetPosition,
+                                   quit: quit,
                                    updater: updater,
                                    ollamaRelay: ollamaRelay, lmstudioMetrics: lmstudioMetrics,
                                    usageStore: usageStore)

--- a/Tests/AccessibilityTransparencyTests.swift
+++ b/Tests/AccessibilityTransparencyTests.swift
@@ -104,6 +104,7 @@ final class AccessibilityTransparencyTests: XCTestCase {
             switchAccount: { _ in false },
             retry: { _ in },
             resetPosition: {},
+            quit: {},
             updater: updater
         )
         .environment(\.codenotchReduceTransparency, true)

--- a/Tests/AntigravityTests.swift
+++ b/Tests/AntigravityTests.swift
@@ -1094,6 +1094,7 @@ final class FirstRunCopyTests: XCTestCase {
                             switchAccount: { _ in true },
                             retry: { _ in },
                             resetPosition: {},
+                            quit: {},
                             updater: Updater())
     }
 

--- a/Tests/OllamaTests.swift
+++ b/Tests/OllamaTests.swift
@@ -810,7 +810,7 @@ final class OllamaRenderTests: XCTestCase {
         let content = SettingsView(preferences: preferences, providers: { store.providerSummaries },
             signOut: { store.signOut(providerID: $0) }, signIn: { store.signIn(providerID: $0) },
             switchAccount: { _ in false }, retry: { store.refresh(providerID: $0) },
-            resetPosition: {}, updater: Updater(), usageStore: store)
+            resetPosition: {}, quit: {}, updater: Updater(), usageStore: store)
             .frame(width: SettingsView.width, height: SettingsView.height)
             .background(Color(nsColor: .windowBackgroundColor))
         let hosting = NSHostingView(rootView: content)

--- a/Tests/SettingsQuitButtonTests.swift
+++ b/Tests/SettingsQuitButtonTests.swift
@@ -1,0 +1,31 @@
+import SwiftUI
+import XCTest
+@testable import Codenotch
+
+@MainActor
+final class SettingsQuitButtonTests: XCTestCase {
+    func testSettingsRendersWithQuitAction() throws {
+        let name = "SettingsQuitButtonTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: name)!
+        defer { defaults.removePersistentDomain(forName: name) }
+        var didQuit = false
+        let settings = SettingsView(
+            preferences: Preferences(defaults: defaults),
+            providers: { [] },
+            signOut: { _ in },
+            signIn: { _ in false },
+            switchAccount: { _ in false },
+            retry: { _ in },
+            resetPosition: {},
+            quit: { didQuit = true },
+            updater: Updater()
+        )
+        let view = settings.frame(width: SettingsView.width, height: SettingsView.height)
+
+        let image = try XCTUnwrap(ImageRenderer(content: view).nsImage)
+        XCTAssertEqual(image.size, CGSize(width: SettingsView.width, height: SettingsView.height))
+
+        settings.quit()
+        XCTAssertTrue(didQuit)
+    }
+}


### PR DESCRIPTION
Adds a Quit Codenotch action at the bottom of the Settings sidebar.

  The action follows the existing Settings architecture: AppDelegate supplies the termination closure,
  SettingsWindowController forwards it, and SettingsView renders it using the same icon badge, spacing,
  and alignment as the other sidebar items.

  Validation:
  - 1,265 tests passed
  - 3 tests skipped
  - Verified the button renders correctly and terminates the app