### PR TITLE
Store the providers that are on, not the ones that are off

### DIFF
--- a/Sources/App/AppDelegate.swift
+++ b/Sources/App/AppDelegate.swift
@@ -118,24 +118,26 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             Log.usage.info("codex profiles: \(self.codexProfiles.map(\.displayPath).joined(separator: ", "), privacy: .public)")
             let claudeProviders = claudeProfiles.map { ClaudeOAuthProvider(profile: $0) }
             self.claudeProviders = claudeProviders
+            let allProviders: [UsageProvider] = claudeProviders
+                + [CursorLocalProvider()]
+                + codexProfiles.map { CodexLocalProvider(profile: $0) }
+                + [AntigravityProvider(),
+                   GLMProvider(), GrokLocalProvider(), DevinLocalProvider(), OpenCodeProvider(),
+                   CommandCodeProvider(), GitHubCopilotProvider(),
+                   OllamaLocalProvider(endpoint: URL(string: preferences.ollamaEndpoint)!),
+                   LMStudioLocalProvider(endpoint: URL(string: preferences.lmstudioEndpoint)!),
+                   OllamaProvider(),
+                   // A closure, not the value: the provider is an actor and
+                   // re-reads the budget on every fetch, so a ceiling typed
+                   // into Settings applies without a restart.
+                   GeminiAPIProvider(budget: {
+                       Preferences.storedGeminiAPIMonthlyTokenBudget()
+                   })]
+                + webProviders
+            preferences.reconcile(discoveredIDs: allProviders.map(\.id))
             let store = UsageStore(
-                providers: claudeProviders
-                    + [CursorLocalProvider()]
-                    + codexProfiles.map { CodexLocalProvider(profile: $0) }
-                    + [AntigravityProvider(),
-                       GLMProvider(), GrokLocalProvider(), DevinLocalProvider(), OpenCodeProvider(),
-                       CommandCodeProvider(), GitHubCopilotProvider(),
-                       OllamaLocalProvider(endpoint: URL(string: preferences.ollamaEndpoint)!),
-                       LMStudioLocalProvider(endpoint: URL(string: preferences.lmstudioEndpoint)!),
-                       OllamaProvider(),
-                       // A closure, not the value: the provider is an actor and
-                       // re-reads the budget on every fetch, so a ceiling typed
-                       // into Settings applies without a restart.
-                       GeminiAPIProvider(budget: {
-                           Preferences.storedGeminiAPIMonthlyTokenBudget()
-                       })]
-                    + webProviders,
-                disconnected: preferences.disconnectedProviders,
+                providers: allProviders,
+                disconnected: preferences.disconnectedIDs(among: allProviders.map(\.id)),
                 // Passed at construction, not left to the sink below, for the
                 // same reason `disconnected` is: the sink delivers a run loop
                 // turn later, so without this every launch draws the built-in
@@ -153,11 +155,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             self.ollamaRelay = relay
             // A single publisher chain exceeds Swift's type-checking time limit.
             let relayPreferences = Publishers.CombineLatest3(
-                preferences.$disconnectedProviders,
+                preferences.$connectedProviders,
                 preferences.$ollamaEndpoint,
                 preferences.$ollamaMetricsEnabled)
             let relayConfiguration = relayPreferences.map { values in
-                (enabled: !values.0.contains("ollama-local") && values.2, endpoint: values.1)
+                (enabled: values.0.contains("ollama-local") && values.2, endpoint: values.1)
             }.eraseToAnyPublisher()
             relayConfiguration
                 .removeDuplicates { $0.enabled == $1.enabled && $0.endpoint == $1.endpoint }
@@ -191,9 +193,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             self.lmstudioMetrics = lmstudio
             // Split like the relay's chain above, and for the same reason.
             let lmstudioPreferences = Publishers.CombineLatest(
-                preferences.$disconnectedProviders, preferences.$lmstudioEndpoint)
+                preferences.$connectedProviders, preferences.$lmstudioEndpoint)
             let lmstudioConfiguration = lmstudioPreferences.map { values in
-                (enabled: !values.0.contains(LMStudioMetrics.providerID), endpoint: values.1)
+                (enabled: values.0.contains(LMStudioMetrics.providerID), endpoint: values.1)
             }.eraseToAnyPublisher()
             lmstudioConfiguration
                 .removeDuplicates { $0.enabled == $1.enabled && $0.endpoint == $1.endpoint }
@@ -388,9 +390,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 .sink { [weak fleet] in fleet?.apply(surfaceStyle: $0) }
                 .store(in: &cancellables)
 
-            preferences.$disconnectedProviders
+            preferences.$connectedProviders
                 .receive(on: RunLoop.main)
-                .sink { [weak store] in store?.disconnected = $0 }
+                .sink { [weak store, weak preferences] connected in
+                    guard let store, let preferences else { return }
+                    store.disconnected = preferences.disconnectedIDs(among: store.knownIDs)
+                    _ = connected
+                }
                 .store(in: &cancellables)
 
             preferences.$ollamaEndpoint

--- a/Sources/App/AppDelegate.swift
+++ b/Sources/App/AppDelegate.swift
@@ -390,12 +390,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 .sink { [weak fleet] in fleet?.apply(surfaceStyle: $0) }
                 .store(in: &cancellables)
 
-            preferences.$connectedProviders
+            Publishers.CombineLatest(preferences.$connectedProviders, preferences.$disabledModels)
                 .receive(on: RunLoop.main)
-                .sink { [weak store, weak preferences] connected in
+                .sink { [weak store, weak preferences] _, _ in
                     guard let store, let preferences else { return }
                     store.disconnected = preferences.disconnectedIDs(among: store.knownIDs)
-                    _ = connected
                 }
                 .store(in: &cancellables)
 

--- a/Sources/Model/UsageStore.swift
+++ b/Sources/Model/UsageStore.swift
@@ -27,6 +27,11 @@ final class UsageStore: ObservableObject {
     @Published private(set) var needsRenewal: Set<String> = []
 
     private let providers: [UsageProvider]
+
+    /// Provider ids plus any model cells currently on screen.
+    var knownIDs: [String] {
+        Array(Set(providers.map(\.id) + snapshots.map(\.id) + localModelSummaries.map(\.id)))
+    }
     /// Provider IDs block fetching before credential access. Model IDs only hide
     /// their cells so disabling one model does not stop the shared runtime.
     @Published var disconnected: Set<String> = [] {

--- a/Sources/Providers/CodexProfile.swift
+++ b/Sources/Providers/CodexProfile.swift
@@ -48,6 +48,11 @@ struct CodexProfile: Equatable, Hashable {
 
     // Preserve the default id so existing readings and preferences survive.
     var id: String { slug.map { "\(Self.defaultID)-\($0)" } ?? Self.defaultID }
+
+    /// Whether a provider id names a Codex profile, default or otherwise.
+    static func isCodex(providerID: String) -> Bool {
+        providerID == defaultID || providerID.hasPrefix(defaultID + "-")
+    }
     var displayName: String { slug.map { "Codex (\($0))" } ?? "Codex" }
 
     static func slug(fromProviderID id: String) -> String? {

--- a/Sources/Settings/LMStudioSettingsRow.swift
+++ b/Sources/Settings/LMStudioSettingsRow.swift
@@ -24,7 +24,7 @@ struct LMStudioSettingsRow: View {
                     get: { enabled },
                     set: { on in
                         preferences.setConnected(on, for: providerID)
-                        store.disconnected = preferences.disconnectedProviders
+                        store.disconnected = preferences.disconnectedIDs(among: store.knownIDs)
                     }
                 ))
                 .labelsHidden()

--- a/Sources/Settings/OllamaSettingsRow.swift
+++ b/Sources/Settings/OllamaSettingsRow.swift
@@ -21,7 +21,7 @@ struct OllamaSettingsRow: View {
                     get: { enabled },
                     set: { on in
                         preferences.setConnected(on, for: "ollama-local")
-                        store.disconnected = preferences.disconnectedProviders
+                        store.disconnected = preferences.disconnectedIDs(among: store.knownIDs)
                     }
                 ))
                 .labelsHidden()

--- a/Sources/Settings/Preferences.swift
+++ b/Sources/Settings/Preferences.swift
@@ -8,10 +8,22 @@ import os
 final class Preferences: ObservableObject {
     static let showUsagePaceKey = "showUsagePace"
 
-    /// Disabled model IDs hide cells without stopping their shared runtime.
-    @Published var disconnectedProviders: Set<String> {
-        didSet { defaults.set(Array(disconnectedProviders), forKey: Keys.disconnected) }
+    /// Provider IDs that currently have a ring. Stored as the ones that are
+    /// on, so a provider added later stays off until someone switches it on —
+    /// Claude and Codex excepted, which still default on as a family.
+    @Published var connectedProviders: Set<String> {
+        didSet { defaults.set(Array(connectedProviders), forKey: Keys.connected) }
     }
+
+    /// Every provider id this copy has already decided on, so a later version's
+    /// new provider is recognised as new rather than as "never chosen".
+    @Published private(set) var seenProviders: Set<String> {
+        didSet { defaults.set(Array(seenProviders), forKey: Keys.seen) }
+    }
+
+    /// The old hidden-providers list, kept only until `reconcile` can invert it
+    /// against the ids actually on this Mac.
+    private var pendingHidden: Set<String>?
 
     @Published var ollamaMetricsEnabled: Bool {
         didSet { defaults.set(ollamaMetricsEnabled, forKey: Keys.ollamaMetricsEnabled) }
@@ -28,8 +40,8 @@ final class Preferences: ObservableObject {
     }
 
     /// Providers whose threshold alerts are muted. Stored as the muted set so
-    /// a provider added later alerts by default — the same reasoning as
-    /// `disconnectedProviders`.
+    /// a provider added later alerts by default. Connection is stored the
+    /// other way: the ones that are on.
     @Published var mutedAlertProviders: Set<String> {
         didSet { defaults.set(Array(mutedAlertProviders), forKey: Keys.mutedAlerts) }
     }
@@ -262,8 +274,10 @@ final class Preferences: ObservableObject {
 
     private let defaults: UserDefaults
     private enum Keys {
-        /// The old name. Kept so existing choices survive the rename.
+        /// The old off-list. Kept so a 1.9 install can invert it once.
         static let disconnected = "hiddenProviders"
+        static let connected = "connectedProviders"
+        static let seen = "seenProviders"
         static let ollamaEndpoint = "ollamaEndpoint"
         static let lmstudioEndpoint = "lmstudioEndpoint"
         static let introducedOllama = "introducedOllama"
@@ -384,11 +398,43 @@ final class Preferences: ObservableObject {
             }
             defaults.set(true, forKey: Keys.migratedOllamaID)
         }
-        let disconnected = Set(defaults.stringArray(forKey: Keys.disconnected) ?? [])
-        self.disconnectedProviders = disconnected
+        let storedConnected = defaults.stringArray(forKey: Keys.connected)
+        let storedSeen = Set(defaults.stringArray(forKey: Keys.seen) ?? [])
+        let connected: Set<String>
+        let seen: Set<String>
+        let hidden: Set<String>?
+        if let storedConnected {
+            connected = Set(storedConnected)
+            seen = storedSeen.isEmpty ? connected : storedSeen
+            hidden = nil
+        } else if defaults.object(forKey: Keys.disconnected) != nil {
+            // An empty off-list is still a choice: everyone was on.
+            hidden = Set(defaults.stringArray(forKey: Keys.disconnected) ?? [])
+            connected = []
+            seen = storedSeen
+        } else if !self.isFirstLaunch || defaults.bool(forKey: Keys.introducedOllama) {
+            // Launched before this key existed, and never hid anyone.
+            hidden = []
+            connected = []
+            seen = storedSeen
+        } else {
+            hidden = nil
+            connected = []
+            seen = storedSeen
+        }
+        self.connectedProviders = connected
+        self.seenProviders = seen
+        self.pendingHidden = hidden
+        let ollamaOn: Bool
+        if storedConnected != nil {
+            ollamaOn = connected.contains("ollama-local")
+        } else if let hidden {
+            ollamaOn = !hidden.contains("ollama-local")
+        } else {
+            ollamaOn = false
+        }
         self.ollamaMetricsEnabled = defaults.object(forKey: Keys.ollamaMetricsEnabled) as? Bool
-            ?? (defaults.bool(forKey: Keys.introducedOllama)
-                && !disconnected.contains("ollama-local"))
+            ?? (defaults.bool(forKey: Keys.introducedOllama) && ollamaOn)
         self.ollamaEndpoint = (try? OllamaEndpoint.parse(
             defaults.string(forKey: Keys.ollamaEndpoint) ?? OllamaEndpoint.defaultAddress
         ).absoluteString) ?? OllamaEndpoint.defaultAddress
@@ -489,16 +535,71 @@ final class Preferences: ObservableObject {
         }
     }
 
+    /// Claude and Codex stay on for a first install and for a newly discovered
+    /// profile. Everyone else starts off.
+    static func isDefaultOnFamily(_ providerID: String) -> Bool {
+        ClaudeProfile.isClaude(providerID: providerID)
+            || CodexProfile.isCodex(providerID: providerID)
+    }
+
     func isConnected(_ providerID: String) -> Bool {
-        !disconnectedProviders.contains(providerID)
+        if defaults.object(forKey: Keys.connected) != nil {
+            return connectedProviders.contains(providerID)
+        }
+        if let hidden = pendingHidden {
+            return !hidden.contains(providerID)
+        }
+        return Self.isDefaultOnFamily(providerID)
     }
 
     func setConnected(_ connected: Bool, for providerID: String) {
-        if connected {
-            disconnectedProviders.remove(providerID)
-        } else {
-            disconnectedProviders.insert(providerID)
+        if defaults.object(forKey: Keys.connected) == nil, let hidden = pendingHidden {
+            let next = connected ? hidden.subtracting([providerID]) : hidden.union([providerID])
+            pendingHidden = next
+            defaults.set(Array(next), forKey: Keys.disconnected)
+            seenProviders.insert(providerID)
+            return
         }
+        if defaults.object(forKey: Keys.connected) == nil {
+            // First install: persist Claude and Codex as on, then apply this toggle.
+            connectedProviders = ["claude", "codex"]
+        }
+        if connected {
+            connectedProviders.insert(providerID)
+        } else {
+            connectedProviders.remove(providerID)
+        }
+        seenProviders.insert(providerID)
+    }
+
+    /// Fold this Mac's current provider ids into the stored on-list.
+    ///
+    /// First launch writes Claude and Codex. An upgrade from `hiddenProviders`
+    /// inverts that off-list against `discoveredIDs`. After that, only a
+    /// never-seen Claude or Codex id is added automatically.
+    func reconcile(discoveredIDs: [String]) {
+        let discovered = Set(discoveredIDs)
+        if defaults.object(forKey: Keys.connected) != nil {
+            let novel = discovered.subtracting(seenProviders)
+            for id in novel where Self.isDefaultOnFamily(id) {
+                connectedProviders.insert(id)
+            }
+            seenProviders.formUnion(discovered)
+            return
+        }
+        if let hidden = pendingHidden {
+            connectedProviders = discovered.subtracting(hidden)
+            seenProviders = discovered
+            pendingHidden = nil
+            return
+        }
+        connectedProviders = Set(discovered.filter(Self.isDefaultOnFamily))
+        seenProviders = discovered
+    }
+
+    /// What `UsageStore` still treats as the off-list, among ids it knows.
+    func disconnectedIDs(among discovered: [String]) -> Set<String> {
+        Set(discovered.filter { !isConnected($0) })
     }
 
     /// Record a new order, keeping the ids that are not on this Mac today.

--- a/Sources/Settings/Preferences.swift
+++ b/Sources/Settings/Preferences.swift
@@ -21,6 +21,14 @@ final class Preferences: ObservableObject {
         didSet { defaults.set(Array(seenProviders), forKey: Keys.seen) }
     }
 
+    /// Loaded-model cells hide without stopping the shared runtime. Stored as
+    /// the ones that are off: a model Ollama or LM Studio loads later stays
+    /// visible until someone hides it. Providers cannot share this list —
+    /// their on-list treats absence as off.
+    @Published private(set) var disabledModels: Set<String> {
+        didSet { defaults.set(Array(disabledModels), forKey: Keys.disabledModels) }
+    }
+
     /// The old hidden-providers list, kept only until `reconcile` can invert it
     /// against the ids actually on this Mac.
     private var pendingHidden: Set<String>?
@@ -278,6 +286,7 @@ final class Preferences: ObservableObject {
         static let disconnected = "hiddenProviders"
         static let connected = "connectedProviders"
         static let seen = "seenProviders"
+        static let disabledModels = "disabledModels"
         static let ollamaEndpoint = "ollamaEndpoint"
         static let lmstudioEndpoint = "lmstudioEndpoint"
         static let introducedOllama = "introducedOllama"
@@ -422,9 +431,21 @@ final class Preferences: ObservableObject {
             connected = []
             seen = storedSeen
         }
-        self.connectedProviders = connected
-        self.seenProviders = seen
+        self.connectedProviders = connected.filter { !Self.isModelCell($0) }
+        self.seenProviders = seen.filter { !Self.isModelCell($0) }
         self.pendingHidden = hidden
+        let models: Set<String>
+        if let storedDisabled = defaults.stringArray(forKey: Keys.disabledModels) {
+            models = Set(storedDisabled)
+        } else {
+            // Model cells that lived on the old off-list stay off. Read the
+            // leftover even after `connectedProviders` exists: an earlier
+            // invert left those ids in `hiddenProviders` and then ignored them.
+            let leftover = hidden ?? Set(defaults.stringArray(forKey: Keys.disconnected) ?? [])
+            models = leftover.filter(Self.isModelCell)
+        }
+        self.disabledModels = models
+        defaults.set(Array(models), forKey: Keys.disabledModels)
         let ollamaOn: Bool
         if storedConnected != nil {
             ollamaOn = connected.contains("ollama-local")
@@ -542,7 +563,16 @@ final class Preferences: ObservableObject {
             || CodexProfile.isCodex(providerID: providerID)
     }
 
+    /// Model cells are `providerID:model:…`. A new loaded model is not a new
+    /// provider, and absence on the provider on-list cannot mean on for these.
+    static func isModelCell(_ id: String) -> Bool {
+        id.contains(":model:")
+    }
+
     func isConnected(_ providerID: String) -> Bool {
+        if Self.isModelCell(providerID) {
+            return !disabledModels.contains(providerID)
+        }
         if defaults.object(forKey: Keys.connected) != nil {
             return connectedProviders.contains(providerID)
         }
@@ -553,6 +583,14 @@ final class Preferences: ObservableObject {
     }
 
     func setConnected(_ connected: Bool, for providerID: String) {
+        if Self.isModelCell(providerID) {
+            if connected {
+                disabledModels.remove(providerID)
+            } else {
+                disabledModels.insert(providerID)
+            }
+            return
+        }
         if defaults.object(forKey: Keys.connected) == nil, let hidden = pendingHidden {
             let next = connected ? hidden.subtracting([providerID]) : hidden.union([providerID])
             pendingHidden = next
@@ -576,10 +614,13 @@ final class Preferences: ObservableObject {
     ///
     /// First launch writes Claude and Codex. An upgrade from `hiddenProviders`
     /// inverts that off-list against `discoveredIDs`. After that, only a
-    /// never-seen Claude or Codex id is added automatically.
+    /// never-seen Claude or Codex id is added automatically. Model cells stay
+    /// on `disabledModels` and are not inverted.
     func reconcile(discoveredIDs: [String]) {
-        let discovered = Set(discoveredIDs)
+        let discovered = Set(discoveredIDs.filter { !Self.isModelCell($0) })
         if defaults.object(forKey: Keys.connected) != nil {
+            connectedProviders.subtract(connectedProviders.filter(Self.isModelCell))
+            seenProviders.subtract(seenProviders.filter(Self.isModelCell))
             let novel = discovered.subtracting(seenProviders)
             for id in novel where Self.isDefaultOnFamily(id) {
                 connectedProviders.insert(id)
@@ -588,7 +629,7 @@ final class Preferences: ObservableObject {
             return
         }
         if let hidden = pendingHidden {
-            connectedProviders = discovered.subtracting(hidden)
+            connectedProviders = discovered.subtracting(hidden.filter { !Self.isModelCell($0) })
             seenProviders = discovered
             pendingHidden = nil
             return

--- a/Sources/Settings/SettingsView.swift
+++ b/Sources/Settings/SettingsView.swift
@@ -507,7 +507,7 @@ struct SettingsView: View {
         .formStyle(.grouped)
         // A row switched off jumps from one group to the other. Scoped to that
         // one value so nothing else on the page inherits an animation.
-        .animation(.snappy(duration: 0.25), value: preferences.disconnectedProviders)
+        .animation(.snappy(duration: 0.25), value: preferences.connectedProviders)
     }
 
     // One pane, because they are one question: what Codenotch looks like and

--- a/Sources/Settings/SettingsView.swift
+++ b/Sources/Settings/SettingsView.swift
@@ -508,6 +508,7 @@ struct SettingsView: View {
         // A row switched off jumps from one group to the other. Scoped to that
         // one value so nothing else on the page inherits an animation.
         .animation(.snappy(duration: 0.25), value: preferences.connectedProviders)
+        .animation(.snappy(duration: 0.25), value: preferences.disabledModels)
     }
 
     // One pane, because they are one question: what Codenotch looks like and

--- a/Tests/LMStudioProviderTests.swift
+++ b/Tests/LMStudioProviderTests.swift
@@ -135,7 +135,7 @@ final class LMStudioProviderTests: XCTestCase {
     func testTheEndpointPreferenceIsLoopbackOnlyAndPersists() {
         let defaults = isolatedDefaults()
         let fresh = Preferences(defaults: defaults)
-        XCTAssertTrue(fresh.isConnected("lmstudio"), "on by default, like every provider; nothing shows until LM Studio answers")
+        XCTAssertFalse(fresh.isConnected("lmstudio"), "off until switched on; nothing shows until LM Studio answers")
         XCTAssertNoThrow(try LMStudioEndpoint.parse(fresh.lmstudioEndpoint))
         XCTAssertTrue(fresh.lmstudioEndpoint.hasPrefix("http://127.0.0.1:"))
         fresh.lmstudioEndpoint = "http://127.0.0.1:41343"

--- a/Tests/LMStudioViewTests.swift
+++ b/Tests/LMStudioViewTests.swift
@@ -181,7 +181,7 @@ final class LMStudioViewTests: XCTestCase {
                                       logsDirectory: FileManager.default.temporaryDirectory.appendingPathComponent(domain))
         for enabled in [false, true] {
             preferences.setConnected(enabled, for: "lmstudio")
-            store.disconnected = preferences.disconnectedProviders
+            store.disconnected = preferences.disconnectedIDs(among: store.knownIDs)
             let content = LMStudioSettingsRow(preferences: preferences, store: store, metrics: metrics)
                 .padding(20).frame(width: 460).background(Color(nsColor: .windowBackgroundColor))
             let hosting = NSHostingView(rootView: content)

--- a/Tests/NotchLayoutTests.swift
+++ b/Tests/NotchLayoutTests.swift
@@ -480,7 +480,8 @@ final class PreferencesTests: XCTestCase {
     func testEverythingIsConnectedByDefault() {
         let p = preferences()
         XCTAssertTrue(p.isConnected("claude"))
-        XCTAssertTrue(p.isConnected("a-provider-that-does-not-exist-yet"))
+        XCTAssertTrue(p.isConnected("codex"))
+        XCTAssertFalse(p.isConnected("a-provider-that-does-not-exist-yet"))
     }
 
     func testConnectingAndDisconnectingRoundTrips() {

--- a/Tests/OllamaPreferencesTests.swift
+++ b/Tests/OllamaPreferencesTests.swift
@@ -31,6 +31,7 @@ final class OllamaPreferencesTests: XCTestCase {
         XCTAssertFalse(preferences.isConnected("cursor"))
         XCTAssertFalse(preferences.isConnected("ollama-local"))
         XCTAssertFalse(preferences.isConnected("ollama-local:model:qwen3"))
+        XCTAssertEqual(preferences.disabledModels, ["ollama-local:model:qwen3"])
         XCTAssertEqual(preferences.providerOrder, ["ollama-local:model:qwen3", "codex", "ollama-local"])
         XCTAssertEqual(preferences.mutedAlertProviders, ["ollama-local", "claude"])
         XCTAssertFalse(preferences.ollamaMetricsEnabled)

--- a/Tests/OllamaPreferencesTests.swift
+++ b/Tests/OllamaPreferencesTests.swift
@@ -13,7 +13,7 @@ final class OllamaPreferencesTests: XCTestCase {
     func testFreshAndUpstreamUsersKeepInventoryEnabledWithoutStartingRelay() {
         let store = defaults()
         let fresh = Preferences(defaults: store)
-        XCTAssertTrue(fresh.isConnected("ollama-local"))
+        XCTAssertFalse(fresh.isConnected("ollama-local"))
         XCTAssertFalse(fresh.ollamaMetricsEnabled)
         fresh.setConnected(false, for: "ollama-local")
         let next = Preferences(defaults: store)
@@ -28,7 +28,9 @@ final class OllamaPreferencesTests: XCTestCase {
         store.set(["ollama:model:qwen3", "codex", "ollama-local:model:qwen3", "ollama"], forKey: "providerOrder")
         store.set(["ollama", "claude"], forKey: "mutedAlertProviders")
         let preferences = Preferences(defaults: store)
-        XCTAssertEqual(preferences.disconnectedProviders, ["cursor", "ollama-local", "ollama-local:model:qwen3"])
+        XCTAssertFalse(preferences.isConnected("cursor"))
+        XCTAssertFalse(preferences.isConnected("ollama-local"))
+        XCTAssertFalse(preferences.isConnected("ollama-local:model:qwen3"))
         XCTAssertEqual(preferences.providerOrder, ["ollama-local:model:qwen3", "codex", "ollama-local"])
         XCTAssertEqual(preferences.mutedAlertProviders, ["ollama-local", "claude"])
         XCTAssertFalse(preferences.ollamaMetricsEnabled)
@@ -53,7 +55,7 @@ final class OllamaPreferencesTests: XCTestCase {
         store.set(["ollama"], forKey: "hiddenProviders")
         store.set(["ollama", "codex"], forKey: "providerOrder")
         let preferences = Preferences(defaults: store)
-        XCTAssertEqual(preferences.disconnectedProviders, ["ollama"])
+        XCTAssertFalse(preferences.isConnected("ollama"))
         XCTAssertEqual(preferences.providerOrder, ["ollama", "codex"])
         XCTAssertTrue(preferences.isConnected("ollama-local"))
     }

--- a/Tests/OllamaTests.swift
+++ b/Tests/OllamaTests.swift
@@ -499,14 +499,17 @@ final class OllamaLifecycleTests: XCTestCase {
         let defaults = isolatedDefaults(), local = RuntimeStub(), cloud = QuotaStub()
         let preferences = Preferences(defaults: defaults)
         preferences.setConnected(true, for: "ollama-local")
+        preferences.setConnected(true, for: cloud.id)
         local.models = try OllamaLocalUsage.parse(Data(#"{"models":[{"name":"qwen3:8b"},{"name":"llama3.1:8b"}]}"#.utf8)).models
         let store = UsageStore(providers: [cloud, local], archive: UsageArchive(defaults: defaults))
         await store.refresh()
         let llama = "ollama-local:model:llama3.1:8b", qwen = "ollama-local:model:qwen3:8b"
+        preferences.setConnected(true, for: llama)
+        preferences.setConnected(true, for: qwen)
         preferences.setProviderOrder([qwen, cloud.id, llama])
         store.order = preferences.providerOrder
         preferences.setConnected(false, for: qwen)
-        store.disconnected = preferences.disconnectedProviders
+        store.disconnected = preferences.disconnectedIDs(among: store.knownIDs)
         XCTAssertEqual(store.notchSnapshots.map(\.id), [cloud.id, llama])
         XCTAssertTrue(store.localModelSummaries.contains { $0.id == qwen }, "Hidden models remain available in Not connected")
         XCTAssertTrue(preferences.isConnected("ollama-local"))
@@ -516,13 +519,13 @@ final class OllamaLifecycleTests: XCTestCase {
 
         let restored = Preferences(defaults: defaults)
         let relaunched = UsageStore(providers: [cloud, local], archive: UsageArchive(defaults: defaults),
-                                    disconnected: restored.disconnectedProviders, order: restored.providerOrder)
+                                    disconnected: restored.disconnectedIDs(among: [cloud.id, local.id, llama, qwen]), order: restored.providerOrder)
         await relaunched.refresh()
         XCTAssertEqual(relaunched.notchSnapshots.map(\.id), [cloud.id, llama])
         restored.setConnected(true, for: qwen)
         restored.setProviderOrder(ProviderOrder.joiningConnected(qwen, in: restored.providerOrder,
                                                                  isConnected: restored.isConnected))
-        relaunched.disconnected = restored.disconnectedProviders
+        relaunched.disconnected = restored.disconnectedIDs(among: [cloud.id, local.id, llama, qwen])
         relaunched.order = restored.providerOrder
         XCTAssertEqual(relaunched.notchSnapshots.map(\.id), [cloud.id, llama, qwen])
         relaunched.disconnected.insert("ollama-local")
@@ -806,7 +809,7 @@ final class OllamaRenderTests: XCTestCase {
         let preferences = Preferences(defaults: defaults)
         let local = RuntimeStub(), cloud = QuotaStub()
         let store = UsageStore(providers: [cloud, local], archive: UsageArchive(defaults: defaults),
-                               disconnected: preferences.disconnectedProviders)
+                               disconnected: preferences.disconnectedIDs(among: [cloud.id, local.id]))
         let content = SettingsView(preferences: preferences, providers: { store.providerSummaries },
             signOut: { store.signOut(providerID: $0) }, signIn: { store.signIn(providerID: $0) },
             switchAccount: { _ in false }, retry: { store.refresh(providerID: $0) },
@@ -833,7 +836,7 @@ final class OllamaRenderTests: XCTestCase {
         }
         try await capture("off")
         preferences.setConnected(true, for: "ollama-local")
-        store.disconnected = preferences.disconnectedProviders
+        store.disconnected = preferences.disconnectedIDs(among: store.knownIDs)
         await store.refresh()
         try await capture("empty")
         local.models = try OllamaLocalUsage.parse(Data(#"{"models":[{"name":"qwen3:8b","size":6442450944},{"name":"llama3.1:8b","size":4831838208}]}"#.utf8)).models
@@ -844,7 +847,7 @@ final class OllamaRenderTests: XCTestCase {
         store.order = preferences.providerOrder
         try await capture("reordered")
         preferences.setConnected(false, for: qwen)
-        store.disconnected = preferences.disconnectedProviders
+        store.disconnected = preferences.disconnectedIDs(among: store.knownIDs)
         try await capture("hidden")
         local.models = []
         await store.refresh(providerID: "ollama-local")?.value
@@ -905,10 +908,10 @@ final class OllamaRenderTests: XCTestCase {
         defer { defaults.removePersistentDomain(forName: domain) }
         let preferences = Preferences(defaults: defaults)
         let store = UsageStore(providers: [RuntimeStub()], archive: UsageArchive(defaults: defaults),
-                               disconnected: preferences.disconnectedProviders)
+                               disconnected: preferences.disconnectedIDs(among: ["ollama-local"]))
         for enabled in [false, true] {
             preferences.setConnected(enabled, for: "ollama-local")
-            store.disconnected = preferences.disconnectedProviders
+            store.disconnected = preferences.disconnectedIDs(among: store.knownIDs)
             if enabled { await store.refresh() }
             let content = OllamaSettingsRow(preferences: preferences, store: store, relay: OllamaActivityRelay())
                 .padding(20).frame(width: 460).background(Color(nsColor: .windowBackgroundColor))

--- a/Tests/PreferencesTests.swift
+++ b/Tests/PreferencesTests.swift
@@ -31,7 +31,8 @@ final class PreferencesMigrationTests: XCTestCase {
         Preferences.migrateFromPreviousName(into: fresh, from: oldName)
 
         let preferences = Preferences(defaults: fresh)
-        XCTAssertEqual(preferences.disconnectedProviders, ["glm"])
+        XCTAssertFalse(preferences.isConnected("glm"))
+        XCTAssertTrue(preferences.isConnected("claude"))
         XCTAssertEqual(preferences.notchVisibility, .alwaysShow)
     }
 
@@ -69,6 +70,49 @@ final class PreferencesMigrationTests: XCTestCase {
         XCTAssertEqual(preferences.notchEdge, .right)
         XCTAssertEqual(preferences.notchSize, .medium)
         XCTAssertEqual(preferences.weeklyRing, .off)
+        XCTAssertTrue(preferences.isConnected("claude"))
+        XCTAssertTrue(preferences.isConnected("codex"))
+        XCTAssertTrue(preferences.isConnected("claude-work"))
+        XCTAssertFalse(preferences.isConnected("cursor"))
+        XCTAssertFalse(preferences.isConnected("glm"))
+    }
+
+    func testAFirstLaunchSeedsClaudeAndCodexOnceDiscovered() {
+        let (fresh, name) = makeDefaults()
+        let preferences = Preferences(defaults: fresh)
+        preferences.reconcile(discoveredIDs: ["claude", "codex", "cursor", "glm", "claude-work"])
+        XCTAssertEqual(preferences.connectedProviders, ["claude", "codex", "claude-work"])
+        XCTAssertFalse(preferences.isConnected("cursor"))
+
+        let again = Preferences(defaults: UserDefaults(suiteName: name)!)
+        again.reconcile(discoveredIDs: ["claude", "codex", "cursor", "glm", "claude-work", "deepseek"])
+        XCTAssertFalse(again.isConnected("cursor"))
+        XCTAssertFalse(again.isConnected("deepseek"))
+        XCTAssertTrue(again.isConnected("claude"))
+    }
+
+    func testHiddenProvidersInvertAgainstWhatThisMacHas() {
+        let (fresh, _) = makeDefaults()
+        fresh.set(["glm", "cursor"], forKey: "hiddenProviders")
+        let preferences = Preferences(defaults: fresh)
+        XCTAssertFalse(preferences.isConnected("glm"))
+        XCTAssertTrue(preferences.isConnected("claude"))
+        preferences.reconcile(discoveredIDs: ["claude", "codex", "cursor", "glm"])
+        XCTAssertEqual(preferences.connectedProviders, ["claude", "codex"])
+        XCTAssertFalse(preferences.isConnected("cursor"))
+        XCTAssertTrue(preferences.isConnected("claude"))
+    }
+
+    func testANewClaudeProfileTurnsOnWithoutReopeningCursor() {
+        let (fresh, name) = makeDefaults()
+        let preferences = Preferences(defaults: fresh)
+        preferences.reconcile(discoveredIDs: ["claude", "codex", "cursor"])
+        XCTAssertFalse(preferences.isConnected("cursor"))
+
+        let later = Preferences(defaults: UserDefaults(suiteName: name)!)
+        later.reconcile(discoveredIDs: ["claude", "codex", "cursor", "claude-work"])
+        XCTAssertTrue(later.isConnected("claude-work"))
+        XCTAssertFalse(later.isConnected("cursor"))
     }
 
     /// Off by default, and it has to stay chosen once it is chosen: an extra

--- a/Tests/PreferencesTests.swift
+++ b/Tests/PreferencesTests.swift
@@ -115,6 +115,93 @@ final class PreferencesMigrationTests: XCTestCase {
         XCTAssertFalse(later.isConnected("cursor"))
     }
 
+    /// A 1.9 install with nothing hidden still shows each loaded model after
+    /// the invert. Model cells are not providers: they are absent from the
+    /// on-list, and absence there must not mean off.
+    func testAnUpgradeDoesNotHideLoadedModels() {
+        let (fresh, _) = makeDefaults()
+        fresh.set([String](), forKey: "hiddenProviders")
+        let preferences = Preferences(defaults: fresh)
+        preferences.reconcile(discoveredIDs: ["claude", "codex", "ollama-local"])
+        let model = "ollama-local:model:qwen3:8b"
+        XCTAssertFalse(preferences.disconnectedIDs(among: [
+            "claude", "codex", "ollama-local", model
+        ]).contains(model))
+        XCTAssertTrue(preferences.isConnected(model))
+        XCTAssertTrue(preferences.isConnected("ollama-local"))
+        XCTAssertTrue(preferences.disabledModels.isEmpty)
+    }
+
+    /// Model ids on the old off-list stay off. They are not inverted onto
+    /// `connectedProviders`.
+    func testAHiddenModelStaysHiddenAfterTheOnListInvert() {
+        let (fresh, name) = makeDefaults()
+        fresh.set(["glm", "ollama-local:model:qwen3"], forKey: "hiddenProviders")
+        let preferences = Preferences(defaults: fresh)
+        preferences.reconcile(discoveredIDs: ["claude", "codex", "glm", "ollama-local"])
+        XCTAssertFalse(preferences.isConnected("glm"))
+        XCTAssertTrue(preferences.isConnected("ollama-local"))
+        XCTAssertFalse(preferences.isConnected("ollama-local:model:qwen3"))
+        XCTAssertEqual(preferences.disabledModels, ["ollama-local:model:qwen3"])
+        XCTAssertFalse(preferences.connectedProviders.contains { Preferences.isModelCell($0) })
+
+        let again = Preferences(defaults: UserDefaults(suiteName: name)!)
+        XCTAssertFalse(again.isConnected("ollama-local:model:qwen3"))
+        XCTAssertTrue(again.isConnected("ollama-local"))
+    }
+
+    /// An invert that already wrote `connectedProviders` still left model ids
+    /// on `hiddenProviders`. Those hides must not be forgotten.
+    func testModelHidesSurviveAPreviousInvertThatDroppedThem() {
+        let (fresh, _) = makeDefaults()
+        fresh.set(["claude", "codex", "ollama-local"], forKey: "connectedProviders")
+        fresh.set(["claude", "codex", "ollama-local"], forKey: "seenProviders")
+        fresh.set(["ollama-local:model:qwen3"], forKey: "hiddenProviders")
+        let preferences = Preferences(defaults: fresh)
+        XCTAssertFalse(preferences.isConnected("ollama-local:model:qwen3"))
+        XCTAssertTrue(preferences.isConnected("ollama-local"))
+        XCTAssertEqual(preferences.disabledModels, ["ollama-local:model:qwen3"])
+    }
+
+    /// Recomputing the store off-list after a provider toggle must not hide
+    /// models that nobody hid.
+    func testSwitchingAProviderDoesNotHideLoadedModels() {
+        let (fresh, _) = makeDefaults()
+        let preferences = Preferences(defaults: fresh)
+        preferences.reconcile(discoveredIDs: ["claude", "codex", "cursor", "ollama-local"])
+        let model = "ollama-local:model:qwen3:8b"
+        XCTAssertTrue(preferences.isConnected(model))
+        preferences.setConnected(true, for: "cursor")
+        XCTAssertTrue(preferences.isConnected(model))
+        XCTAssertFalse(preferences.disconnectedIDs(among: [
+            "claude", "codex", "cursor", "ollama-local", model
+        ]).contains(model))
+        XCTAssertTrue(preferences.disabledModels.isEmpty)
+    }
+
+    /// A newly loaded model is on until hidden, and hiding it does not put it
+    /// on the provider on-list.
+    func testALoadedModelStaysOffTheProviderOnList() {
+        let (fresh, name) = makeDefaults()
+        let preferences = Preferences(defaults: fresh)
+        preferences.reconcile(discoveredIDs: ["claude", "codex", "ollama-local"])
+        let model = "ollama-local:model:qwen3:8b"
+        XCTAssertTrue(preferences.isConnected(model))
+        preferences.setConnected(false, for: model)
+        XCTAssertEqual(preferences.disabledModels, [model])
+        XCTAssertFalse(preferences.connectedProviders.contains(model))
+        XCTAssertFalse(preferences.seenProviders.contains(model))
+
+        let hidden = Preferences(defaults: UserDefaults(suiteName: name)!)
+        XCTAssertFalse(hidden.isConnected(model))
+        hidden.setConnected(true, for: model)
+        XCTAssertTrue(hidden.disabledModels.isEmpty)
+
+        let shown = Preferences(defaults: UserDefaults(suiteName: name)!)
+        XCTAssertTrue(shown.isConnected(model))
+        XCTAssertFalse(shown.connectedProviders.contains(model))
+    }
+
     /// Off by default, and it has to stay chosen once it is chosen: an extra
     /// arc in a 44pt circle changes how every reading looks, so it is not
     /// something to switch on for somebody, nor to forget they switched on.


### PR DESCRIPTION
## Summary

Codenotch used to remember which providers were switched off. Anything not on that list was treated as on, so a new install — and every newly added provider — lit up rings the user had never asked for. If you only subscribe to one or two tools, you had to go through Settings and turn the rest off.

This stores the providers that are on instead.

A first install starts with Claude and Codex, which is probably what most people actually have. Everything else stays off until you switch it on. An existing install keeps the rings you already chose. A provider added in a later version stays off; a newly discovered Claude or Codex account still defaults on.

## Test plan

- [x] First install: only Claude / Codex connected
- [x] Upgrade: previously-on providers stay on
- [x] Toggle Cursor on, relaunch, it stays on
- [x] A newly discovered Claude profile defaults on without turning Cursor on