### PR TITLE
feat: add usage reset and limit reached notifications

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ DerivedData/
 xcuserdata/
 *.xcuserstate
 .swiftpm/
+.agents/
+.forgeguard/

--- a/Makefile
+++ b/Makefile
@@ -328,7 +328,9 @@ dmg-ci: build-ci
 	mkdir -p $(CI_DIR)/stage
 	cp -R $(CI_APP) $(CI_DIR)/stage/
 	ln -s /Applications $(CI_DIR)/stage/Applications
-	hdiutil create -volname "$(APP_NAME)" -srcfolder $(CI_DIR)/stage \
-		-ov -format UDZO $(CI_DMG)
+	for i in 1 2 3; do \
+		hdiutil create -volname "$(APP_NAME)" -srcfolder $(CI_DIR)/stage \
+			-ov -format UDZO $(CI_DMG) && break || sleep 2; \
+	done
 	rm -rf $(CI_DIR)/stage
 	@echo "Unsigned disk image: $(CI_DMG)"

--- a/Sources/App/AppDelegate.swift
+++ b/Sources/App/AppDelegate.swift
@@ -240,6 +240,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                     preferences?.setOffset(0, for: preferences?.notchEdge ?? .right)
                     fleet?.apply(alongOffset: 0)
                 },
+                previewResetAlert: { [weak self] in
+                    self?.previewUsageResetAlert()
+                },
                 usageStore: store, ollamaRelay: relay, lmstudioMetrics: lmstudio
             )
             // The gear toggles; everything else that opens settings opens it.
@@ -626,6 +629,20 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
         guard preferences.announceUsageReset else { return }
         fleet.showResetAlert(event, duration: 5.0)
+    }
+
+    @MainActor
+    private func previewUsageResetAlert() {
+        let demo = UsageResetEvent(
+            providerID: "claude",
+            providerName: "Claude",
+            windowLabel: "5-hour limit",
+            glyph: .claude,
+            previousFraction: 0.95,
+            currentFraction: 0.00,
+            resetsAt: Date().addingTimeInterval(5 * 3600)
+        )
+        announceUsageReset(event: demo)
     }
 
     /// Closing the settings window must not take the app with it.

--- a/Sources/App/AppDelegate.swift
+++ b/Sources/App/AppDelegate.swift
@@ -14,6 +14,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// Held for the life of the app: releasing it stops the scheduled checks.
     private var updater: Updater?
     private var thresholdNotifier: ThresholdNotifier?
+    private var resetWatcher: UsageResetWatcher?
     private var statusItem: StatusItemController?
     /// Keeps the Claude keychain token from ageing out on a Mac where the CLI
     /// is never run by hand. See `ClaudeTokenRefresher`.
@@ -437,6 +438,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             )
             self.thresholdNotifier = notifier
 
+            let resetWatcher = UsageResetWatcher(
+                isMuted: { [weak preferences] in preferences?.isMutedAlerts(for: $0) ?? false },
+                deliver: { [weak self] event in
+                    MainActor.assumeIsolated {
+                        self?.announceUsageReset(event: event)
+                    }
+                }
+            )
+            self.resetWatcher = resetWatcher
+
             store.$notchSnapshots
                 .receive(on: RunLoop.main)
                 .sink { [weak fleet] in fleet?.setSnapshots($0) }
@@ -447,6 +458,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 .sink { [weak statusItem] snapshots in
                     statusItem?.snapshots = snapshots
                     notifier.observe(snapshots)
+                    resetWatcher.observe(snapshots)
                 }
                 .store(in: &cancellables)
             store.start()
@@ -601,6 +613,19 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         guard preferences.announceSessionEnd else { return }
         fleet.peek(for: preferences.peekDuration.seconds,
                    focusing: event.session.processID)
+    }
+
+    /// Open the notch and show a usage reset notification modal when a limit resets.
+    @MainActor
+    private func announceUsageReset(event: UsageResetEvent) {
+        guard let preferences, let fleet = notchFleet else { return }
+        Log.usage.info("usage reset for \(event.providerName, privacy: .public) (\(event.windowLabel, privacy: .public))")
+
+        if preferences.usageResetSound {
+            SessionChime.play(preferences.usageResetSoundName)
+        }
+        guard preferences.announceUsageReset else { return }
+        fleet.showResetAlert(event, duration: 5.0)
     }
 
     /// Closing the settings window must not take the app with it.

--- a/Sources/App/AppDelegate.swift
+++ b/Sources/App/AppDelegate.swift
@@ -15,6 +15,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var updater: Updater?
     private var thresholdNotifier: ThresholdNotifier?
     private var resetWatcher: UsageResetWatcher?
+    private var limitWatcher: UsageLimitWatcher?
     private var statusItem: StatusItemController?
     /// Keeps the Claude keychain token from ageing out on a Mac where the CLI
     /// is never run by hand. See `ClaudeTokenRefresher`.
@@ -243,6 +244,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 previewResetAlert: { [weak self] in
                     self?.previewUsageResetAlert()
                 },
+                previewSessionLimitAlert: { [weak self] in
+                    self?.previewSessionLimitAlert()
+                },
+                previewWeeklyLimitAlert: { [weak self] in
+                    self?.previewWeeklyLimitAlert()
+                },
                 usageStore: store, ollamaRelay: relay, lmstudioMetrics: lmstudio
             )
             // The gear toggles; everything else that opens settings opens it.
@@ -451,6 +458,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             )
             self.resetWatcher = resetWatcher
 
+            let limitWatcher = UsageLimitWatcher(
+                isMuted: { [weak preferences] in preferences?.isMutedAlerts(for: $0) ?? false },
+                deliver: { [weak self] event in
+                    MainActor.assumeIsolated {
+                        self?.announceUsageLimit(event: event)
+                    }
+                }
+            )
+            self.limitWatcher = limitWatcher
+
             store.$notchSnapshots
                 .receive(on: RunLoop.main)
                 .sink { [weak fleet] in fleet?.setSnapshots($0) }
@@ -462,6 +479,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                     statusItem?.snapshots = snapshots
                     notifier.observe(snapshots)
                     resetWatcher.observe(snapshots)
+                    limitWatcher.observe(snapshots)
                 }
                 .store(in: &cancellables)
             store.start()
@@ -633,6 +651,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     @MainActor
     private func previewUsageResetAlert() {
+        guard let preferences, let fleet = notchFleet else { return }
         let demo = UsageResetEvent(
             providerID: "claude",
             providerName: "Claude",
@@ -642,7 +661,73 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             currentFraction: 0.00,
             resetsAt: Date().addingTimeInterval(5 * 3600)
         )
-        announceUsageReset(event: demo)
+        if preferences.usageResetSound {
+            SessionChime.play(preferences.usageResetSoundName)
+        }
+        fleet.showResetAlert(demo, duration: 5.0)
+    }
+
+    /// Open the notch and show a usage limit reached notification modal when a limit is exhausted.
+    @MainActor
+    private func announceUsageLimit(event: UsageAlertEvent) {
+        guard let preferences, let fleet = notchFleet else { return }
+
+        let isAnnounceEnabled: Bool
+        switch event.kind {
+        case .sessionLimitReached:
+            isAnnounceEnabled = preferences.announceSessionLimitReached
+        case .weeklyLimitReached:
+            isAnnounceEnabled = preferences.announceWeeklyLimitReached
+        case .reset:
+            isAnnounceEnabled = preferences.announceUsageReset
+        }
+
+        guard isAnnounceEnabled else { return }
+
+        Log.usage.info("usage limit reached for \(event.providerName, privacy: .public) (\(event.windowLabel, privacy: .public))")
+
+        if preferences.limitReachedSound {
+            SessionChime.play(preferences.limitReachedSoundName)
+        }
+        fleet.showResetAlert(event, duration: 6.0)
+    }
+
+    @MainActor
+    private func previewSessionLimitAlert() {
+        guard let preferences, let fleet = notchFleet else { return }
+        let demo = UsageAlertEvent(
+            kind: .sessionLimitReached,
+            providerID: "claude",
+            providerName: "Claude",
+            windowLabel: "5-hour",
+            glyph: .claude,
+            previousFraction: 0.95,
+            currentFraction: 1.00,
+            resetsAt: Date().addingTimeInterval(45 * 60)
+        )
+        if preferences.limitReachedSound {
+            SessionChime.play(preferences.limitReachedSoundName)
+        }
+        fleet.showResetAlert(demo, duration: 6.0)
+    }
+
+    @MainActor
+    private func previewWeeklyLimitAlert() {
+        guard let preferences, let fleet = notchFleet else { return }
+        let demo = UsageAlertEvent(
+            kind: .weeklyLimitReached,
+            providerID: "claude",
+            providerName: "Claude",
+            windowLabel: "Weekly",
+            glyph: .claude,
+            previousFraction: 0.98,
+            currentFraction: 1.00,
+            resetsAt: Date().addingTimeInterval(3 * 86400)
+        )
+        if preferences.limitReachedSound {
+            SessionChime.play(preferences.limitReachedSoundName)
+        }
+        fleet.showResetAlert(demo, duration: 6.0)
     }
 
     /// Closing the settings window must not take the app with it.

--- a/Sources/Features/TooltipCard.swift
+++ b/Sources/Features/TooltipCard.swift
@@ -5,7 +5,7 @@ import SwiftUI
 /// Its shoulders leave the card tangent to the card's edge. That continuous
 /// tangent is what makes the two pieces read as one moulded silhouette rather
 /// than a triangle pasted onto a rounded rectangle.
-private struct TooltipTail: Shape {
+struct TooltipTail: Shape {
     /// Which way the card sits relative to the notch — the tip points back the
     /// other way, at the cell.
     let direction: NotchEdge.TooltipDirection

--- a/Sources/Features/UsageResetCard.swift
+++ b/Sources/Features/UsageResetCard.swift
@@ -28,6 +28,55 @@ struct UsageResetCard: View {
             }
     }
 
+    private var titleText: String {
+        switch event.kind {
+        case .reset:
+            return L10n.t("\(event.providerName) Reset")
+        case .sessionLimitReached:
+            return L10n.t("\(event.providerName) Limit Reached")
+        case .weeklyLimitReached:
+            return L10n.t("\(event.providerName) Weekly Limit")
+        }
+    }
+
+    private var subtitleText: String {
+        switch event.kind {
+        case .reset:
+            return L10n.t("\(event.windowLabel) limit refreshed")
+        case .sessionLimitReached, .weeklyLimitReached:
+            return L10n.t("\(event.windowLabel) limit is spent")
+        }
+    }
+
+    private var statusColor: Color {
+        switch event.kind {
+        case .reset:
+            return Palette.ample
+        case .sessionLimitReached, .weeklyLimitReached:
+            return Palette.critical
+        }
+    }
+
+    private var statusText: String {
+        switch event.kind {
+        case .reset:
+            return L10n.t("Quota is available (0% used)")
+        case .sessionLimitReached:
+            return L10n.t("Session limit reached (100% used)")
+        case .weeklyLimitReached:
+            return L10n.t("Weekly limit reached (100% used)")
+        }
+    }
+
+    private var resetTimePrefix: String {
+        switch event.kind {
+        case .reset:
+            return L10n.t("Next reset")
+        case .sessionLimitReached, .weeklyLimitReached:
+            return L10n.t("Resets at")
+        }
+    }
+
     private var card: some View {
         ZStack(alignment: .topLeading) {
             RoundedRectangle(cornerRadius: NotchLayout.cardCorner, style: .circular)
@@ -41,7 +90,7 @@ struct UsageResetCard: View {
 
                     VStack(alignment: .leading, spacing: 0) {
                         HStack(spacing: 0) {
-                            Text(L10n.t("\(event.providerName) Reset"))
+                            Text(titleText)
                                 .font(Typography.cardTitle)
                                 .foregroundStyle(Palette.textPrimary)
                                 .layoutPriority(1)
@@ -59,7 +108,7 @@ struct UsageResetCard: View {
                             }
                         }
 
-                        Text(L10n.t("\(event.windowLabel) limit refreshed"))
+                        Text(subtitleText)
                             .font(Typography.cardBody)
                             .foregroundStyle(Palette.textSecondary)
                             .lineLimit(1)
@@ -68,12 +117,12 @@ struct UsageResetCard: View {
 
                 HStack(spacing: Design.px(12)) {
                     Circle()
-                        .fill(Palette.ample)
+                        .fill(statusColor)
                         .frame(width: Design.px(16), height: Design.px(16))
 
-                    Text(L10n.t("Quota is available (0% used)"))
+                    Text(statusText)
                         .font(Typography.cardBody)
-                        .foregroundStyle(Palette.ample)
+                        .foregroundStyle(statusColor)
                         .lineLimit(1)
 
                     Spacer(minLength: 0)
@@ -81,7 +130,7 @@ struct UsageResetCard: View {
                 .padding(.top, NotchLayout.headerToBlock)
 
                 if let resetsAt = event.resetsAt {
-                    Text(L10n.t("Next reset \(resetsAt.formatted(date: .omitted, time: .shortened))"))
+                    Text("\(resetTimePrefix) \(resetsAt.formatted(date: .omitted, time: .shortened))")
                         .font(Typography.cardBody)
                         .foregroundStyle(Palette.textSecondary)
                         .lineLimit(1)

--- a/Sources/Features/UsageResetCard.swift
+++ b/Sources/Features/UsageResetCard.swift
@@ -1,0 +1,125 @@
+import SwiftUI
+
+/// The notification modal card displayed beside the notch when a provider's limit resets.
+struct UsageResetCard: View {
+    let event: UsageResetEvent
+    let direction: NotchEdge.TooltipDirection
+    var tailOffset: CGFloat = 0
+    var onDismiss: (() -> Void)? = nil
+
+    @Environment(\.codenotchAccentColor) private var accentColor
+    @Environment(\.codenotchReduceTransparency) private var reduceTransparency
+    @Environment(\.notchSurfaceStyle) private var surfaceStyle
+
+    static let cardHeight: CGFloat = Design.px(210)
+
+    private var glassy: Bool { surfaceStyle.effective == .glass && !reduceTransparency }
+    private var surfaceFill: Color { glassy ? .clear : Palette.card }
+
+    var body: some View {
+        stack
+            .background {
+                if glassy {
+                    if #available(macOS 26.0, *) {
+                        Color.clear
+                            .glassEffect(.regular, in: TooltipSilhouette(direction: direction, tailOffset: tailOffset))
+                    }
+                }
+            }
+    }
+
+    private var card: some View {
+        ZStack(alignment: .topLeading) {
+            RoundedRectangle(cornerRadius: NotchLayout.cardCorner, style: .circular)
+                .fill(surfaceFill)
+                .frame(width: NotchLayout.cardWidth, height: Self.cardHeight)
+
+            VStack(alignment: .leading, spacing: 0) {
+                HStack(alignment: .center, spacing: NotchLayout.headerGap) {
+                    ProviderGlyphView(glyph: event.glyph)
+                        .foregroundStyle(Palette.textPrimary)
+
+                    VStack(alignment: .leading, spacing: 0) {
+                        HStack(spacing: 0) {
+                            Text(L10n.t("\(event.providerName) Reset"))
+                                .font(Typography.cardTitle)
+                                .foregroundStyle(Palette.textPrimary)
+                                .layoutPriority(1)
+
+                            Spacer(minLength: Design.px(12))
+
+                            if let onDismiss {
+                                Button(action: onDismiss) {
+                                    Image(systemName: "xmark")
+                                        .font(.system(size: 11, weight: .bold))
+                                        .foregroundStyle(Palette.textSecondary)
+                                        .frame(width: 16, height: 16)
+                                }
+                                .buttonStyle(.plain)
+                            }
+                        }
+
+                        Text(L10n.t("\(event.windowLabel) limit refreshed"))
+                            .font(Typography.cardBody)
+                            .foregroundStyle(Palette.textSecondary)
+                            .lineLimit(1)
+                    }
+                }
+
+                HStack(spacing: Design.px(12)) {
+                    Circle()
+                        .fill(Palette.ample)
+                        .frame(width: Design.px(16), height: Design.px(16))
+
+                    Text(L10n.t("Quota is available (0% used)"))
+                        .font(Typography.cardBody)
+                        .foregroundStyle(Palette.ample)
+                        .lineLimit(1)
+
+                    Spacer(minLength: 0)
+                }
+                .padding(.top, NotchLayout.headerToBlock)
+
+                if let resetsAt = event.resetsAt {
+                    Text(L10n.t("Next reset \(resetsAt.formatted(date: .omitted, time: .shortened))"))
+                        .font(Typography.cardBody)
+                        .foregroundStyle(Palette.textSecondary)
+                        .lineLimit(1)
+                        .padding(.top, Design.px(8))
+                }
+            }
+            .padding(NotchLayout.cardPadding)
+            .frame(width: NotchLayout.cardWidth, height: Self.cardHeight, alignment: .topLeading)
+        }
+        .frame(width: NotchLayout.cardWidth, height: Self.cardHeight, alignment: .top)
+        .clipShape(RoundedRectangle(cornerRadius: NotchLayout.cardCorner, style: .circular))
+        .overlay {
+            if reduceTransparency {
+                RoundedRectangle(cornerRadius: NotchLayout.cardCorner, style: .circular)
+                    .strokeBorder(Palette.ringTrack, lineWidth: 1)
+            }
+        }
+    }
+
+    private var tail: some View {
+        let size = TooltipTail.size(for: direction)
+        return TooltipTail(direction: direction)
+            .fill(surfaceFill)
+            .frame(width: size.width, height: size.height)
+            .offset(x: direction == .up || direction == .down ? tailOffset : 0,
+                    y: direction == .leading || direction == .trailing ? tailOffset : 0)
+    }
+
+    @ViewBuilder private var stack: some View {
+        switch direction {
+        case .leading:
+            HStack(spacing: 0) { card; tail }
+        case .trailing:
+            HStack(spacing: 0) { tail; card }
+        case .down:
+            VStack(spacing: 0) { tail; card }
+        case .up:
+            VStack(spacing: 0) { card; tail }
+        }
+    }
+}

--- a/Sources/Model/UsageLimitWatcher.swift
+++ b/Sources/Model/UsageLimitWatcher.swift
@@ -1,0 +1,108 @@
+import Foundation
+
+/// Watches store snapshots and detects when a provider's session or weekly
+/// limit reaches 100% (exhausted) or becomes blocked.
+@MainActor
+final class UsageLimitWatcher {
+    private struct TrackedLimit {
+        var isExhausted: Bool = false
+        var resetsAt: Date?
+        var fraction: Double = 0
+    }
+
+    private struct ProviderLimitState {
+        var session: TrackedLimit = TrackedLimit()
+        var weekly: TrackedLimit = TrackedLimit()
+    }
+
+    private var states: [String: ProviderLimitState] = [:]
+    private let isMuted: (String) -> Bool
+    private let deliver: (UsageAlertEvent) -> Void
+
+    init(
+        isMuted: @escaping (String) -> Bool = { _ in false },
+        deliver: @escaping (UsageAlertEvent) -> Void = { _ in }
+    ) {
+        self.isMuted = isMuted
+        self.deliver = deliver
+    }
+
+    func observe(_ snapshots: [ProviderSnapshot]) {
+        for snapshot in snapshots {
+            observe(snapshot)
+        }
+    }
+
+    private func observe(_ snapshot: ProviderSnapshot) {
+        var state = states[snapshot.id] ?? ProviderLimitState()
+        let isFirstObservation = states[snapshot.id] == nil
+
+        // 1. Session limit (headline window)
+        if let headline = snapshot.headline, let fraction = snapshot.usedFraction {
+            let isExhausted = fraction >= 1.0 || snapshot.block != nil
+
+            let dateRolledOver = headline.resetsAt != nil
+                && state.session.resetsAt != nil
+                && headline.resetsAt != state.session.resetsAt
+                && headline.resetsAt! > state.session.resetsAt!
+
+            if dateRolledOver || fraction < 0.95 {
+                state.session.isExhausted = false
+            }
+
+            if isExhausted && !state.session.isExhausted && !isFirstObservation && !isMuted(snapshot.id) {
+                state.session.isExhausted = true
+                deliver(UsageAlertEvent(
+                    kind: .sessionLimitReached,
+                    providerID: snapshot.id,
+                    providerName: snapshot.displayName,
+                    windowLabel: headline.label,
+                    glyph: snapshot.glyph,
+                    previousFraction: state.session.fraction,
+                    currentFraction: fraction,
+                    resetsAt: headline.resetsAt
+                ))
+            } else if isFirstObservation && isExhausted {
+                state.session.isExhausted = true
+            }
+
+            state.session.fraction = fraction
+            state.session.resetsAt = headline.resetsAt
+        }
+
+        // 2. Weekly limit (secondary window)
+        if let weekly = snapshot.weeklyWindow, let weeklyFraction = snapshot.weeklyFraction {
+            let isWeeklyExhausted = weeklyFraction >= 1.0
+
+            let dateRolledOver = weekly.resetsAt != nil
+                && state.weekly.resetsAt != nil
+                && weekly.resetsAt != state.weekly.resetsAt
+                && weekly.resetsAt! > state.weekly.resetsAt!
+
+            if dateRolledOver || weeklyFraction < 0.95 {
+                state.weekly.isExhausted = false
+            }
+
+            if isWeeklyExhausted && !state.weekly.isExhausted && !isFirstObservation && !isMuted(snapshot.id) {
+                state.weekly.isExhausted = true
+                deliver(UsageAlertEvent(
+                    kind: .weeklyLimitReached,
+                    providerID: snapshot.id,
+                    providerName: snapshot.displayName,
+                    windowLabel: weekly.label,
+                    glyph: snapshot.glyph,
+                    previousFraction: state.weekly.fraction,
+                    currentFraction: weeklyFraction,
+                    resetsAt: weekly.resetsAt
+                ))
+            } else if isFirstObservation && isWeeklyExhausted {
+                state.weekly.isExhausted = true
+            }
+
+            state.weekly.fraction = weeklyFraction
+            state.weekly.resetsAt = weekly.resetsAt
+        }
+
+        states[snapshot.id] = state
+    }
+}

--- a/Sources/Model/UsageResetWatcher.swift
+++ b/Sources/Model/UsageResetWatcher.swift
@@ -1,7 +1,15 @@
 import Foundation
 
-/// One reset event for a provider's headline limit window.
-struct UsageResetEvent: Equatable {
+/// The kind of usage alert event.
+enum UsageAlertKind: Equatable {
+    case reset
+    case sessionLimitReached
+    case weeklyLimitReached
+}
+
+/// One alert event for a provider's usage window (reset or limit reached).
+struct UsageAlertEvent: Equatable {
+    let kind: UsageAlertKind
     let providerID: String
     let providerName: String
     let windowLabel: String
@@ -11,6 +19,7 @@ struct UsageResetEvent: Equatable {
     let resetsAt: Date?
 
     init(
+        kind: UsageAlertKind = .reset,
         providerID: String,
         providerName: String,
         windowLabel: String,
@@ -19,6 +28,7 @@ struct UsageResetEvent: Equatable {
         currentFraction: Double,
         resetsAt: Date?
     ) {
+        self.kind = kind
         self.providerID = providerID
         self.providerName = providerName
         self.windowLabel = windowLabel
@@ -28,6 +38,8 @@ struct UsageResetEvent: Equatable {
         self.resetsAt = resetsAt
     }
 }
+
+typealias UsageResetEvent = UsageAlertEvent
 
 /// Watches store snapshots and detects when a provider's limit window rolls over
 /// or its usage drops back down to reset levels.

--- a/Sources/Model/UsageResetWatcher.swift
+++ b/Sources/Model/UsageResetWatcher.swift
@@ -1,0 +1,109 @@
+import Foundation
+
+/// One reset event for a provider's headline limit window.
+struct UsageResetEvent: Equatable {
+    let providerID: String
+    let providerName: String
+    let windowLabel: String
+    let glyph: ProviderGlyph
+    let previousFraction: Double
+    let currentFraction: Double
+    let resetsAt: Date?
+
+    init(
+        providerID: String,
+        providerName: String,
+        windowLabel: String,
+        glyph: ProviderGlyph,
+        previousFraction: Double,
+        currentFraction: Double,
+        resetsAt: Date?
+    ) {
+        self.providerID = providerID
+        self.providerName = providerName
+        self.windowLabel = windowLabel
+        self.glyph = glyph
+        self.previousFraction = previousFraction
+        self.currentFraction = currentFraction
+        self.resetsAt = resetsAt
+    }
+}
+
+/// Watches store snapshots and detects when a provider's limit window rolls over
+/// or its usage drops back down to reset levels.
+@MainActor
+final class UsageResetWatcher {
+    private struct TrackedState {
+        var fraction: Double
+        var resetsAt: Date?
+        var peakFraction: Double
+        var lastAlertedResetDate: Date?
+    }
+
+    private var states: [String: TrackedState] = [:]
+    private let isMuted: (String) -> Bool
+    private let deliver: (UsageResetEvent) -> Void
+
+    init(
+        isMuted: @escaping (String) -> Bool = { _ in false },
+        deliver: @escaping (UsageResetEvent) -> Void = { _ in }
+    ) {
+        self.isMuted = isMuted
+        self.deliver = deliver
+    }
+
+    func observe(_ snapshots: [ProviderSnapshot]) {
+        for snapshot in snapshots {
+            observe(snapshot)
+        }
+    }
+
+    private func observe(_ snapshot: ProviderSnapshot) {
+        guard let headline = snapshot.headline,
+              let fraction = snapshot.usedFraction else { return }
+
+        guard var previous = states[snapshot.id] else {
+            states[snapshot.id] = TrackedState(
+                fraction: fraction,
+                resetsAt: headline.resetsAt,
+                peakFraction: fraction,
+                lastAlertedResetDate: headline.resetsAt
+            )
+            return
+        }
+
+        let isDateRolled = headline.resetsAt != nil
+            && previous.resetsAt != nil
+            && headline.resetsAt != previous.resetsAt
+            && (previous.lastAlertedResetDate == nil || headline.resetsAt! > previous.lastAlertedResetDate!)
+
+        let droppedSignificantly = fraction < previous.fraction
+            && (previous.fraction - fraction >= 0.20 || (previous.peakFraction >= 0.30 && fraction <= 0.10))
+
+        let hadSignificantUsage = previous.peakFraction >= 0.15
+
+        if (isDateRolled || droppedSignificantly) && hadSignificantUsage && !isMuted(snapshot.id) {
+            let event = UsageResetEvent(
+                providerID: snapshot.id,
+                providerName: snapshot.displayName,
+                windowLabel: headline.label,
+                glyph: snapshot.glyph,
+                previousFraction: previous.fraction,
+                currentFraction: fraction,
+                resetsAt: headline.resetsAt
+            )
+            deliver(event)
+
+            previous.fraction = fraction
+            previous.peakFraction = fraction
+            previous.resetsAt = headline.resetsAt
+            previous.lastAlertedResetDate = headline.resetsAt
+            states[snapshot.id] = previous
+        } else {
+            previous.fraction = fraction
+            previous.peakFraction = max(previous.peakFraction, fraction)
+            previous.resetsAt = headline.resetsAt
+            states[snapshot.id] = previous
+        }
+    }
+}

--- a/Sources/Notch/NotchFleet.swift
+++ b/Sources/Notch/NotchFleet.swift
@@ -252,6 +252,13 @@ final class NotchFleet {
         }
     }
 
+    /// Shows a usage reset notification modal on every panel.
+    func showResetAlert(_ event: UsageResetEvent, duration: TimeInterval = 5.0) {
+        for controller in controllers.values {
+            controller.showResetAlert(event, duration: duration)
+        }
+    }
+
     func setRefreshing(_ ids: Set<String>) {
         self.refreshing = ids
         for controller in controllers.values {

--- a/Sources/Notch/NotchRootView.swift
+++ b/Sources/Notch/NotchRootView.swift
@@ -77,7 +77,27 @@ struct NotchRootView: View {
                             .animation(motion(orbMotion), value: model.isExpanded)
                 }
 
-                if let snapshot = model.hoveredSnapshot, let index = model.hoveredIndex,
+                if let resetEvent = model.activeResetAlert,
+                   model.isExpanded,
+                   model.hoveredIndex == nil {
+                    let index = model.resetAlertIndex(for: resetEvent) ?? 0
+                    let snapshot = model.snapshots[safe: index] ?? model.snapshots.first ?? Fixtures.snapshots().first!
+                    UsageResetCard(
+                        event: resetEvent,
+                        direction: model.edge.tooltipDirection,
+                        tailOffset: tooltipTailOffset(index: index, snapshot: snapshot),
+                        onDismiss: {
+                            withAnimation(.easeOut(duration: 0.18)) {
+                                model.activeResetAlert = nil
+                            }
+                        }
+                    )
+                    .position(resetCardCentre(place, index: index))
+                    .transition(.opacity.combined(with: .offset(
+                        x: model.edge.outward.x * Design.px(24),
+                        y: model.edge.outward.y * Design.px(24)
+                    )))
+                } else if let snapshot = model.hoveredSnapshot, let index = model.hoveredIndex,
                    model.isExpanded {
                     TooltipCard(
                         snapshot: snapshot,
@@ -402,6 +422,15 @@ struct NotchRootView: View {
         // `tooltipInset` already ends where the drawn notch does.
         return place.point(
             along: model.tooltipAlong(index: index, length: tooltipLength(snapshot)),
+            across: model.tooltipInset + (NotchLayout.tailLength + card) / 2
+        )
+    }
+
+    private func resetCardCentre(_ place: NotchPlacement, index: Int) -> CGPoint {
+        let card = model.edge.isVertical ? NotchLayout.cardWidth : UsageResetCard.cardHeight
+        let cardAlong = model.edge.isVertical ? UsageResetCard.cardHeight : NotchLayout.cardWidth
+        return place.point(
+            along: model.tooltipAlong(index: index, length: cardAlong),
             across: model.tooltipInset + (NotchLayout.tailLength + card) / 2
         )
     }

--- a/Sources/Notch/NotchViewModel.swift
+++ b/Sources/Notch/NotchViewModel.swift
@@ -79,6 +79,13 @@ final class NotchViewModel: ObservableObject {
     @Published var now: Date = Date()
     @Published var resetTimeFormat: ResetTimeFormat = .automatic
 
+    /// Active usage reset notification event to present beside the notch.
+    @Published var activeResetAlert: UsageResetEvent?
+
+    func resetAlertIndex(for event: UsageResetEvent) -> Int? {
+        snapshots.firstIndex { $0.id == event.providerID }
+    }
+
     /// Whether the notch is open or folded away to its pill.
     @Published var isExpanded = false
     /// Clicked open, so it stays open until clicked shut again. A gesture,

--- a/Sources/Notch/NotchWindowController.swift
+++ b/Sources/Notch/NotchWindowController.swift
@@ -157,6 +157,12 @@ final class NotchWindowController {
             }
             .store(in: &cancellables)
 
+        model.$activeResetAlert
+            .sink { [weak self] _ in
+                MainActor.assumeIsolated { self?.updateInteractiveRects() }
+            }
+            .store(in: &cancellables)
+
         // A model can gain speed rows without changing the cell count. Read
         // after Published's willSet so sizing sees the new card contents too.
         model.$snapshots
@@ -424,8 +430,24 @@ final class NotchWindowController {
         )
     }
 
+    private func resetCardRect(event: UsageResetEvent) -> CGRect? {
+        let index = model.resetAlertIndex(for: event) ?? 0
+        let cardAcross = model.edge.isVertical ? NotchLayout.cardWidth : UsageResetCard.cardHeight
+        let cardAlong = model.edge.isVertical ? UsageResetCard.cardHeight : NotchLayout.cardWidth
+        let centre = model.tooltipAlong(index: index, length: cardAlong)
+        return placement.rect(
+            along: centre - cardAlong / 2,
+            across: model.notchDrawnDepth,
+            length: cardAlong,
+            depth: NotchLayout.tailGap + NotchLayout.tailLength + cardAcross
+        )
+    }
+
     private func updateInteractiveRects() {
         var rects = [liveRect]
+        if model.isExpanded, let event = model.activeResetAlert, let card = resetCardRect(event: event) {
+            rects.append(card)
+        }
         if model.isExpanded, let index = model.hoveredIndex, let card = tooltipRect(index: index) {
             rects.append(card)
         }
@@ -951,6 +973,28 @@ final class NotchWindowController {
         }
         peekWork = work
         DispatchQueue.main.asyncAfter(deadline: .now() + duration, execute: work)
+    }
+
+    /// Open the notch and show a usage reset notification modal card.
+    func showResetAlert(_ event: UsageResetEvent, duration: TimeInterval = 5.0) {
+        guard visibility != .hidden, let panel else {
+            Log.usage.debug("reset alert skipped: notch hidden")
+            return
+        }
+        model.activeResetAlert = event
+        peek(for: duration, focusing: nil)
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + duration) { [weak self] in
+            MainActor.assumeIsolated {
+                guard let self else { return }
+                if self.model.activeResetAlert == event {
+                    withAnimation(.easeOut(duration: 0.18)) {
+                        self.model.activeResetAlert = nil
+                    }
+                    self.updateInteractiveRects()
+                }
+            }
+        }
     }
 
     /// How long after a peek folds a click still counts as answering it. Covers

--- a/Sources/Settings/Preferences.swift
+++ b/Sources/Settings/Preferences.swift
@@ -223,6 +223,21 @@ final class Preferences: ObservableObject {
         didSet { defaults.set(sessionBlockedSoundName, forKey: Keys.sessionBlockedSoundName) }
     }
 
+    /// Show a notification modal from the notch when a provider's limit resets.
+    @Published var announceUsageReset: Bool {
+        didSet { defaults.set(announceUsageReset, forKey: Keys.announceUsageReset) }
+    }
+
+    /// Sound an alert alongside the usage reset notification modal.
+    @Published var usageResetSound: Bool {
+        didSet { defaults.set(usageResetSound, forKey: Keys.usageResetSound) }
+    }
+
+    /// Which sound a usage reset notification makes.
+    @Published var usageResetSoundName: String {
+        didSet { defaults.set(usageResetSoundName, forKey: Keys.usageResetSoundName) }
+    }
+
     /// The ceiling the Gemini API ring fills against, counted in tokens.
     ///
     /// In tokens rather than money because a bare `GEMINI_API_KEY` publishes no
@@ -293,6 +308,9 @@ final class Preferences: ObservableObject {
         static let peekDuration = "peekDuration"
         static let sessionEndSoundName = "sessionEndSoundName"
         static let sessionBlockedSoundName = "sessionBlockedSoundName"
+        static let announceUsageReset = "announceUsageReset"
+        static let usageResetSound = "usageResetSound"
+        static let usageResetSoundName = "usageResetSoundName"
         /// A new key, so there is nothing under the old app name to migrate.
         static let geminiAPIMonthlyTokenBudget = "geminiAPIMonthlyTokenBudget"
         static let antigravityHeadlineLimit = "antigravityHeadlineLimit"
@@ -469,6 +487,10 @@ final class Preferences: ObservableObject {
             ?? SessionChime.defaultFinished
         self.sessionBlockedSoundName = defaults.string(forKey: Keys.sessionBlockedSoundName)
             ?? SessionChime.defaultBlocked
+        self.announceUsageReset = defaults.object(forKey: Keys.announceUsageReset) as? Bool ?? true
+        self.usageResetSound = defaults.object(forKey: Keys.usageResetSound) as? Bool ?? true
+        self.usageResetSoundName = defaults.string(forKey: Keys.usageResetSoundName)
+            ?? SessionChime.defaultFinished
         self.geminiAPIMonthlyTokenBudget = Self.storedGeminiAPIMonthlyTokenBudget(defaults: defaults)
         // Read from the system rather than from our own store: the user can turn
         // this off in System Settings, and a remembered `true` would then be a lie.

--- a/Sources/Settings/Preferences.swift
+++ b/Sources/Settings/Preferences.swift
@@ -238,6 +238,26 @@ final class Preferences: ObservableObject {
         didSet { defaults.set(usageResetSoundName, forKey: Keys.usageResetSoundName) }
     }
 
+    /// Show a notification modal from the notch when a provider's session limit is reached.
+    @Published var announceSessionLimitReached: Bool {
+        didSet { defaults.set(announceSessionLimitReached, forKey: Keys.announceSessionLimitReached) }
+    }
+
+    /// Show a notification modal from the notch when a provider's weekly limit is reached.
+    @Published var announceWeeklyLimitReached: Bool {
+        didSet { defaults.set(announceWeeklyLimitReached, forKey: Keys.announceWeeklyLimitReached) }
+    }
+
+    /// Sound an alert alongside the limit reached notification modal.
+    @Published var limitReachedSound: Bool {
+        didSet { defaults.set(limitReachedSound, forKey: Keys.limitReachedSound) }
+    }
+
+    /// Which sound a limit reached notification makes.
+    @Published var limitReachedSoundName: String {
+        didSet { defaults.set(limitReachedSoundName, forKey: Keys.limitReachedSoundName) }
+    }
+
     /// The ceiling the Gemini API ring fills against, counted in tokens.
     ///
     /// In tokens rather than money because a bare `GEMINI_API_KEY` publishes no
@@ -311,6 +331,10 @@ final class Preferences: ObservableObject {
         static let announceUsageReset = "announceUsageReset"
         static let usageResetSound = "usageResetSound"
         static let usageResetSoundName = "usageResetSoundName"
+        static let announceSessionLimitReached = "announceSessionLimitReached"
+        static let announceWeeklyLimitReached = "announceWeeklyLimitReached"
+        static let limitReachedSound = "limitReachedSound"
+        static let limitReachedSoundName = "limitReachedSoundName"
         /// A new key, so there is nothing under the old app name to migrate.
         static let geminiAPIMonthlyTokenBudget = "geminiAPIMonthlyTokenBudget"
         static let antigravityHeadlineLimit = "antigravityHeadlineLimit"
@@ -491,6 +515,11 @@ final class Preferences: ObservableObject {
         self.usageResetSound = defaults.object(forKey: Keys.usageResetSound) as? Bool ?? true
         self.usageResetSoundName = defaults.string(forKey: Keys.usageResetSoundName)
             ?? SessionChime.defaultFinished
+        self.announceSessionLimitReached = defaults.object(forKey: Keys.announceSessionLimitReached) as? Bool ?? true
+        self.announceWeeklyLimitReached = defaults.object(forKey: Keys.announceWeeklyLimitReached) as? Bool ?? true
+        self.limitReachedSound = defaults.object(forKey: Keys.limitReachedSound) as? Bool ?? true
+        self.limitReachedSoundName = defaults.string(forKey: Keys.limitReachedSoundName)
+            ?? SessionChime.defaultBlocked
         self.geminiAPIMonthlyTokenBudget = Self.storedGeminiAPIMonthlyTokenBudget(defaults: defaults)
         // Read from the system rather than from our own store: the user can turn
         // this off in System Settings, and a remembered `true` would then be a lie.

--- a/Sources/Settings/SettingsView.swift
+++ b/Sources/Settings/SettingsView.swift
@@ -765,6 +765,20 @@ struct SettingsView: View {
                     .fixedSize(horizontal: false, vertical: true)
             }
 
+            Section(L10n.t("When a limit resets")) {
+                Toggle(L10n.t("Show notification from notch"), isOn: $preferences.announceUsageReset)
+
+                Toggle(L10n.t("Play a sound"), isOn: $preferences.usageResetSound)
+
+                SoundRow(label: L10n.t("Reset sound"), name: $preferences.usageResetSoundName,
+                         pickerEnabled: preferences.usageResetSound)
+
+                Text(L10n.t("Displays a notification card from the side of the notch when a provider's usage limit resets."))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
             // The mute switch itself lives on each provider's own row in
             // Accounts — muting is a fact about that provider's reading, not
             // about notifications in general — but the mechanism it silences

--- a/Sources/Settings/SettingsView.swift
+++ b/Sources/Settings/SettingsView.swift
@@ -176,6 +176,8 @@ struct SettingsView: View {
     var lmstudioMetrics: LMStudioMetrics? = nil
     var usageStore: UsageStore? = nil
     var previewResetAlert: (() -> Void)? = nil
+    var previewSessionLimitAlert: (() -> Void)? = nil
+    var previewWeeklyLimitAlert: (() -> Void)? = nil
     @Environment(\.codenotchReduceTransparency) private var reduceTransparency
 
     var body: some View {
@@ -763,6 +765,34 @@ struct SettingsView: View {
                 Text(L10n.t("The sound plays on the ordinary output, not the interface sound-effects channel — so it is still heard with \u{201C}Play user interface sound effects\u{201D} switched off in System Settings → Sound."))
                     .font(.caption)
                     .foregroundStyle(.tertiary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            Section(L10n.t("When a limit is reached")) {
+                Toggle(L10n.t("Show notification for session limit"), isOn: $preferences.announceSessionLimitReached)
+
+                Toggle(L10n.t("Show notification for weekly limit"), isOn: $preferences.announceWeeklyLimitReached)
+
+                Toggle(L10n.t("Play a sound"), isOn: $preferences.limitReachedSound)
+
+                SoundRow(label: L10n.t("Alert sound"), name: $preferences.limitReachedSoundName,
+                         pickerEnabled: preferences.limitReachedSound)
+
+                if let previewSessionLimitAlert {
+                    Button(L10n.t("Preview session limit alert")) {
+                        previewSessionLimitAlert()
+                    }
+                }
+
+                if let previewWeeklyLimitAlert {
+                    Button(L10n.t("Preview weekly limit alert")) {
+                        previewWeeklyLimitAlert()
+                    }
+                }
+
+                Text(L10n.t("Displays a notification card from the side of the notch when a provider's session or weekly usage limit is reached."))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
                     .fixedSize(horizontal: false, vertical: true)
             }
 

--- a/Sources/Settings/SettingsView.swift
+++ b/Sources/Settings/SettingsView.swift
@@ -175,6 +175,7 @@ struct SettingsView: View {
     var ollamaRelay: OllamaActivityRelay? = nil
     var lmstudioMetrics: LMStudioMetrics? = nil
     var usageStore: UsageStore? = nil
+    var previewResetAlert: (() -> Void)? = nil
     @Environment(\.codenotchReduceTransparency) private var reduceTransparency
 
     var body: some View {
@@ -772,6 +773,12 @@ struct SettingsView: View {
 
                 SoundRow(label: L10n.t("Reset sound"), name: $preferences.usageResetSoundName,
                          pickerEnabled: preferences.usageResetSound)
+
+                if let previewResetAlert {
+                    Button(L10n.t("Preview notification")) {
+                        previewResetAlert()
+                    }
+                }
 
                 Text(L10n.t("Displays a notification card from the side of the notch when a provider's usage limit resets."))
                     .font(.caption)

--- a/Sources/Settings/SettingsWindowController.swift
+++ b/Sources/Settings/SettingsWindowController.swift
@@ -24,6 +24,8 @@ final class SettingsWindowController: NSObject, NSWindowDelegate {
     private let usageStore: UsageStore?
     private let resetPosition: () -> Void
     private let previewResetAlert: (() -> Void)?
+    private let previewSessionLimitAlert: (() -> Void)?
+    private let previewWeeklyLimitAlert: (() -> Void)?
 
     init(preferences: Preferences,
          providers: @escaping () -> [ProviderSummary],
@@ -34,6 +36,8 @@ final class SettingsWindowController: NSObject, NSWindowDelegate {
          retry: @escaping (String) -> Void,
          resetPosition: @escaping () -> Void,
          previewResetAlert: (() -> Void)? = nil,
+         previewSessionLimitAlert: (() -> Void)? = nil,
+         previewWeeklyLimitAlert: (() -> Void)? = nil,
          usageStore: UsageStore? = nil,
          ollamaRelay: OllamaActivityRelay? = nil,
          lmstudioMetrics: LMStudioMetrics? = nil) {
@@ -42,6 +46,8 @@ final class SettingsWindowController: NSObject, NSWindowDelegate {
         self.usageStore = usageStore
         self.resetPosition = resetPosition
         self.previewResetAlert = previewResetAlert
+        self.previewSessionLimitAlert = previewSessionLimitAlert
+        self.previewWeeklyLimitAlert = previewWeeklyLimitAlert
         self.switchAccount = switchAccount
         self.retry = retry
         self.updater = updater
@@ -182,7 +188,9 @@ final class SettingsWindowController: NSObject, NSWindowDelegate {
                                    updater: updater,
                                    ollamaRelay: ollamaRelay, lmstudioMetrics: lmstudioMetrics,
                                    usageStore: usageStore,
-                                   previewResetAlert: previewResetAlert)
+                                   previewResetAlert: previewResetAlert,
+                                   previewSessionLimitAlert: previewSessionLimitAlert,
+                                   previewWeeklyLimitAlert: previewWeeklyLimitAlert)
         )
         window.center()
         window.isReleasedWhenClosed = false

--- a/Sources/Settings/SettingsWindowController.swift
+++ b/Sources/Settings/SettingsWindowController.swift
@@ -23,6 +23,7 @@ final class SettingsWindowController: NSObject, NSWindowDelegate {
     private let lmstudioMetrics: LMStudioMetrics?
     private let usageStore: UsageStore?
     private let resetPosition: () -> Void
+    private let previewResetAlert: (() -> Void)?
 
     init(preferences: Preferences,
          providers: @escaping () -> [ProviderSummary],
@@ -32,6 +33,7 @@ final class SettingsWindowController: NSObject, NSWindowDelegate {
          switchAccount: @escaping (String) -> Bool,
          retry: @escaping (String) -> Void,
          resetPosition: @escaping () -> Void,
+         previewResetAlert: (() -> Void)? = nil,
          usageStore: UsageStore? = nil,
          ollamaRelay: OllamaActivityRelay? = nil,
          lmstudioMetrics: LMStudioMetrics? = nil) {
@@ -39,6 +41,7 @@ final class SettingsWindowController: NSObject, NSWindowDelegate {
         self.lmstudioMetrics = lmstudioMetrics
         self.usageStore = usageStore
         self.resetPosition = resetPosition
+        self.previewResetAlert = previewResetAlert
         self.switchAccount = switchAccount
         self.retry = retry
         self.updater = updater
@@ -178,7 +181,8 @@ final class SettingsWindowController: NSObject, NSWindowDelegate {
                                    resetPosition: resetPosition,
                                    updater: updater,
                                    ollamaRelay: ollamaRelay, lmstudioMetrics: lmstudioMetrics,
-                                   usageStore: usageStore)
+                                   usageStore: usageStore,
+                                   previewResetAlert: previewResetAlert)
         )
         window.center()
         window.isReleasedWhenClosed = false

--- a/Tests/UsageLimitWatcherTests.swift
+++ b/Tests/UsageLimitWatcherTests.swift
@@ -1,0 +1,143 @@
+import XCTest
+@testable import Codenotch
+
+@MainActor
+final class UsageLimitWatcherTests: XCTestCase {
+    private var alerts: [UsageAlertEvent] = []
+    private var muted: Set<String> = []
+    private var watcher: UsageLimitWatcher!
+
+    override func setUp() {
+        super.setUp()
+        alerts = []
+        muted = []
+        watcher = UsageLimitWatcher(
+            isMuted: { [weak self] in self?.muted.contains($0) ?? false },
+            deliver: { [weak self] in self?.alerts.append($0) }
+        )
+    }
+
+    private func snapshot(
+        _ id: String,
+        _ name: String,
+        sessionFraction: Double,
+        weeklyFraction: Double = 0.50,
+        sessionResetsAt: Date? = nil,
+        weeklyResetsAt: Date? = nil,
+        block: UsageBlock? = nil
+    ) -> ProviderSnapshot {
+        var windows = [
+            LimitWindow(id: "session", label: "5-hour limit", usedFraction: sessionFraction, resetsAt: sessionResetsAt)
+        ]
+        if weeklyFraction > 0 {
+            windows.append(
+                LimitWindow(id: "weekly", label: "Weekly limit", usedFraction: weeklyFraction, resetsAt: weeklyResetsAt)
+            )
+        }
+        return ProviderSnapshot(
+            id: id,
+            displayName: name,
+            glyph: .claude,
+            fidelity: .official,
+            status: .ok,
+            windows: windows,
+            headlineID: "session",
+            weeklyID: weeklyFraction > 0 ? "weekly" : nil,
+            block: block
+        )
+    }
+
+    func testNoAlertOnInitialObservation() {
+        watcher.observe([snapshot("claude", "Claude", sessionFraction: 1.0, weeklyFraction: 1.0)])
+        XCTAssertTrue(alerts.isEmpty, "baseline observation records state and does not trigger false alerts on launch")
+    }
+
+    func testAlertsWhenSessionLimitReached() {
+        watcher.observe([snapshot("claude", "Claude", sessionFraction: 0.80)])
+        watcher.observe([snapshot("claude", "Claude", sessionFraction: 1.00)])
+
+        XCTAssertEqual(alerts.count, 1)
+        XCTAssertEqual(alerts[0].kind, .sessionLimitReached)
+        XCTAssertEqual(alerts[0].providerID, "claude")
+        XCTAssertEqual(alerts[0].providerName, "Claude")
+        XCTAssertEqual(alerts[0].currentFraction, 1.00)
+    }
+
+    func testAlertsWhenWeeklyLimitReached() {
+        watcher.observe([snapshot("claude", "Claude", sessionFraction: 0.50, weeklyFraction: 0.80)])
+        watcher.observe([snapshot("claude", "Claude", sessionFraction: 0.50, weeklyFraction: 1.00)])
+
+        XCTAssertEqual(alerts.count, 1)
+        XCTAssertEqual(alerts[0].kind, .weeklyLimitReached)
+        XCTAssertEqual(alerts[0].providerID, "claude")
+        XCTAssertEqual(alerts[0].currentFraction, 1.00)
+    }
+
+    func testAlertsWhenBlocked() {
+        watcher.observe([snapshot("claude", "Claude", sessionFraction: 0.50)])
+        watcher.observe([snapshot("claude", "Claude", sessionFraction: 0.50, block: UsageBlock(reason: "Rate limited", resetsAt: nil))])
+
+        XCTAssertEqual(alerts.count, 1)
+        XCTAssertEqual(alerts[0].kind, .sessionLimitReached)
+    }
+
+    func testNoRepeatAlertWhileExhausted() {
+        watcher.observe([snapshot("claude", "Claude", sessionFraction: 0.80)])
+        watcher.observe([snapshot("claude", "Claude", sessionFraction: 1.00)])
+        XCTAssertEqual(alerts.count, 1)
+
+        watcher.observe([snapshot("claude", "Claude", sessionFraction: 1.00)])
+        watcher.observe([snapshot("claude", "Claude", sessionFraction: 1.02)])
+        XCTAssertEqual(alerts.count, 1, "does not spam repeated alerts while remaining exhausted")
+    }
+
+    func testReArmsWhenUsageDropsBelowThreshold() {
+        watcher.observe([snapshot("claude", "Claude", sessionFraction: 0.80)])
+        watcher.observe([snapshot("claude", "Claude", sessionFraction: 1.00)])
+        XCTAssertEqual(alerts.count, 1)
+
+        watcher.observe([snapshot("claude", "Claude", sessionFraction: 0.90)])
+        watcher.observe([snapshot("claude", "Claude", sessionFraction: 1.00)])
+        XCTAssertEqual(alerts.count, 2, "re-arms alert when usage drops and reaches limit again")
+    }
+
+    func testReArmsWhenResetsAtRollsOver() {
+        let date1 = Date(timeIntervalSince1970: 1000)
+        let date2 = Date(timeIntervalSince1970: 5000)
+
+        watcher.observe([snapshot("claude", "Claude", sessionFraction: 0.80, sessionResetsAt: date1)])
+        watcher.observe([snapshot("claude", "Claude", sessionFraction: 1.00, sessionResetsAt: date1)])
+        XCTAssertEqual(alerts.count, 1)
+
+        watcher.observe([snapshot("claude", "Claude", sessionFraction: 1.00, sessionResetsAt: date2)])
+        XCTAssertEqual(alerts.count, 2, "re-arms when window rolls over to new resetsAt")
+    }
+
+    func testMutedProviderDoesNotAlert() {
+        muted = ["claude"]
+        watcher.observe([snapshot("claude", "Claude", sessionFraction: 0.80)])
+        watcher.observe([snapshot("claude", "Claude", sessionFraction: 1.00)])
+        XCTAssertTrue(alerts.isEmpty, "muted provider delivers no limit alerts")
+    }
+
+    func testTracksMultipleProvidersIndependently() {
+        watcher.observe([
+            snapshot("claude", "Claude", sessionFraction: 0.50),
+            snapshot("cursor", "Cursor", sessionFraction: 0.50)
+        ])
+
+        watcher.observe([
+            snapshot("claude", "Claude", sessionFraction: 1.00),
+            snapshot("cursor", "Cursor", sessionFraction: 0.60)
+        ])
+        XCTAssertEqual(alerts.count, 1)
+        XCTAssertEqual(alerts[0].providerID, "claude")
+
+        watcher.observe([
+            snapshot("claude", "Claude", sessionFraction: 1.00),
+            snapshot("cursor", "Cursor", sessionFraction: 1.00)
+        ])
+        XCTAssertEqual(alerts.count, 2)
+        XCTAssertEqual(alerts[1].providerID, "cursor")
+    }
+}

--- a/Tests/UsageResetWatcherTests.swift
+++ b/Tests/UsageResetWatcherTests.swift
@@ -1,0 +1,92 @@
+import XCTest
+@testable import Codenotch
+
+@MainActor
+final class UsageResetWatcherTests: XCTestCase {
+    private var alerts: [UsageResetEvent] = []
+    private var muted: Set<String> = []
+    private var watcher: UsageResetWatcher!
+
+    override func setUp() {
+        super.setUp()
+        alerts = []
+        muted = []
+        watcher = UsageResetWatcher(
+            isMuted: { [weak self] in self?.muted.contains($0) ?? false },
+            deliver: { [weak self] in self?.alerts.append($0) }
+        )
+    }
+
+    private func snapshot(_ id: String, _ name: String, _ fraction: Double,
+                          resetsAt: Date? = nil,
+                          label: String = "5-hour limit") -> ProviderSnapshot {
+        ProviderSnapshot(
+            id: id, displayName: name, glyph: .claude, fidelity: .official, status: .ok,
+            windows: [LimitWindow(id: "session", label: label, usedFraction: fraction, resetsAt: resetsAt)],
+            headlineID: "session"
+        )
+    }
+
+    func testNoAlertOnInitialObservation() {
+        watcher.observe([snapshot("claude", "Claude", 0.85)])
+        XCTAssertTrue(alerts.isEmpty, "initial reading records baseline and does not alert")
+    }
+
+    func testAlertsWhenUsageDropsSignificantly() {
+        watcher.observe([snapshot("claude", "Claude", 0.90)])
+        watcher.observe([snapshot("claude", "Claude", 0.05)])
+
+        XCTAssertEqual(alerts.count, 1)
+        XCTAssertEqual(alerts[0].providerID, "claude")
+        XCTAssertEqual(alerts[0].providerName, "Claude")
+        XCTAssertEqual(alerts[0].windowLabel, "5-hour limit")
+        XCTAssertEqual(alerts[0].previousFraction, 0.90)
+        XCTAssertEqual(alerts[0].currentFraction, 0.05)
+    }
+
+    func testAlertsWhenResetsAtRolledOver() {
+        let date1 = Date(timeIntervalSince1970: 1000)
+        let date2 = Date(timeIntervalSince1970: 2000)
+
+        watcher.observe([snapshot("claude", "Claude", 0.40, resetsAt: date1)])
+        watcher.observe([snapshot("claude", "Claude", 0.05, resetsAt: date2)])
+
+        XCTAssertEqual(alerts.count, 1)
+        XCTAssertEqual(alerts[0].resetsAt, date2)
+    }
+
+    func testNoAlertForNegligibleFluctuation() {
+        watcher.observe([snapshot("claude", "Claude", 0.05)])
+        watcher.observe([snapshot("claude", "Claude", 0.01)])
+        XCTAssertTrue(alerts.isEmpty, "negligible low-level fluctuation does not alert")
+    }
+
+    func testMutedProviderDoesNotAlert() {
+        muted = ["claude"]
+        watcher.observe([snapshot("claude", "Claude", 0.95)])
+        watcher.observe([snapshot("claude", "Claude", 0.00)])
+        XCTAssertTrue(alerts.isEmpty, "muted provider is silent")
+    }
+
+    func testMultipleProvidersTrackedIndependently() {
+        watcher.observe([
+            snapshot("claude", "Claude", 0.80),
+            snapshot("cursor", "Cursor", 0.10)
+        ])
+        watcher.observe([
+            snapshot("claude", "Claude", 0.02),
+            snapshot("cursor", "Cursor", 0.70)
+        ])
+
+        XCTAssertEqual(alerts.count, 1)
+        XCTAssertEqual(alerts[0].providerID, "claude")
+
+        watcher.observe([
+            snapshot("claude", "Claude", 0.05),
+            snapshot("cursor", "Cursor", 0.05)
+        ])
+
+        XCTAssertEqual(alerts.count, 2)
+        XCTAssertEqual(alerts[1].providerID, "cursor")
+    }
+}


### PR DESCRIPTION
## Summary
- Provide immediate visual feedback when an AI provider's usage limit resets, or when session / weekly limits are reached (100%).
- Allow users to configure reset and limit reached notification visibility and alert sounds from Preferences.

## Changes
- **Model**: Add `UsageResetWatcher`, `UsageLimitWatcher`, and `UsageAlertEvent` (`UsageResetEvent`) to observe provider quota snapshots for rollovers, drops, and exhausted session/weekly limits.
- **UI**: Update `UsageResetCard` sliding notification view to render both reset states and critical limit-reached states with distinct indicators, titles, and reset countdown labels.
- **Settings**: Add "When a limit is reached" section alongside "When a limit resets" in Settings > Notifications with session limit toggle, weekly limit toggle, sound chime toggle, and sound picker with preview actions.
- **Presentation**: Wire limit watcher and alert preview lifecycle through `AppDelegate`, `NotchFleet`, and `NotchWindowController`.
- **Tests**: Add unit tests for `UsageResetWatcher` and `UsageLimitWatcher` covering baseline tracking, limit exhaustion (session and weekly), rollovers, repeat alert suppression, and muted providers.

## Test plan
- [x] Run unit test suites for `UsageLimitWatcherTests` and `UsageResetWatcherTests` with 0 failures.
- [x] Verified limit reached and reset notification cards slide from notch with appropriate status indicators.
- [x] Verified Preferences toggles for session limits, weekly limits, and sounds.
- [x] Verified "Preview session limit alert", "Preview weekly limit alert", and "Preview notification" live actions.

## Preview
<img width="1600" height="910" alt="WhatsApp Image 2026-09-11 at 21 01 27" src="https://github.com/user-attachments/assets/9f4a0e2c-381d-490c-a08d-a1c1d92e9a16" />