### PR TITLE
Add Simplified Chinese for settings captions and usage details

### DIFF
--- a/Sources/Features/DeepSeekUsageDetail.swift
+++ b/Sources/Features/DeepSeekUsageDetail.swift
@@ -39,23 +39,23 @@ struct DeepSeekUsageDetail: View {
                 .frame(height: NotchLayout.hairline)
                 .padding(.top, NotchLayout.blockSpacing)
 
-            SplitRow(leading: "Usage details", trailing: timeZoneText)
+            SplitRow(leading: L10n.t("Usage details"), trailing: timeZoneText)
                 .padding(.top, NotchLayout.blockSpacing)
 
             HStack(spacing: NotchLayout.blockSpacing) {
-                DeepSeekMetric(label: "Tokens", value: UsageFormat.tokens(detail.totalTokens))
-                DeepSeekMetric(label: "Cost", value: moneyText)
-                DeepSeekMetric(label: "Requests", value: "\(detail.totalRequests)")
-                DeepSeekMetric(label: "API keys", value: "\(detail.visibleAPIKeyCount)")
+                DeepSeekMetric(label: L10n.t("Tokens"), value: UsageFormat.tokens(detail.totalTokens))
+                DeepSeekMetric(label: L10n.t("Cost"), value: moneyText)
+                DeepSeekMetric(label: L10n.t("Requests"), value: "\(detail.totalRequests)")
+                DeepSeekMetric(label: L10n.t("API keys"), value: "\(detail.visibleAPIKeyCount)")
             }
             .frame(width: NotchLayout.cardTextWidth)
             .padding(.top, NotchLayout.blockSpacing)
 
-            DeepSeekUsageChart(title: "Daily tokens", values: points.map { Double($0.tokens) }, formatter: {
+            DeepSeekUsageChart(title: L10n.t("Daily tokens"), values: points.map { Double($0.tokens) }, formatter: {
                 UsageFormat.tokens(Int($0))
             })
                 .padding(.top, NotchLayout.blockSpacing)
-            DeepSeekUsageChart(title: "Daily cost", values: points.map { $0.cost }, formatter: {
+            DeepSeekUsageChart(title: L10n.t("Daily cost"), values: points.map { $0.cost }, formatter: {
                 Self.money($0, currency: detail.currency)
             })
             .padding(.top, NotchLayout.usageDetailChartGap)
@@ -110,7 +110,7 @@ private struct DeepSeekUsageChart: View {
             HStack(alignment: .firstTextBaseline) {
                 Text(title).foregroundStyle(Palette.textPrimary)
                 Spacer(minLength: 0)
-                Text("peak \(formatter(values.max() ?? 0))")
+                Text(L10n.t("peak \(formatter(values.max() ?? 0))"))
                     .foregroundStyle(Palette.textSecondary)
                     .lineLimit(1)
             }

--- a/Sources/Features/TooltipCard.swift
+++ b/Sources/Features/TooltipCard.swift
@@ -462,9 +462,9 @@ private struct MoneyBreakdownView: View {
             .padding(.top, NotchLayout.labelToBar)
 
             HStack(spacing: NotchLayout.blockSpacing) {
-                MoneyStat(label: "Spent", value: amount(money.spent), color: accentColor)
-                MoneyStat(label: "Remaining", value: amount(money.remaining), color: Palette.textSecondary)
-                MoneyStat(label: "Funded", value: amount(money.funded), color: Palette.textPrimary)
+                MoneyStat(label: L10n.t("Spent"), value: amount(money.spent), color: accentColor)
+                MoneyStat(label: L10n.t("Remaining"), value: amount(money.remaining), color: Palette.textSecondary)
+                MoneyStat(label: L10n.t("Funded"), value: amount(money.funded), color: Palette.textPrimary)
             }
             .frame(width: NotchLayout.cardTextWidth)
             .padding(.top, NotchLayout.moneyBarToStats)
@@ -812,22 +812,22 @@ private struct CodexUsageSection: View {
     }
 
     private var todayText: String {
-        usage.usageToday(now: now).map { UsageFormat.tokens($0) } ?? "Pending"
+        usage.usageToday(now: now).map { UsageFormat.tokens($0) } ?? L10n.t("Pending")
     }
 
     private var metrics: [CodexMetric] {
         let summary = usage.summary
         return [
             CodexMetric(id: "lifetime", value: UsageFormat.tokens(summary?.lifetimeTokens),
-                        label: "Lifetime tokens"),
+                        label: L10n.t("Lifetime tokens")),
             CodexMetric(id: "peak", value: UsageFormat.tokens(summary?.peakDailyTokens),
-                        label: "Peak tokens"),
+                        label: L10n.t("Peak tokens")),
             CodexMetric(id: "longest", value: UsageFormat.duration(
-                seconds: summary?.longestRunningTurnSeconds), label: "Longest chat"),
+                seconds: summary?.longestRunningTurnSeconds), label: L10n.t("Longest chat")),
             CodexMetric(id: "current-streak", value: UsageFormat.days(
-                summary?.currentStreakDays), label: "Current streak"),
+                summary?.currentStreakDays), label: L10n.t("Current streak")),
             CodexMetric(id: "longest-streak", value: UsageFormat.days(
-                summary?.longestStreakDays), label: "Longest streak")
+                summary?.longestStreakDays), label: L10n.t("Longest streak"))
         ]
     }
 
@@ -846,9 +846,9 @@ private struct CodexUsageSection: View {
                 .fill(Palette.ringTrack)
                 .frame(height: NotchLayout.hairline)
 
-            SplitRow(leading: "Today", trailing: todayText)
+            SplitRow(leading: L10n.t("Today"), trailing: todayText)
                 .padding(.top, NotchLayout.blockSpacing)
-            SplitRow(leading: "30-day tokens",
+            SplitRow(leading: L10n.t("30-day tokens"),
                      trailing: UsageFormat.tokens(usage.usageInLast30Days(now: now)))
                 .padding(.top, NotchLayout.codexUsageRowGap)
             CodexDailyUsageChart(buckets: buckets, maximum: maximum)

--- a/Sources/Localizable.xcstrings
+++ b/Sources/Localizable.xcstrings
@@ -11476,6 +11476,468 @@
           }
         }
       }
+    },
+    "A system notification the moment a provider's headline limit crosses 80%, and again at 100% — once per crossing, and again only after the window rolls over. Mute one from the bell beside its row in Accounts.": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "当某家服务的主额度越过 80% 时发一条系统通知，100% 时再发一次 — 每次越过只发一次，要等额度窗口滚动过后才会再发。可在「账号」里该行旁边的铃铛上静音。"
+          }
+        }
+      }
+    },
+    "Codenotch already knows the moment an agent stops working or stops to ask you something. Clicking the notch while it is open brings that session's app to the front — the app, not the tab: only some terminals let anything outside them choose a tab, so the tooltip names the session instead.": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Codenotch 已经知道助手何时停下来、或停下来问你。刘海展开时点一下，会把那个会话的应用带到前台 — 是应用，不是标签页：只有部分终端允许外部选定标签，所以提示里会写会话名称。"
+          }
+        }
+      }
+    },
+    "The sound plays on the ordinary output, not the interface sound-effects channel — so it is still heard with “Play user interface sound effects” switched off in System Settings → Sound.": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "声音走普通输出，不是界面音效通道 — 所以在系统设置 → 声音里关掉「播放用户界面声音效果」之后仍然听得见。"
+          }
+        }
+      }
+    },
+    "Most readings are borrowed from a tool that already holds the account. DeepSeek is the exception: clicking Sign in opens its own Codenotch WebView, and signing out here clears only that session and its saved reading.": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "大多数读数借自已经持有该账号的工具。DeepSeek 是例外：点「登录」会打开 Codenotch 自己的 WebView，在这里退出只会清掉这次会话和已保存的读数。"
+          }
+        }
+      }
+    },
+    "Lifetime tokens": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "累计 token"
+          }
+        }
+      }
+    },
+    "Peak tokens": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "峰值 token"
+          }
+        }
+      }
+    },
+    "Longest chat": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "最长对话"
+          }
+        }
+      }
+    },
+    "Current streak": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "当前连续"
+          }
+        }
+      }
+    },
+    "Longest streak": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "最长连续"
+          }
+        }
+      }
+    },
+    "Today": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "今日"
+          }
+        }
+      }
+    },
+    "30-day tokens": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "30 天 token"
+          }
+        }
+      }
+    },
+    "Pending": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "待出"
+          }
+        }
+      }
+    },
+    "Spent": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已花费"
+          }
+        }
+      }
+    },
+    "Remaining": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "剩余"
+          }
+        }
+      }
+    },
+    "Funded": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已充值"
+          }
+        }
+      }
+    },
+    "Usage details": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "用量明细"
+          }
+        }
+      }
+    },
+    "Tokens": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Token"
+          }
+        }
+      }
+    },
+    "Cost": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "费用"
+          }
+        }
+      }
+    },
+    "Requests": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "请求"
+          }
+        }
+      }
+    },
+    "API keys": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API 密钥"
+          }
+        }
+      }
+    },
+    "Daily tokens": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "每日 token"
+          }
+        }
+      }
+    },
+    "Daily cost": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "每日费用"
+          }
+        }
+      }
+    },
+    "peak %@": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "峰值 %@"
+          }
+        }
+      }
+    },
+    "Account usage (%@)": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "账号用量（%@）"
+          }
+        }
+      }
+    },
+    "Monitoring off.": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未在监视。"
+          }
+        }
+      }
+    },
+    "Open LM Studio": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "打开 LM Studio"
+          }
+        }
+      }
+    },
+    "Open Ollama": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "打开 Ollama"
+          }
+        }
+      }
+    },
+    "Server address": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "服务器地址"
+          }
+        }
+      }
+    },
+    "Check connection": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "检查连接"
+          }
+        }
+      }
+    },
+    "Apply": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "应用"
+          }
+        }
+      }
+    },
+    "API token": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API 令牌"
+          }
+        }
+      }
+    },
+    "Remove": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "移除"
+          }
+        }
+      }
+    },
+    "Checking LM Studio…": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在检查 LM Studio…"
+          }
+        }
+      }
+    },
+    "Connecting to LM Studio…": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在连接 LM Studio…"
+          }
+        }
+      }
+    },
+    "Checking Ollama…": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在检查 Ollama…"
+          }
+        }
+      }
+    },
+    "Connecting to Ollama…": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在连接 Ollama…"
+          }
+        }
+      }
+    },
+    "Loaded models appear in Accounts → Connected and are checked every second. Embedding models are not shown.": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已加载的模型会出现在「账号 → 已连接」，每秒检查一次。不显示嵌入模型。"
+          }
+        }
+      }
+    },
+    "A token is stored and sent with every request.": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已保存令牌，每次请求都会带上。"
+          }
+        }
+      }
+    },
+    "Only needed when LM Studio's server requires a token (Developer → Server Settings). Without one, requests are sent with no Authorization header.": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "仅当 LM Studio 服务器要求令牌时才需要（开发者 → 服务器设置）。不填则请求不带 Authorization 头。"
+          }
+        }
+      }
+    },
+    "Detected models appear in Accounts → Connected. Model loading and unloading is checked every second.": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "检测到的模型会出现在「账号 → 已连接」。模型加载和卸载每秒检查一次。"
+          }
+        }
+      }
+    },
+    "Measure speed and thinking": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "测量速度与思考"
+          }
+        }
+      }
+    },
+    "To measure responses, point your chat client to http://127.0.0.1:11435 and keep Codenotch open.": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "要测量回复，把聊天客户端指向 http://127.0.0.1:11435，并保持 Codenotch 打开。"
+          }
+        }
+      }
     }
   },
   "version": "1.0"

--- a/Sources/Providers/Sites.swift
+++ b/Sources/Providers/Sites.swift
@@ -111,7 +111,7 @@ enum Sites {
             let reading = try DeepSeekUsage.reading(fromJSON: payload.summary)
             var windows = [LimitWindow(
                 id: "spend",
-                label: "Account usage (\(reading.currency))",
+                label: L10n.t("Account usage (\(reading.currency))"),
                 usedFraction: reading.usedFraction,
                 money: UsageMoneyBreakdown(currency: reading.currency,
                                            spent: reading.spent,

--- a/Sources/Settings/LMStudioSettingsRow.swift
+++ b/Sources/Settings/LMStudioSettingsRow.swift
@@ -33,15 +33,15 @@ struct LMStudioSettingsRow: View {
             }
             .font(.body)
 
-            Button("Open LM Studio") { store.openAccountSource(providerID: providerID) }
+            Button(L10n.t("Open LM Studio")) { store.openAccountSource(providerID: providerID) }
                 .controlSize(.small)
 
             HStack {
-                TextField("Server address", text: $address)
+                TextField(L10n.t("Server address"), text: $address)
                     .textFieldStyle(.roundedBorder)
                     .onSubmit { applyAddress() }
                     .accessibilityLabel("LM Studio server address")
-                Button(address == preferences.lmstudioEndpoint ? "Check connection" : "Apply") {
+                Button(address == preferences.lmstudioEndpoint ? L10n.t("Check connection") : L10n.t("Apply")) {
                     applyAddress()
                 }
                 .disabled(address == preferences.lmstudioEndpoint && (!enabled || checking))
@@ -51,16 +51,16 @@ struct LMStudioSettingsRow: View {
             if let addressError {
                 Text(addressError).foregroundStyle(.orange)
             } else if !enabled {
-                Text("Monitoring off.")
+                Text(L10n.t("Monitoring off."))
                     .foregroundStyle(.secondary)
             } else if checking && snapshot?.hasReading != true {
-                Text("Checking LM Studio…").foregroundStyle(.secondary)
+                Text(L10n.t("Checking LM Studio…")).foregroundStyle(.secondary)
             } else {
-                Text(snapshot?.localRuntime?.summary ?? snapshot?.statusMessage ?? "Connecting to LM Studio…")
+                Text(snapshot?.localRuntime?.summary ?? snapshot?.statusMessage ?? L10n.t("Connecting to LM Studio…"))
                     .foregroundStyle(snapshot?.hasReading == true ? Color.secondary : .orange)
             }
 
-            Text("Loaded models appear in Accounts → Connected and are checked every second. Embedding models are not shown.")
+            Text(L10n.t("Loaded models appear in Accounts → Connected and are checked every second. Embedding models are not shown."))
                 .foregroundStyle(.secondary)
 
             tokenEntry
@@ -80,7 +80,7 @@ struct LMStudioSettingsRow: View {
     /// wins over it, so a shell that exports one needs no entry here.
     private var tokenEntry: some View {
         VStack(alignment: .leading, spacing: 4) {
-            Text("API token")
+            Text(L10n.t("API token"))
                 .foregroundStyle(.secondary)
             HStack(spacing: 8) {
                 SecureField("sk-lm-…", text: $token)
@@ -88,7 +88,7 @@ struct LMStudioSettingsRow: View {
                     .textFieldStyle(.roundedBorder)
                     .labelsHidden()
                     .frame(maxWidth: 260)
-                Button("Save") {
+                Button(L10n.t("Save")) {
                     guard !token.isEmpty else { return }
                     LMStudioCredentials.store(token)
                     token = ""
@@ -98,7 +98,7 @@ struct LMStudioSettingsRow: View {
                 .disabled(token.isEmpty)
                 .controlSize(.small)
                 if LMStudioCredentials.isPresent {
-                    Button("Remove") {
+                    Button(L10n.t("Remove")) {
                         LMStudioCredentials.delete()
                         tokenSaved = false
                         if enabled { store.refresh(providerID: providerID) }
@@ -106,12 +106,12 @@ struct LMStudioSettingsRow: View {
                     .controlSize(.small)
                 }
                 if tokenSaved {
-                    Text("Saved").foregroundStyle(.green)
+                    Text(L10n.t("Saved")).foregroundStyle(.green)
                 }
             }
             Text(LMStudioCredentials.isPresent
-                 ? "A token is stored and sent with every request."
-                 : "Only needed when LM Studio's server requires a token (Developer → Server Settings). Without one, requests are sent with no Authorization header.")
+                 ? L10n.t("A token is stored and sent with every request.")
+                 : L10n.t("Only needed when LM Studio's server requires a token (Developer → Server Settings). Without one, requests are sent with no Authorization header."))
                 .foregroundStyle(.secondary)
         }
         .padding(.top, 2)

--- a/Sources/Settings/OllamaSettingsRow.swift
+++ b/Sources/Settings/OllamaSettingsRow.swift
@@ -30,15 +30,15 @@ struct OllamaSettingsRow: View {
             }
             .font(.body)
 
-            Button("Open Ollama") { store.openAccountSource(providerID: "ollama-local") }
+            Button(L10n.t("Open Ollama")) { store.openAccountSource(providerID: "ollama-local") }
                 .controlSize(.small)
 
             HStack {
-                TextField("Server address", text: $address)
+                TextField(L10n.t("Server address"), text: $address)
                     .textFieldStyle(.roundedBorder)
                     .onSubmit { applyAddress() }
                     .accessibilityLabel("Ollama server address")
-                Button(address == preferences.ollamaEndpoint ? "Check connection" : "Apply") {
+                Button(address == preferences.ollamaEndpoint ? L10n.t("Check connection") : L10n.t("Apply")) {
                     applyAddress()
                 }
                 .disabled(address == preferences.ollamaEndpoint && (!enabled || checking))
@@ -48,21 +48,21 @@ struct OllamaSettingsRow: View {
             if let addressError {
                 Text(addressError).foregroundStyle(.orange)
             } else if !enabled {
-                Text("Monitoring off.")
+                Text(L10n.t("Monitoring off."))
                     .foregroundStyle(.secondary)
             } else if checking && snapshot?.hasReading != true {
-                Text("Checking Ollama…").foregroundStyle(.secondary)
+                Text(L10n.t("Checking Ollama…")).foregroundStyle(.secondary)
             } else {
-                Text(snapshot?.localRuntime?.summary ?? snapshot?.statusMessage ?? "Connecting to Ollama…")
+                Text(snapshot?.localRuntime?.summary ?? snapshot?.statusMessage ?? L10n.t("Connecting to Ollama…"))
                     .foregroundStyle(snapshot?.hasReading == true ? Color.secondary : .orange)
             }
 
-            Text("Detected models appear in Accounts → Connected. Model loading and unloading is checked every second.")
+            Text(L10n.t("Detected models appear in Accounts → Connected. Model loading and unloading is checked every second."))
                 .foregroundStyle(.secondary)
 
-            Toggle("Measure speed and thinking", isOn: $preferences.ollamaMetricsEnabled)
+            Toggle(L10n.t("Measure speed and thinking"), isOn: $preferences.ollamaMetricsEnabled)
                 .disabled(!enabled)
-            Text("To measure responses, point your chat client to http://127.0.0.1:11435 and keep Codenotch open.")
+            Text(L10n.t("To measure responses, point your chat client to http://127.0.0.1:11435 and keep Codenotch open."))
                 .foregroundStyle(.secondary)
             if enabled, preferences.ollamaMetricsEnabled, let relay {
                 OllamaRelayStatus(relay: relay)


### PR DESCRIPTION
## Summary

Several settings captions and tooltip labels still fell back to English on a Chinese Mac: threshold alerts, session-end help, Ollama and LM Studio, the DeepSeek accounts footnote, and the Codex / DeepSeek usage detail rows.

This routes those strings through the catalog and fills in Simplified Chinese. English source wording is unchanged. Missing translations still fall back to English.

## Test plan

- [x] `make build`
- [x] Switch Codenotch to 简体中文 and check Notifications, Ollama, LM Studio, Accounts, and the Codex / DeepSeek hover cards