### PR TITLE
chore: add issue templates, pr template, and codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default owner for the repository
+* @vinzdg

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,90 @@
+name: Bug Report
+description: Report an issue or unexpected behavior in Codenotch.
+title: "fix: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for reporting a bug! Please fill out the sections below to help us investigate.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Bug Description
+      description: A clear and concise description of what the bug is.
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce
+      description: Steps to reproduce the behavior.
+      placeholder: |
+        1. Open Codenotch with provider '...'
+        2. Perform action '...'
+        3. See error
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: A clear description of what you expected to happen.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: provider
+    attributes:
+      label: Affected Provider (if applicable)
+      description: Which AI provider or subsystem is experiencing issues?
+      options:
+        - Claude (CLI / Desktop)
+        - OpenAI Codex
+        - Gemini API
+        - Ollama (Local)
+        - LM Studio (Local)
+        - UI / Notch Presentation
+        - Settings / Preferences
+        - Other / Not Provider-Specific
+    validations:
+      required: false
+
+  - type: input
+    id: environment
+    attributes:
+      label: Environment & macOS Version
+      description: e.g., macOS Sequoia 15.0, Apple Silicon M3 / Intel
+      placeholder: "macOS 15.0 (Apple Silicon)"
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Codenotch Version
+      description: The version of Codenotch where this occurred (e.g., 1.9.0, or git commit SHA).
+      placeholder: "1.9.0"
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant Logs (Unified Log)
+      description: |
+        Run `/usr/bin/log stream --predicate 'subsystem == "com.vinz.codenotch"' --level debug` and paste relevant lines.
+      render: shell
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional Context
+      description: Add any other context or screenshots about the problem here.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Ask a question or discuss ideas
+    url: https://github.com/vinzdg/codenotch/discussions
+    about: Ask questions, share ideas, and engage with the community.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,41 @@
+name: Feature Request
+description: Suggest an idea or improvement for Codenotch.
+title: "feat: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for suggesting an enhancement for Codenotch!
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or Motivation
+      description: Is your feature request related to a problem or limitation? A clear description of what the problem is (e.g. "I'm always frustrated when...").
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed Solution
+      description: A clear and concise description of what you want to happen.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: A clear and concise description of any alternative solutions or features you've considered.
+    validations:
+      required: false
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional Context / Mockups
+      description: Add any mockups, screenshots, or design thoughts here.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/provider_request.yml
+++ b/.github/ISSUE_TEMPLATE/provider_request.yml
@@ -1,0 +1,44 @@
+name: Provider Request
+description: Request support for a new AI provider or CLI tool.
+title: "feat(provider): add support for <Provider Name>"
+labels: ["provider-request", "enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for requesting a new AI provider integration for Codenotch!
+
+  - type: input
+    id: provider_name
+    attributes:
+      label: Provider Name
+      description: Name of the AI service or tool (e.g., Anthropic Claude, Perplexity, OpenRouter, Copilot).
+      placeholder: "e.g. OpenRouter"
+    validations:
+      required: true
+
+  - type: textarea
+    id: details
+    attributes:
+      label: Quota / Limit Mechanics
+      description: |
+        How does this provider structure its rate limits or quotas? (e.g. 5-hour rolling window, monthly token pool, request-per-minute ceiling, credit balance).
+    validations:
+      required: true
+
+  - type: textarea
+    id: endpoints_auth
+    attributes:
+      label: Available CLI / API Endpoints & Auth Method
+      description: |
+        How does the local client or CLI communicate with this provider? Where are credentials stored (macOS Keychain, config JSON in `~/.config/...`, environment variable)?
+    validations:
+      required: false
+
+  - type: textarea
+    id: documentation
+    attributes:
+      label: Documentation / References
+      description: Links to official documentation, CLI repositories, or API references.
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+## Summary
+<!-- Explain the motivation and what this PR accomplishes. Include relevant issue numbers (e.g. Fixes #123). -->
+
+## Changes
+<!-- List the specific changes made in this PR. -->
+- 
+
+## Test Plan
+<!-- Describe the tests you ran to verify your changes. -->
+- [ ] Run test suite (`make test-ci`)
+- [ ] Tested on macOS (version: )
+- [ ] UI / Notch interactions verified (if applicable)
+
+## Screenshots / Screen Recordings
+<!-- If your change introduces visual or interactive changes to the notch, attach screenshots or recordings. -->

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ DerivedData/
 xcuserdata/
 *.xcuserstate
 .swiftpm/
+.agents/
+.forgeguard/


### PR DESCRIPTION
## Summary
- Establish structured GitHub templates for issues and pull requests to streamline community contributions.
- Add code ownership specification to automatically route pull request reviews.

## Changes
- **Issue Templates**: Add GitHub Issue Forms for bug reports (`bug_report.yml`), feature requests (`feature_request.yml`), and AI provider integration requests (`provider_request.yml`), along with `config.yml` linking to GitHub Discussions.
- **PR Template**: Add `.github/PULL_REQUEST_TEMPLATE.md` with standard Summary, Changes, Test Plan, and Screenshots sections.
- **Governance**: Add `.github/CODEOWNERS` assigning default review ownership to `@vinzdg`.

## Test Plan
- [x] Verified YAML syntax and structure for issue form definitions.
- [x] Verified pull request template markdown rendering.
- [x] Verified CODEOWNERS syntax and paths.