### PR TITLE
Build and test the Windows port in CI

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,0 +1,46 @@
+name: Windows
+
+# The port under windows/ is Rust, and CI and Package only ever run Xcode, so a
+# Windows change could merge on a green check that never compiled it. Its own
+# file, so those two stay about the Mac app.
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'windows/**'
+      - '.github/workflows/windows.yml'
+  pull_request:
+    paths:
+      - 'windows/**'
+      - '.github/workflows/windows.yml'
+
+jobs:
+  build:
+    if: github.repository == 'vinzdg/codenotch'
+    name: Build and test
+    runs-on: windows-latest
+    defaults:
+      run:
+        working-directory: windows
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+
+      # Tauri and the windows crate make a cold build several minutes long.
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: windows
+
+      - name: Build
+        run: cargo build --locked
+
+      - name: Test
+        run: cargo test --locked
+
+      # Reported rather than enforced: the crate already carries warnings, and
+      # failing on them would hold every change hostage to that cleanup.
+      - name: Clippy
+        run: cargo clippy --all-targets --locked


### PR DESCRIPTION
CI and Package only run Xcode, so a change under `windows/` merges on a green check that never compiled it. That's how #112, #115 and #132 went in: about 3,300 lines of Rust. They do build (I checked by hand), but nothing would have said so if they didn't.

This adds `.github/workflows/windows.yml`. It's a separate file, so `ci.yml` and `package.yml` stay about the Mac app.

- It runs on `windows-latest`, and only when something under `windows/` or the workflow itself changes, on pushes to `main` and on pull requests.
- It uses the same `github.repository == 'vinzdg/codenotch'` guard as #110, so forks stay quiet.
- From `windows/`, it runs `cargo build`, `cargo test` and `cargo clippy --all-targets`, all with `--locked`.
- `Swatinem/rust-cache` caches the dependency build, which takes several minutes cold.

Clippy warnings are reported, not enforced. The crate has 28 existing warnings, mostly doc-comment indentation, and failing on them would block every Windows PR on that cleanup. The check can be tightened once they're gone.

## Test plan

- [x] The three commands pass locally with `--locked` on `main` @ `25e1a08` (Windows 11): 24 tests pass and 1 is ignored (the live `agy` test).
- [x] The workflow parses, and the action versions exist (`checkout@v7`, `rust-toolchain@stable`, `rust-cache@v2`).
- [x] This PR's own run: it changes the workflow file, so it triggers itself.
