### PR TITLE
Add Kimi provider, session tracking, and exact-tab session focus

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ A Windows port — Rust/Tauri 2, same design and providers — lives in [`window
 | **OpenCode** | official | The Go plan's official usage endpoint, with the `opencode-go` key OpenCode itself stores on sign-in. |
 | **Command Code** | official | The GOAT plan's `/alpha` billing endpoints, with the key the Command Code app writes to `~/.commandcode/auth.json`. |
 | **GitHub Copilot** | official | GitHub's Copilot quota endpoint, authenticated with the GitHub CLI session already on the Mac (`gh auth login`). |
+| **Kimi** | official | The Kimi Code CLI session in `~/.kimi-code/credentials/kimi-code.json`, against the same `/usages` endpoint the CLI's `/usage` asks. Shows the 5-hour rate window and the weekly quota. |
 
 Most providers borrow a credential or session from a tool already on your Mac.
 DeepSeek is the explicit browser-login exception: it never reads a browser's

--- a/Sources/App/AppDelegate.swift
+++ b/Sources/App/AppDelegate.swift
@@ -124,7 +124,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                     + codexProfiles.map { CodexLocalProvider(profile: $0) }
                     + [AntigravityProvider(),
                        GLMProvider(), GrokLocalProvider(), DevinLocalProvider(), OpenCodeProvider(),
-                       CommandCodeProvider(), GitHubCopilotProvider(),
+                       CommandCodeProvider(), GitHubCopilotProvider(), KimiProvider(),
                        OllamaLocalProvider(endpoint: URL(string: preferences.ollamaEndpoint)!),
                        LMStudioLocalProvider(endpoint: URL(string: preferences.lmstudioEndpoint)!),
                        OllamaProvider(),

--- a/Sources/App/AppDelegate.swift
+++ b/Sources/App/AppDelegate.swift
@@ -481,6 +481,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             "gemini": AntigravityActivityMonitor(),
             "grok": GrokActivityMonitor(),
             "gemini-api": GeminiAPIActivityMonitor(),
+            "kimi": KimiActivityMonitor(),
         ]
         var claudeMonitors: [ClaudeSessionMonitor] = []
         for profile in claudeProfiles {

--- a/Sources/App/AppDelegate.swift
+++ b/Sources/App/AppDelegate.swift
@@ -243,6 +243,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             )
             // The gear toggles; everything else that opens settings opens it.
             fleet.onOpenSettings = { [weak settings] in settings?.toggle() }
+            // A session row answers where it runs by taking you there.
+            fleet.onFocusSession = { pid in
+                Task { _ = await SessionFocus.focus(pid: pid) }
+            }
             self.settings = settings
 
             // What changed, once per version — including on a fresh install,

--- a/Sources/Features/TooltipCard.swift
+++ b/Sources/Features/TooltipCard.swift
@@ -883,6 +883,8 @@ private struct BlockedRow: View {
 private struct SessionRow: View {
     let session: AgentSession
     let now: Date
+    /// Set when rows can be clicked to jump to the session's terminal.
+    var onFocus: ((pid_t) -> Void)? = nil
     @Environment(\.codenotchAccentColor) private var accentColor
 
     private var stateColor: Color {
@@ -924,6 +926,13 @@ private struct SessionRow: View {
             )
             .padding(.top, NotchLayout.sessionRowGap)
         }
+        // Sessions that publish a pid can be jumped to; the rest are text,
+        // and a gesture on them would promise something it cannot do.
+        .contentShape(Rectangle())
+        .onTapGesture {
+            guard let pid = session.processID else { return }
+            onFocus?(pid)
+        }
     }
 }
 
@@ -934,6 +943,7 @@ private struct SessionList: View {
     let now: Date
     /// How many rows this screen has room for; the rest are counted.
     let cap: Int
+    var onFocus: ((pid_t) -> Void)? = nil
 
     /// Busy sessions first, so what is hidden is what matters least.
     private var ordered: [AgentSession] {
@@ -959,7 +969,7 @@ private struct SessionList: View {
             // are counted rather than drawn: the card is clipped, not scrolled,
             // so anything past the budget silently pushes the title off the top.
             ForEach(Array(shown.enumerated()), id: \.element.id) { index, session in
-                SessionRow(session: session, now: now)
+                SessionRow(session: session, now: now, onFocus: onFocus)
                     .padding(.top, NotchLayout.blockSpacing)
             }
 
@@ -986,6 +996,9 @@ struct TooltipCard: View {
     var sessionCap: Int = NotchLayout.defaultSessionCap
     var resetTimeFormat: ResetTimeFormat = .automatic
     var tailOffset: CGFloat = 0
+    /// A tap on a session row jumps to that session's terminal — nil leaves
+    /// the rows as plain text.
+    var onFocusSession: ((pid_t) -> Void)? = nil
     @AppStorage(Preferences.showUsagePaceKey) private var showUsagePace = false
 
     /// The phase a local model is in, and the queue behind it, for the header.
@@ -1037,7 +1050,8 @@ struct TooltipCard: View {
                         DeepSeekUsageDetail(detail: usageDetail)
                     }
                     if let activity, snapshot.localModel == nil {
-                        SessionList(summary: activity, now: now, cap: sessionCap)
+                        SessionList(summary: activity, now: now, cap: sessionCap,
+                                    onFocus: onFocusSession)
                     }
                 }
                 // An identity, so one provider's rows are never interpolated

--- a/Sources/Notch/NotchFleet.swift
+++ b/Sources/Notch/NotchFleet.swift
@@ -69,6 +69,7 @@ final class NotchFleet {
     var onToggleKeepOpen: (() -> Void)?
     var onRefreshProvider: ((String) async -> Void)?
     var onOpenSettings: (() -> Void)?
+    var onFocusSession: ((pid_t) -> Void)?
     var signInItems: [(title: String, action: () -> Void)] = []
     /// An ⌥-drag on any one panel settled at a new offset. Persisting it is
     /// Preferences' job, same division `apply(edge:)` already keeps.
@@ -369,6 +370,7 @@ final class NotchFleet {
         controller.onRefreshProvider = onRefreshProvider
         controller.onOpenSettings = onOpenSettings
         controller.model.onOpenSettings = onOpenSettings
+        controller.model.onFocusSession = onFocusSession
         controller.onReposition = onReposition
         controller.onMoveToEdge = onMoveToEdge
         controller.onToggleKeepOpen = onToggleKeepOpen

--- a/Sources/Notch/NotchRootView.swift
+++ b/Sources/Notch/NotchRootView.swift
@@ -86,7 +86,8 @@ struct NotchRootView: View {
                         direction: model.edge.tooltipDirection,
                         sessionCap: model.sessionCap,
                         resetTimeFormat: model.resetTimeFormat,
-                        tailOffset: tooltipTailOffset(index: index, snapshot: snapshot)
+                        tailOffset: tooltipTailOffset(index: index, snapshot: snapshot),
+                        onFocusSession: model.onFocusSession
                     )
                         // Deliberately *no* `.id` here: the card is one object
                         // that travels and resizes between cells, which reads

--- a/Sources/Notch/NotchViewModel.swift
+++ b/Sources/Notch/NotchViewModel.swift
@@ -149,6 +149,9 @@ final class NotchViewModel: ObservableObject {
     /// the one action people actually get stuck without a second, ordinary
     /// route that only needs SwiftUI's own gesture recognition to work.
     var onOpenSettings: (() -> Void)?
+    /// A tap on a session row in the tooltip: jump to the terminal tab the
+    /// session runs in. Takes the session's pid; wired to `SessionFocus`.
+    var onFocusSession: ((pid_t) -> Void)?
     /// Which screen edge the notch is welded to. Everything geometric reads
     /// this through `placement` rather than assuming an axis.
     @Published var edge: NotchEdge = .right

--- a/Sources/Notch/NotchWindowController.swift
+++ b/Sources/Notch/NotchWindowController.swift
@@ -628,6 +628,13 @@ final class NotchWindowController {
             updateInteractiveRects()
             return
         }
+        // Clicks on the tooltip card belong to whatever is drawn there — the
+        // session rows take their own taps — and must not fall through to the
+        // cell refetch or the pin toggle underneath.
+        if model.isExpanded, let index = model.hoveredIndex,
+           let card = tooltipRect(index: index), card.contains(local) {
+            return
+        }
         guard model.isExpanded else {
             // Opens it, the same as the pointer arriving would — it must not
             // also pin it. The pill's hot zone is deliberately generous, since
@@ -964,7 +971,9 @@ final class NotchWindowController {
             return false
         }
         pendingFocus = nil
-        return SessionFocus.activateApp(owning: pending.pid)
+        // The same exact-tab jump a session row gives, not just the app.
+        Task { _ = await SessionFocus.focus(pid: pending.pid) }
+        return true
     }
 
     /// Tear down a controller whose display is gone: hide first so no panel

--- a/Sources/Providers/GlyphOutline.swift
+++ b/Sources/Providers/GlyphOutline.swift
@@ -409,6 +409,20 @@ enum GlyphOutline {
          CGPoint(x: 0.6820, y: 0.2000), CGPoint(x: 0.0200, y: 0.2000)]
     ]
 
+    /// Kimi's mark: a bold geometric K, defined rather than traced, the same
+    /// approach as `glm` — eleven vertices in the unit box, exact at any size.
+    ///
+    /// One loop, no counters. The stem and both arms share one stroke depth
+    /// (0.2), so the letter reads at one weight.
+    static let kimi: [[CGPoint]] = [
+        [CGPoint(x: 0.0600, y: 1.0000), CGPoint(x: 0.0600, y: 0.0000),
+         CGPoint(x: 0.2600, y: 0.0000), CGPoint(x: 0.2600, y: 0.3800),
+         CGPoint(x: 0.6800, y: 0.0000), CGPoint(x: 0.9400, y: 0.0000),
+         CGPoint(x: 0.4800, y: 0.4400), CGPoint(x: 0.9800, y: 1.0000),
+         CGPoint(x: 0.7000, y: 1.0000), CGPoint(x: 0.2600, y: 0.5400),
+         CGPoint(x: 0.2600, y: 1.0000)]
+    ]
+
     /// Grok's mark, flattened from grok.com's favicon SVG.
     ///
     /// Two filled loops — the interlocking swirls with the diagonal slash —

--- a/Sources/Providers/KimiCredentials.swift
+++ b/Sources/Providers/KimiCredentials.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+/// Token from `~/.kimi-code/credentials/kimi-code.json`.
+///
+/// Kimi Code CLI signs in through auth.kimi.com and writes the OAuth session
+/// here — one file per managed provider, and `kimi-code` is the Kimi Code
+/// account itself. Codenotch only reads it: the access token lives fifteen
+/// minutes (`expires_in: 900`) and refreshing is the CLI's job, the same
+/// bargain as Grok's — writing a new one would race the CLI for the file.
+/// `KIMI_CODE_HOME` moves the whole data root, so the path honours it.
+struct KimiCredentials {
+    static var authURL: URL {
+        let override = ProcessInfo.processInfo.environment["KIMI_CODE_HOME"]
+            .flatMap { value -> String? in value.isEmpty ? nil : value }
+        let root = override.map { URL(fileURLWithPath: $0) }
+            ?? URL(fileURLWithPath: NSHomeDirectory()).appendingPathComponent(".kimi-code")
+        return root.appendingPathComponent("credentials/kimi-code.json")
+    }
+
+    let accessToken: String
+    let expiresAt: Date
+
+    var isExpired: Bool { expiresAt <= Date() }
+
+    static func account(from url: URL = authURL) -> ProviderAccount? {
+        guard (try? load(from: url)) != nil else { return nil }
+        return ProviderAccount(
+            label: nil,   // the token carries no address
+            plan: nil,
+            source: "Kimi Code",
+            manageURL: URL(string: "https://www.kimi.com/code/console")
+        )
+    }
+
+    static func load(from url: URL = authURL) throws -> KimiCredentials {
+        guard let data = try? Data(contentsOf: url),
+              let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let token = root["access_token"] as? String, !token.isEmpty
+        else { throw UsageProviderError.needsAuth }
+
+        // `expires_at` is epoch seconds. A file without one is not a session
+        // to trust with a request that cannot succeed.
+        guard let expires = (root["expires_at"] as? NSNumber)?.doubleValue, expires > 0
+        else { throw UsageProviderError.needsAuth }
+
+        return KimiCredentials(accessToken: token,
+                               expiresAt: Date(timeIntervalSince1970: expires))
+    }
+}

--- a/Sources/Providers/KimiProvider.swift
+++ b/Sources/Providers/KimiProvider.swift
@@ -1,0 +1,78 @@
+import Foundation
+import os
+
+/// Reads Kimi Code usage from the endpoint the CLI's own `/usage` asks, with
+/// the OAuth token the CLI stores on sign-in — see `KimiCredentials`.
+///
+/// The numbers are Kimi's, so this is `.official`. The token expires every
+/// fifteen minutes and the CLI renews it as it runs; an expired one is
+/// `.credentialExpired`, the same answer Grok gives, because minting a new
+/// token here would race the CLI for the file. A 404 is the endpoint's own
+/// answer for an account with no Kimi Code plan — readable, but metering
+/// nothing, and not an error.
+actor KimiProvider: UsageProvider {
+    nonisolated let id = "kimi"
+    nonisolated let displayName = "Kimi"
+    nonisolated let glyph = ProviderGlyph.kimi
+
+    private let session: URLSession
+    private let authURL: URL
+
+    init(session: URLSession = .shared, authURL: URL = KimiCredentials.authURL) {
+        self.session = session
+        self.authURL = authURL
+    }
+
+    nonisolated var signInRoute: SignInRoute {
+        .guidance(L10n.t("Run kimi and sign in with /login — it writes and refreshes the token this reads."))
+    }
+
+    nonisolated func account() -> ProviderAccount? { KimiCredentials.account() }
+
+    func fetchSnapshot() async throws -> ProviderSnapshot {
+        let credentials = try KimiCredentials.load(from: authURL)
+        if credentials.isExpired { throw UsageProviderError.credentialExpired }
+
+        let body = try await fetch(token: credentials.accessToken)
+        Log.usage.debug("kimi usages -> \(body.prefix(400), privacy: .public)")
+        let read = try KimiUsage.read(fromJSON: body)
+
+        return ProviderSnapshot(
+            id: id,
+            displayName: displayName,
+            glyph: glyph,
+            fidelity: .official,
+            status: .ok,
+            windows: read.windows,
+            headlineID: "rolling",
+            weeklyID: "weekly",
+            plan: read.plan
+        )
+    }
+
+    private func fetch(token: String) async throws -> String {
+        var request = URLRequest(url: KimiUsage.endpoint)
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.timeoutInterval = 15
+
+        Log.usage.debug("GET api.kimi.com/coding/v1/usages")
+        let (data, response) = try await session.data(for: request)
+        let status = (response as? HTTPURLResponse)?.statusCode ?? 0
+        Log.usage.debug("kimi usages endpoint answered \(status)")
+
+        if status == 401 || status == 403 { throw UsageProviderError.needsAuth }
+        // The endpoint's answer for an account without a Kimi Code plan — the
+        // CLI's own message for it is "Usage endpoint not available".
+        if status == 404 {
+            throw UsageProviderError.nothingMetered(L10n.t("No Kimi Code plan on this account"))
+        }
+        if status == 429 {
+            throw UsageProviderError.rateLimited(retryAfter: 60)
+        }
+        guard (200..<300).contains(status),
+              let text = String(data: data, encoding: .utf8)
+        else { throw UsageProviderError.badResponse(status: status) }
+        return text
+    }
+}

--- a/Sources/Providers/KimiUsage.swift
+++ b/Sources/Providers/KimiUsage.swift
@@ -1,0 +1,121 @@
+import Foundation
+
+/// Parses `GET https://api.kimi.com/coding/v1/usages`.
+///
+/// The managed Kimi Code account's windows, the same figures the CLI's
+/// `/usage` leads with — recorded live (user id redacted):
+///
+/// ```json
+/// {"user":{"userId":"…","membership":{"level":"LEVEL_ADVANCED"}},
+///  "usage":{"limit":"100","used":"2","remaining":"98",
+///           "resetTime":"2026-09-15T19:39:34.389610Z"},
+///  "limits":[{"window":{"duration":300,"timeUnit":"TIME_UNIT_MINUTE"},
+///             "detail":{"limit":"100","used":"8","remaining":"92",
+///                       "resetTime":"2026-09-11T16:39:34.389610Z"}}]}
+/// ```
+///
+/// Two shapes of the same row: `usage` is the account summary (the weekly
+/// window — the CLI assumes a week when no window is stated), each `limits[]`
+/// entry names its own window. Counts arrive as decimal *strings*, and a
+/// 300-minute window is the 5-hour one — minute durations divisible by 60 are
+/// normalised to hours, as the CLI does. The Extra Usage wallet
+/// (`boosterWallet`) is money, not a window, and is left out here.
+enum KimiUsage {
+    static let endpoint = URL(string: "https://api.kimi.com/coding/v1/usages")!
+
+    struct Read {
+        let windows: [LimitWindow]
+        /// The membership tier, named the way the account names it
+        /// (`LEVEL_ADVANCED` → "Advanced"). Nil when there is nothing to name.
+        let plan: String?
+    }
+
+    static func read(fromJSON json: String) throws -> Read {
+        guard let data = json.data(using: .utf8),
+              let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else { throw UsageProviderError.badResponse(status: 0) }
+
+        var windows: [LimitWindow] = []
+        if let summary = root["usage"] as? [String: Any],
+           let window = row(id: "weekly", label: L10n.t("Weekly limit"),
+                            from: summary, duration: 7 * 86400) {
+            windows.append(window)
+        }
+        for entry in root["limits"] as? [[String: Any]] ?? [] {
+            guard let detail = entry["detail"] as? [String: Any],
+                  let (id, label, duration) = windowKind(from: entry["window"])
+            else { continue }
+            if let window = row(id: id, label: label, from: detail, duration: duration) {
+                windows.append(window)
+            }
+        }
+        guard !windows.isEmpty else {
+            throw UsageProviderError.nothingMetered(L10n.t("No Kimi Code usage limits on this account"))
+        }
+
+        return Read(windows: windows, plan: plan(from: root))
+    }
+
+    /// One metered row. `used` and `limit` are decimal strings in the wire
+    /// format, but numbers are accepted too — the denominator decides whether
+    /// there is a fraction to show at all.
+    private static func row(id: String, label: String,
+                            from detail: [String: Any], duration: TimeInterval) -> LimitWindow? {
+        guard let used = count(detail["used"]) else { return nil }
+        let resetsAt = (detail["resetTime"] as? String).flatMap(date(from:))
+        guard let limit = count(detail["limit"]), limit > 0 else {
+            return LimitWindow(id: id, label: label, used: used,
+                               resetsAt: resetsAt, duration: duration)
+        }
+        return LimitWindow(id: id, label: label,
+                           usedFraction: Double(used) / Double(limit),
+                           resetsAt: resetsAt, duration: duration)
+    }
+
+    /// A `limits[]` window as an id, a label and a length. Only the windows
+    /// Kimi meters today — the 5-hour rate window and the weekly quota — get
+    /// named; anything else is left out rather than mislabelled.
+    private static func windowKind(from raw: Any?) -> (id: String, label: String, duration: TimeInterval)? {
+        guard let window = raw as? [String: Any],
+              let duration = count(window["duration"]), duration > 0,
+              let unit = window["timeUnit"] as? String
+        else { return nil }
+        switch unit {
+        case "TIME_UNIT_MINUTE" where duration % 60 == 0:
+            let hours = duration / 60
+            return hours == 5
+                ? ("rolling", L10n.t("5h limit"), TimeInterval(duration * 60))
+                : nil
+        case "TIME_UNIT_HOUR" where duration == 5:
+            return ("rolling", L10n.t("5h limit"), TimeInterval(duration * 3600))
+        case "TIME_UNIT_WEEK" where duration == 1:
+            return ("weekly", L10n.t("Weekly limit"), 7 * 86400)
+        default:
+            return nil
+        }
+    }
+
+    /// `LEVEL_ADVANCED` → "Advanced"; the raw level when there is no prefix to
+    /// strip; nil when the account says nothing.
+    private static func plan(from root: [String: Any]) -> String? {
+        guard let user = root["user"] as? [String: Any],
+              let membership = user["membership"] as? [String: Any],
+              let level = membership["level"] as? String, !level.isEmpty
+        else { return nil }
+        let name = level.hasPrefix("LEVEL_") ? String(level.dropFirst("LEVEL_".count)) : level
+        return name.lowercased().capitalized
+    }
+
+    private static func count(_ any: Any?) -> Int? {
+        if let number = any as? NSNumber { return number.intValue }
+        guard let text = any as? String, let value = Int(text) else { return nil }
+        return value
+    }
+
+    private static func date(from stamp: String) -> Date? {
+        let fractional = ISO8601DateFormatter()
+        fractional.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        if let date = fractional.date(from: stamp) { return date }
+        return ISO8601DateFormatter().date(from: stamp)
+    }
+}

--- a/Sources/Providers/ProviderGlyph.swift
+++ b/Sources/Providers/ProviderGlyph.swift
@@ -28,6 +28,7 @@ enum ProviderGlyph: String, Codable, Equatable {
     case opencode
     case commandcode
     case copilot
+    case kimi
     case ollama
     case ollamaLocal = "ollama-local"
     case lmstudio
@@ -59,6 +60,7 @@ enum ProviderGlyph: String, Codable, Equatable {
         case .opencode: return 0.95
         case .commandcode: return 0.96
         case .copilot: return 0.96
+        case .kimi:   return 0.95
         case .ollama: return 0.95
         case .third:  return 1.0
         case .ollamaLocal: return 0.98
@@ -81,6 +83,7 @@ enum ProviderGlyph: String, Codable, Equatable {
         case .opencode: return GlyphOutline.opencode
         case .commandcode: return GlyphOutline.commandcode
         case .copilot: return GlyphOutline.copilot
+        case .kimi:   return GlyphOutline.kimi
         case .ollama, .ollamaLocal: return GlyphOutline.ollama
         }
     }

--- a/Sources/Sessions/ClaudeSessionRecord.swift
+++ b/Sources/Sessions/ClaudeSessionRecord.swift
@@ -80,9 +80,11 @@ struct ClaudeSessionRecord {
     ///
     /// `waitingFor` is dropped on purpose: the only states that reach here come
     /// from the transcript, and the transcript cannot see a permission prompt.
+    /// The pid stays: the registry file still names the process to jump to.
     func session(state: AgentSession.State, since: Date) -> AgentSession {
         AgentSession(id: session.id, name: session.name, detail: session.detail,
-                     state: state, waitingFor: nil, since: since)
+                     state: state, waitingFor: nil, since: since,
+                     processID: session.processID)
     }
 
     static func surface(_ entrypoint: String?) -> String {

--- a/Sources/Sessions/KimiActivityMonitor.swift
+++ b/Sources/Sessions/KimiActivityMonitor.swift
@@ -1,0 +1,295 @@
+import Combine
+import Darwin
+import Foundation
+
+/// Follows running Kimi Code CLIs, the way `ClaudeSessionMonitor` follows
+/// Claude Code.
+///
+/// Kimi writes no live-session registry, so discovery works the other way
+/// around: find the CLI's own processes (`kimi-code`) and match each one's
+/// working directory to a session in `session_index.jsonl`. State comes from
+/// the session's `wire.jsonl`, which records turn boundaries and approval
+/// prompts with millisecond timestamps — a richer signal than Grok's
+/// recency-only heuristic: a turn in flight is `busy`, an approval waiting on
+/// an answer is `waiting`, a turn that just ended is `success`, and a live
+/// TUI sitting at its prompt is `idle`. The pid goes into the session, so a
+/// peek click raises the terminal it runs in — see `SessionFocus`.
+@MainActor
+final class KimiActivityMonitor: ObservableObject, AgentActivityMonitor {
+    @Published private(set) var sessions: [AgentSession] = []
+    var sessionsPublisher: AnyPublisher<[AgentSession], Never> { $sessions.eraseToAnyPublisher() }
+
+    private let root: URL
+    private let interval: TimeInterval
+    private let staleAfter: TimeInterval
+    private var timer: Timer?
+
+    init(
+        root: URL = KimiActivity.root,
+        interval: TimeInterval = 2,
+        staleAfter: TimeInterval = 90
+    ) {
+        self.root = root
+        self.interval = interval
+        self.staleAfter = staleAfter
+    }
+
+    func start() {
+        rescan()
+        let timer = Timer(timeInterval: interval, repeats: true) { [weak self] _ in
+            MainActor.assumeIsolated { self?.rescan() }
+        }
+        RunLoop.main.add(timer, forMode: .common)
+        self.timer = timer
+    }
+
+    func stop() {
+        timer?.invalidate()
+        timer = nil
+    }
+
+    private func rescan() {
+        let found = KimiActivity.read(root: root, staleAfter: staleAfter)
+        guard found != sessions else { return }
+        sessions = found
+    }
+}
+
+enum KimiActivity {
+    /// Everything the monitor reads lives under the CLI's data root.
+    static var root: URL {
+        let override = ProcessInfo.processInfo.environment["KIMI_CODE_HOME"]
+            .flatMap { value -> String? in value.isEmpty ? nil : value }
+        return override.map { URL(fileURLWithPath: $0) }
+            ?? URL(fileURLWithPath: NSHomeDirectory()).appendingPathComponent(".kimi-code")
+    }
+
+    /// A turn that has written nothing for this long is not running, whatever
+    /// the last wire record says — thinking streams deltas, tools report when
+    /// they finish, so silence means the CLI is gone or wedged.
+    static func read(root: URL, staleAfter: TimeInterval, now: Date = Date()) -> [AgentSession] {
+        let byWorkDir = index(root: root)
+        // Newest process first, so when two TUIs share a directory the newer
+        // one is paired with the newer session.
+        let live = processes()
+            .filter { $0.cwd != nil && byWorkDir[resolve($0.cwd!)] != nil }
+            .sorted { ($0.startedAt ?? .distantPast) > ($1.startedAt ?? .distantPast) }
+        var remaining = byWorkDir
+        return live.compactMap { process in
+            let key = resolve(process.cwd!)
+            guard let sessionDir = remaining.removeValue(forKey: key) else { return nil }
+            return session(sessionDir: sessionDir, pid: process.pid,
+                           startedAt: process.startedAt, workDir: process.cwd!,
+                           staleAfter: staleAfter, now: now)
+        }
+        .sorted { $0.since == $1.since ? $0.id < $1.id : $0.since > $1.since }
+    }
+
+    static func session(sessionDir: URL, pid: pid_t, startedAt: Date?,
+                        workDir: String, staleAfter: TimeInterval, now: Date) -> AgentSession? {
+        guard ProcessLiveness.isAlive(pid: pid, startedAt: startedAt) else { return nil }
+
+        let wire = sessionDir
+            .appendingPathComponent("agents/main/wire.jsonl")
+        let modified = (try? FileManager.default.attributesOfItem(atPath: wire.path))?[.modificationDate] as? Date
+        let turn = tail(of: wire).flatMap { KimiActivity.turn(inTail: $0) }
+
+        /// Two levels, not one: `repos/personal` says something where
+        /// `personal` could be any folder on the machine.
+        let url = URL(fileURLWithPath: workDir)
+        let parent = url.deletingLastPathComponent().lastPathComponent
+        let name = parent.isEmpty ? (url.lastPathComponent.isEmpty ? "Kimi" : url.lastPathComponent)
+            : "\(parent)/\(url.lastPathComponent)"
+
+        /// Where it is running, the way Claude's rows name the surface. The
+        /// owning app is the same answer `SessionFocus` jumps to on a peek
+        /// click; a CLI nobody claims is a terminal one.
+        let surface = SessionFocus.owningApp(of: pid)?.localizedName ?? L10n.t("Terminal")
+
+        let state: AgentSession.State
+        var waitingFor: String?
+        var since = modified ?? now
+        switch turn {
+        case .waiting(let at, let what):
+            // An approval holds until it is answered, however long that takes —
+            // no staleness ladder here.
+            state = .waiting
+            waitingFor = what
+            since = at
+        case .busy(let at):
+            if let modified, now.timeIntervalSince(modified) <= staleAfter {
+                state = .busy
+                since = at ?? modified
+            } else {
+                state = .idle
+            }
+        case .finished(let at):
+            state = now.timeIntervalSince(at) <= 10 ? .success : .idle
+            since = at
+        case nil:
+            state = .idle
+        }
+
+        return AgentSession(
+            id: "kimi.\(sessionDir.lastPathComponent)",
+            name: name,
+            detail: surface,
+            state: state,
+            waitingFor: waitingFor,
+            since: since,
+            processID: pid
+        )
+    }
+
+    /// The last 64 KB of the wire is enough: turn boundaries are one line
+    /// each, and a turn writes dozens.
+    private static let tailBytes: UInt64 = 65_536
+
+    static func tail(of url: URL) -> Data? {
+        guard let handle = try? FileHandle(forReadingFrom: url) else { return nil }
+        defer { try? handle.close() }
+        let size = (try? handle.seekToEnd()) ?? 0
+        let offset = size > tailBytes ? size - tailBytes : 0
+        try? handle.seek(toOffset: offset)
+        return try? handle.readToEnd()
+    }
+
+    /// What the main agent is doing, read off the wire's own records.
+    enum Turn {
+        /// Loop records carry no timestamp of their own; the caller falls
+        /// back to the wire's modification time.
+        case busy(since: Date?)
+        case finished(since: Date)
+        case waiting(since: Date, for: String?)
+    }
+
+    /// Newest relevant record wins. Turn records are top-level
+    /// (`{"type":"turn.prompt",…,"time":<ms>}`); approval records can arrive
+    /// wrapped in a `context.append_loop_event` envelope, so one level of
+    /// nesting is unwrapped. Subagent records are not the session's turn.
+    ///
+    /// Loop activity (`tool.call`, `step.begin`, …) also means busy: a long
+    /// turn fills the tail with more than 64 KB of tool chatter, pushing its
+    /// own `turn.prompt` out of the window, and only `turn.ended` may say it
+    /// is over.
+    static func turn(inTail data: Data) -> Turn? {
+        /// Records that only exist while a turn runs.
+        let loopActivity: Set<String> = [
+            "context.append_loop_event", "content.part",
+            "step.begin", "step.end", "tool.call", "tool.result",
+            "think", "text", "llm.request",
+        ]
+        guard let text = String(data: data, encoding: .utf8) else { return nil }
+        /// Set by an `approval.resolved` seen while scanning backwards: any
+        /// request further back was the one it answered.
+        var approvalResolved = false
+        for line in text.split(separator: "\n").reversed() {
+            guard let object = try? JSONSerialization.jsonObject(with: Data(line.utf8)) as? [String: Any]
+            else { continue }
+            var record = object
+            if record["type"] as? String == "context.append_loop_event",
+               let event = record["event"] as? [String: Any] {
+                record = event
+            }
+            if let agent = record["agentId"] as? String, agent != "main" { continue }
+            guard let type = record["type"] as? String else { continue }
+            let time = (record["time"] as? NSNumber)
+                .map { Date(timeIntervalSince1970: $0.doubleValue / 1000) }
+            switch type {
+            case "approval.requested":
+                if approvalResolved { continue }
+                return .waiting(since: time ?? Date(), for: summary(of: record))
+            case "approval.resolved":
+                approvalResolved = true
+                continue
+            case "turn.prompt", "prompt.accepted":
+                return .busy(since: time)
+            case "turn.ended":
+                return .finished(since: time ?? Date())
+            default:
+                if loopActivity.contains(type) { return .busy(since: time) }
+                continue
+            }
+        }
+        return nil
+    }
+
+    /// What an approval is asking about, in whichever field the CLI put it.
+    private static func summary(of record: [String: Any]) -> String? {
+        for key in ["tool", "toolName", "name", "command", "summary"] {
+            if let value = record[key] as? String, !value.isEmpty { return value }
+        }
+        return nil
+    }
+
+    /// workDir → newest session directory, from the CLI's own index.
+    /// `/private` prefixes are resolved on both sides before comparing.
+    static func index(root: URL) -> [String: URL] {
+        let indexURL = root.appendingPathComponent("session_index.jsonl")
+        guard let text = try? String(contentsOf: indexURL, encoding: .utf8) else { return [:] }
+        var byWorkDir: [String: URL] = [:]
+        for line in text.split(separator: "\n") {
+            guard let record = try? JSONSerialization.jsonObject(with: Data(line.utf8)) as? [String: Any],
+                  let workDir = record["workDir"] as? String,
+                  let sessionDir = record["sessionDir"] as? String
+            else { continue }
+            byWorkDir[resolve(workDir)] = URL(fileURLWithPath: sessionDir)
+        }
+        return byWorkDir
+    }
+
+    private static func resolve(_ path: String) -> String {
+        URL(fileURLWithPath: path).resolvingSymlinksInPath().path
+    }
+
+    // MARK: - Process discovery
+
+    struct Process {
+        let pid: pid_t
+        let startedAt: Date?
+        let cwd: String?
+    }
+
+    /// Every running `kimi-code` (or `kimi`) process. The managed install is
+    /// a single binary under `~/.kimi-code/bin/kimi`; either the command name
+    /// or that path marks it. A `node` wrapper script would not be found —
+    /// the CLI ships the binary.
+    static func processes() -> [Process] {
+        var count = proc_listpids(UInt32(PROC_ALL_PIDS), 0, nil, 0)
+        guard count > 0 else { return [] }
+        var pids = [pid_t](repeating: 0, count: Int(count) / MemoryLayout<pid_t>.stride + 16)
+        count = proc_listpids(UInt32(PROC_ALL_PIDS), 0, &pids,
+                              Int32(pids.count * MemoryLayout<pid_t>.stride))
+        guard count > 0 else { return [] }
+        return pids.prefix(Int(count) / MemoryLayout<pid_t>.stride)
+            .compactMap { process(pid: $0) }
+    }
+
+    static func process(pid: pid_t) -> Process? {
+        guard pid > 0 else { return nil }
+        var info = proc_bsdinfo()
+        let read = proc_pidinfo(pid, PROC_PIDTBSDINFO, 0, &info,
+                                Int32(MemoryLayout<proc_bsdinfo>.size))
+        guard read == Int32(MemoryLayout<proc_bsdinfo>.size) else { return nil }
+        let comm = withUnsafePointer(to: &info.pbi_comm) { pointer in
+            pointer.withMemoryRebound(to: CChar.self, capacity: Int(MAXCOMLEN)) {
+                String(cString: $0)
+            }
+        }
+        guard comm == "kimi-code" || comm == "kimi" || executablePath(of: pid) else {
+            return nil
+        }
+        let startedAt = Date(timeIntervalSince1970:
+            Double(info.pbi_start_tvsec) + Double(info.pbi_start_tvusec) / 1_000_000)
+        return Process(pid: pid, startedAt: startedAt, cwd: SessionFocus.currentDirectory(of: pid))
+    }
+
+    /// True when the executable is the managed binary — covers a comm the
+    /// kernel truncated.
+    private static func executablePath(of pid: pid_t) -> Bool {
+        var buffer = [CChar](repeating: 0, count: Int(MAXPATHLEN))
+        let read = proc_pidpath(pid, &buffer, UInt32(buffer.count))
+        guard read > 0 else { return false }
+        return String(cString: buffer).hasSuffix("/.kimi-code/bin/kimi")
+    }
+}

--- a/Sources/Sessions/SessionFocus.swift
+++ b/Sources/Sessions/SessionFocus.swift
@@ -10,13 +10,63 @@ import Foundation
 /// up the process tree until something turns up that macOS considers an
 /// application, and that is what gets raised.
 ///
-/// This stops at the application. Selecting the *tab* inside it needs the
-/// terminal's own scripting interface and there is no general one: Terminal.app
-/// and iTerm2 can match a tab by tty over AppleScript, Warp and Ghostty publish
-/// no scripting dictionary at all. Rather than work for two terminals and
-/// silently do nothing in a third, the app is raised for everybody and the
-/// tooltip names the session so the last hop is one keystroke.
+/// Raising the app is the answer every terminal gets. Selecting the *tab*
+/// inside it needs the terminal's own scripting interface and there is no
+/// general one — cmux answers through its socket CLI, Terminal.app and iTerm2
+/// by tty over AppleScript, Warp and Ghostty publish nothing. `focus` tries
+/// the tab and settles for the app; `activateApp` is the app-only route.
 enum SessionFocus {
+    /// Select the tab this process runs in where the terminal allows it, then
+    /// raise the owning application either way.
+    ///
+    /// The tab selection runs off the calling actor: cmux's CLI and osascript
+    /// are subprocesses that would otherwise stall the notch's tap handling.
+    @discardableResult
+    static func focus(pid: pid_t) async -> Bool {
+        let app = owningApp(of: pid)
+        let tty = tty(of: pid)
+        let cwd = currentDirectory(of: pid)
+        await Task.detached(priority: .userInitiated) {
+            _ = TerminalTabFocus.selectTab(bundleID: app?.bundleIdentifier, pid: pid, tty: tty, cwd: cwd)
+        }.value
+        guard let app else {
+            Log.usage.debug("no owning app for pid \(pid, privacy: .public)")
+            return false
+        }
+        return await MainActor.run { app.activate() }
+    }
+
+    /// The process's controlling terminal, named the way ps prints it
+    /// (`ttys014`). Nil when it has none — agents with no terminal to go back
+    /// to, which is most desktop-hosted sessions.
+    static func tty(of pid: pid_t) -> String? {
+        var info = kinfo_proc()
+        var size = MemoryLayout<kinfo_proc>.stride
+        var mib: [Int32] = [CTL_KERN, KERN_PROC, KERN_PROC_PID, pid]
+        guard sysctl(&mib, u_int(mib.count), &info, &size, nil, 0) == 0, size > 0
+        else { return nil }
+        // NODEV (-1) is "no controlling terminal"; devname would read it as a
+        // real device number and answer garbage.
+        guard info.kp_eproc.e_tdev != -1,
+              let name = devname(info.kp_eproc.e_tdev, S_IFCHR)
+        else { return nil }
+        return String(cString: name)
+    }
+
+    /// The process's working directory — how a terminal that publishes no tty
+    /// (cmux's AppleScript interface) can still name the tab it lives in.
+    static func currentDirectory(of pid: pid_t) -> String? {
+        var info = proc_vnodepathinfo()
+        let read = proc_pidinfo(pid, PROC_PIDVNODEPATHINFO, 0, &info,
+                                Int32(MemoryLayout<proc_vnodepathinfo>.size))
+        guard read == Int32(MemoryLayout<proc_vnodepathinfo>.size) else { return nil }
+        return withUnsafePointer(to: &info.pvi_cdir.vip_path) { pointer in
+            pointer.withMemoryRebound(to: CChar.self, capacity: Int(MAXPATHLEN)) {
+                String(cString: $0)
+            }
+        }
+    }
+
     /// Raise whichever application owns this process.
     ///
     /// Returns false when the chain runs out before an application appears,

--- a/Sources/Sessions/TerminalTabFocus.swift
+++ b/Sources/Sessions/TerminalTabFocus.swift
@@ -1,0 +1,228 @@
+import AppKit
+import Foundation
+
+/// Selects the exact tab a session is running in, where the terminal offers
+/// a way to name it.
+///
+/// There is no general mechanism — every terminal is its own answer, and each
+/// costs a one-time Automation consent for AppleScript:
+///
+/// * **cmux** matches a terminal panel by its *working directory* — the
+///   session process's own cwd. Its socket CLI would be nicer (it names tabs
+///   by tty), but the server refuses any client that is not itself inside a
+///   cmux terminal session (manaflow-ai/cmux#3089) — and Codenotch never is.
+/// * **Terminal.app** and **iTerm2** match a tab by tty.
+/// * Everything else publishes nothing (Warp, Ghostty), and the caller falls
+///   back to raising the app — the honest answer rather than a silent no-op.
+enum TerminalTabFocus {
+    /// Best effort: true when a tab was selected. Anything going wrong —
+    /// no tty, no cwd, no match, a refused prompt — is false, and the caller
+    /// still raises the app.
+    static func selectTab(bundleID: String?, pid: pid_t, tty: String?, cwd: String?) -> Bool {
+        switch bundleID {
+        case "com.cmuxterm.app":
+            // The exact surface, named by the id the session's own process
+            // tree carries in its environment; cwd matching is the fallback
+            // for a tree that publishes nothing readable.
+            if let surface = cmuxSurfaceID(of: pid) {
+                return selectCmuxTerminal(matching: "id of term is \"\(surface)\"")
+            }
+            guard let cwd else { return false }
+            let condition = cmuxPathCandidates(cwd)
+                .map { "working directory of term is \"\(appleScriptEscaped($0))\"" }
+                .joined(separator: " or ")
+            return selectCmuxTerminal(matching: condition)
+        case "com.apple.Terminal":
+            guard let tty else { return false }
+            return runOsascript("""
+                tell application "Terminal"
+                  repeat with w in windows
+                    repeat with t in tabs of w
+                      if tty of t is "/dev/\(tty)" then
+                        set selected of t to true
+                        set index of w to 1
+                        return "found"
+                      end if
+                    end repeat
+                  end repeat
+                end tell
+                """)
+        case "com.googlecode.iterm2":
+            guard let tty else { return false }
+            return runOsascript("""
+                tell application "iTerm2"
+                  repeat with w in windows
+                    repeat with t in tabs of w
+                      repeat with s in sessions of t
+                        if tty of s is "/dev/\(tty)" then
+                          select s
+                          select t
+                          select w
+                          return "found"
+                        end if
+                      end repeat
+                    end repeat
+                  end repeat
+                end tell
+                """)
+        default:
+            return false
+        }
+    }
+
+    // MARK: - cmux
+
+    /// The scripting dictionary's `terminal` panels carry an `id`, a
+    /// `working directory` and a title but no tty; `select tab` picks the
+    /// workspace, and `focus` plus `activate window` finish the job.
+    private static func selectCmuxTerminal(matching condition: String) -> Bool {
+        return runOsascript("""
+            tell application "cmux"
+              repeat with w in windows
+                repeat with t in tabs of w
+                  repeat with term in terminals of t
+                    if \(condition) then
+                      select tab t
+                      focus term
+                      activate window w
+                      return "found"
+                    end if
+                  end repeat
+                end repeat
+              end repeat
+            end tell
+            """)
+    }
+
+    /// The session's own process tree knows exactly which surface it lives
+    /// in: cmux exports CMUX_SURFACE_ID into every terminal it spawns, and
+    /// the agent inherits it. Read up the ancestry until it turns up —
+    /// wrappers occasionally scrub it from the agent itself, but the shell
+    /// or launcher above still has it.
+    static func cmuxSurfaceID(of pid: pid_t) -> String? {
+        for candidate in SessionFocus.ancestry(of: pid) {
+            for entry in environment(of: candidate) {
+                guard entry.hasPrefix("CMUX_SURFACE_ID=") else { continue }
+                let value = String(entry.dropFirst("CMUX_SURFACE_ID=".count))
+                if !value.isEmpty { return value }
+            }
+        }
+        return nil
+    }
+
+    /// A process's full argument/environment block as NUL-separated strings.
+    /// Same-user reads only — which is all a session's own tree ever needs.
+    static func environment(of pid: pid_t) -> [String] {
+        var mib: [Int32] = [CTL_KERN, KERN_PROCARGS2, pid]
+        var size = 0
+        guard sysctl(&mib, 3, nil, &size, nil, 0) == 0, size > MemoryLayout<Int32>.size
+        else { return [] }
+        var buffer = [CChar](repeating: 0, count: size)
+        guard sysctl(&mib, 3, &buffer, &size, nil, 0) == 0 else { return [] }
+        var strings: [String] = []
+        buffer.withUnsafeBytes { raw in
+            var offset = MemoryLayout<Int32>.size   // past argc
+            while offset < raw.count {
+                guard let nul = raw[offset...].firstIndex(of: 0) else { break }
+                // Empty runs separate the blocks (path, argv, env) — skip
+                // them rather than stop at the first one.
+                if nul == offset {
+                    offset += 1
+                    continue
+                }
+                if let string = String(bytes: raw[offset..<nul], encoding: .utf8) {
+                    strings.append(string)
+                }
+                offset = nul + 1
+            }
+        }
+        return strings
+    }
+
+    /// The same directory, spelled the ways it might appear: the kernel's
+    /// report can carry a `/private` prefix the terminal's title never shows,
+    /// and symlinks along the path resolve differently on either side.
+    static func cmuxPathCandidates(_ cwd: String) -> [String] {
+        var candidates = [cwd]
+        let resolved = URL(fileURLWithPath: cwd).resolvingSymlinksInPath().path
+        if resolved != cwd { candidates.append(resolved) }
+        for path in [cwd, resolved] {
+            if path.hasPrefix("/private/") {
+                candidates.append(String(path.dropFirst("/private".count)))
+            } else {
+                candidates.append("/private" + path)
+            }
+        }
+        var seen = Set<String>()
+        return candidates.filter { seen.insert($0).inserted }
+    }
+
+    /// An AppleScript string literal's two dangerous characters, escaped.
+    static func appleScriptEscaped(_ value: String) -> String {
+        value.replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
+    }
+
+    // MARK: - Running the tools
+
+    /// A short subprocess with its stdout collected concurrently, so a large
+    /// reply cannot fill the pipe and wedge the writer. Nil on any failure.
+    static func run(_ launchPath: String, _ arguments: [String],
+                    timeout: TimeInterval = 3) -> String? {
+        let process = Process()
+        let pipe = Pipe()
+        let errorPipe = Pipe()
+        process.executableURL = URL(fileURLWithPath: launchPath)
+        process.arguments = arguments
+        process.standardOutput = pipe
+        process.standardError = errorPipe
+        do {
+            try process.run()
+        } catch {
+            Log.sessions.notice("tab focus: cannot launch \(launchPath, privacy: .public): \(error.localizedDescription, privacy: .public)")
+            return nil
+        }
+
+        let collected = Mutex(Data())
+        let drained = DispatchSemaphore(value: 0)
+        DispatchQueue.global().async {
+            collected.withLock { $0 = pipe.fileHandleForReading.readDataToEndOfFile() }
+            drained.signal()
+        }
+        let deadline = Date().addingTimeInterval(timeout)
+        while process.isRunning && Date() < deadline {
+            Thread.sleep(forTimeInterval: 0.01)
+        }
+        if process.isRunning {
+            process.terminate()
+            return nil
+        }
+        // Process exit and pipe drainage are not the same event: a fast
+        // command is often reaped while the reader thread is still unscheduled,
+        // and reading before it lands parses an empty string as "no match".
+        _ = drained.wait(timeout: .now() + 1)
+        guard process.terminationStatus == 0 else {
+            let stderr = String(data: errorPipe.fileHandleForReading.readDataToEndOfFile(),
+                                encoding: .utf8) ?? ""
+            Log.sessions.notice("tab focus: \(arguments.first ?? "", privacy: .public) exited \(process.terminationStatus, privacy: .public): \(stderr.prefix(300), privacy: .public)")
+            return nil
+        }
+        return collected.withLock { String(data: $0, encoding: .utf8) }
+    }
+
+    private static func runOsascript(_ script: String) -> Bool {
+        run("/usr/bin/osascript", ["-e", script]).map { $0.contains("found") } ?? false
+    }
+
+    /// `NSLock` boxed for the reader thread's hand-off.
+    private final class Mutex<Value>: @unchecked Sendable {
+        private var value: Value
+        private let lock = NSLock()
+        init(_ value: Value) { self.value = value }
+        func withLock<T>(_ body: (inout Value) -> T) -> T {
+            lock.lock()
+            defer { lock.unlock() }
+            return body(&value)
+        }
+    }
+}

--- a/Sources/Settings/SettingsView.swift
+++ b/Sources/Settings/SettingsView.swift
@@ -942,7 +942,7 @@ struct SettingsView: View {
     /// this, sees four blank rings and concludes it is broken — and the
     /// distinction that catches them out is Claude *Code*, not the Claude app.
     static var setupCopy: String {
-        L10n.t("Codenotch reads usage from tools already signed in on this Mac — it never asks for your password. Install and sign in to any of Claude Code (the terminal tool, not the Claude app), Cursor (the editor or cursor-agent), Codex, Antigravity, GLM, Grok, OpenCode, Command Code, GitHub Copilot or a Gemini API key (via Gemini CLI, OpenCode or Hermes), and its ring appears in the notch.")
+        L10n.t("Codenotch reads usage from tools already signed in on this Mac — it never asks for your password. Install and sign in to any of Claude Code (the terminal tool, not the Claude app), Cursor (the editor or cursor-agent), Codex, Antigravity, GLM, Grok, OpenCode, Command Code, GitHub Copilot, Kimi Code or a Gemini API key (via Gemini CLI, OpenCode or Hermes), and its ring appears in the notch.")
     }
 
     /// Said before it happens rather than after. A system dialogue asking to

--- a/Tests/KimiActivityTests.swift
+++ b/Tests/KimiActivityTests.swift
@@ -1,0 +1,180 @@
+import XCTest
+@testable import Codenotch
+
+/// The wire state machine: turn records are top-level lines with millisecond
+/// `time`, approval records may arrive wrapped in a loop-event envelope, and
+/// subagent records never speak for the session.
+final class KimiTurnTests: XCTestCase {
+    private func tail(_ lines: [String]) -> Data {
+        Data(lines.joined(separator: "\n").utf8)
+    }
+
+    func testAPromptIsBusy() {
+        let turn = KimiActivity.turn(inTail: tail([
+            #"{"type":"turn.prompt","agentId":"main","promptId":"msg_1","time":1789140953652}"#,
+        ]))
+        guard case .busy(let at) = turn, let since = at else {
+            return XCTFail("expected busy, got \(String(describing: turn))")
+        }
+        XCTAssertEqual(since.timeIntervalSince1970, 1789140953.652, accuracy: 0.001)
+    }
+
+    /// A long turn fills the tail with tool chatter, pushing its own
+    /// `turn.prompt` out of the window — loop records still mean busy.
+    func testLoopActivityWithoutThePromptIsStillBusy() {
+        let turn = KimiActivity.turn(inTail: tail([
+            #"{"type":"context.append_loop_event","agentId":"main","event":{"type":"tool.result","toolCallId":"t1"}}"#,
+            #"{"type":"context.append_loop_event","agentId":"main","event":{"type":"tool.call","name":"Bash"}}"#,
+        ]))
+        guard case .busy = turn else { return XCTFail("expected busy, got \(String(describing: turn))") }
+    }
+
+    /// Post-turn bookkeeping is not loop activity — after `turn.ended` the
+    /// session is finished even with usage records trailing it.
+    func testBookkeepingAfterTheTurnIsFinished() {
+        let turn = KimiActivity.turn(inTail: tail([
+            #"{"type":"turn.ended","agentId":"main","reason":"completed","time":1789140953652}"#,
+            #"{"type":"usage.record","agentId":"main"}"#,
+            #"{"type":"token_counting.turn_recorded","agentId":"main"}"#,
+        ]))
+        guard case .finished = turn else { return XCTFail("expected finished, got \(String(describing: turn))") }
+    }
+
+    func testAnEndedTurnIsFinished() {
+        let turn = KimiActivity.turn(inTail: tail([
+            #"{"type":"turn.prompt","agentId":"main","time":1789140953000}"#,
+            #"{"type":"turn.ended","agentId":"main","reason":"completed","time":1789140953652}"#,
+        ]))
+        guard case .finished = turn else { return XCTFail("expected finished, got \(String(describing: turn))") }
+    }
+
+    func testAnOpenApprovalIsWaiting() {
+        let turn = KimiActivity.turn(inTail: tail([
+            #"{"type":"turn.prompt","agentId":"main","time":1789140953000}"#,
+            #"{"type":"approval.requested","agentId":"main","tool":"Bash","time":1789140954000}"#,
+        ]))
+        guard case .waiting(_, let what) = turn else { return XCTFail("expected waiting, got \(String(describing: turn))") }
+        XCTAssertEqual(what, "Bash")
+    }
+
+    /// Wrapped approval records are read through the envelope, and a resolved
+    /// one hands the turn back to whatever came before it.
+    func testAResolvedWrappedApprovalIsBusyAgain() {
+        let turn = KimiActivity.turn(inTail: tail([
+            #"{"type":"turn.prompt","agentId":"main","time":1789140953000}"#,
+            #"{"type":"context.append_loop_event","agentId":"main","event":{"type":"approval.requested","tool":"Bash","time":1789140954000}}"#,
+            #"{"type":"context.append_loop_event","agentId":"main","event":{"type":"approval.resolved","time":1789140955000}}"#,
+        ]))
+        guard case .busy = turn else { return XCTFail("expected busy, got \(String(describing: turn))") }
+    }
+
+    func testASubagentRecordIsNotTheSessionsTurn() {
+        let turn = KimiActivity.turn(inTail: tail([
+            #"{"type":"turn.ended","agentId":"main","time":1789140953000}"#,
+            #"{"type":"turn.prompt","agentId":"agent-0","time":1789140954000}"#,
+        ]))
+        guard case .finished = turn else { return XCTFail("expected finished, got \(String(describing: turn))") }
+    }
+
+    func testUnrelatedRecordsAndBrokenLinesAreSkipped() {
+        let turn = KimiActivity.turn(inTail: tail([
+            #"{"type":"turn.prompt","agentId":"main","time":1789140953000}"#,
+            "not json at all",
+            #"{"type":"tool.call","agentId":"main","name":"Bash"}"#,
+            #"{"type":"usage.record","agentId":"main"}"#,
+        ]))
+        guard case .busy = turn else { return XCTFail("expected busy, got \(String(describing: turn))") }
+    }
+
+    func testAnEmptyWireHasNoTurn() {
+        XCTAssertNil(KimiActivity.turn(inTail: Data()))
+    }
+}
+
+/// Session assembly: a live pid plus a wire fixture, with time injected.
+final class KimiActivitySessionTests: XCTestCase {
+    private var directory: URL!
+
+    override func setUpWithError() throws {
+        directory = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("kimi-activity-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(
+            at: directory.appendingPathComponent("agents/main"),
+            withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: directory)
+    }
+
+    private func wire(_ lines: [String], modified: Date) throws -> URL {
+        let url = directory.appendingPathComponent("agents/main/wire.jsonl")
+        try lines.joined(separator: "\n").write(to: url, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.modificationDate: modified], ofItemAtPath: url.path)
+        return url
+    }
+
+    private func session(now: Date, staleAfter: TimeInterval = 90) -> AgentSession? {
+        KimiActivity.session(sessionDir: directory, pid: getpid(), startedAt: nil,
+                             workDir: "/tmp/some-project", staleAfter: staleAfter, now: now)
+    }
+
+    func testATurnInFlightIsBusy() throws {
+        let now = Date()
+        _ = try wire([#"{"type":"turn.prompt","agentId":"main","time":\#(Int(now.timeIntervalSince1970 * 1000))}"#],
+                     modified: now)
+        let session = try XCTUnwrap(session(now: now))
+        XCTAssertEqual(session.state, .busy)
+        XCTAssertEqual(session.id, "kimi.\(directory.lastPathComponent)")
+        XCTAssertEqual(session.name, "tmp/some-project")
+        /// The second line names where the CLI runs — the app SessionFocus
+        /// would jump to — the way Claude's rows name the surface.
+        XCTAssertEqual(session.detail,
+                       SessionFocus.owningApp(of: getpid())?.localizedName ?? "Terminal")
+        XCTAssertEqual(session.processID, getpid())
+    }
+
+    /// A turn whose wire has not moved in longer than the stale window is a
+    /// stalled CLI, not work in progress.
+    func testAStaleTurnIsIdle() throws {
+        let now = Date()
+        _ = try wire([#"{"type":"turn.prompt","agentId":"main","time":1}"#],
+                     modified: now.addingTimeInterval(-300))
+        XCTAssertEqual(session(now: now)?.state, .idle)
+    }
+
+    func testAJustEndedTurnIsSuccessThenIdle() throws {
+        let now = Date()
+        let ended = Int(now.addingTimeInterval(-5).timeIntervalSince1970 * 1000)
+        _ = try wire([#"{"type":"turn.ended","agentId":"main","reason":"completed","time":\#(ended)}"#],
+                     modified: now.addingTimeInterval(-5))
+        XCTAssertEqual(session(now: now)?.state, .success)
+        XCTAssertEqual(session(now: now.addingTimeInterval(60))?.state, .idle)
+    }
+
+    /// An approval holds however long it takes — no staleness ladder.
+    func testAWaitingApprovalDoesNotGoStale() throws {
+        let now = Date()
+        _ = try wire([#"{"type":"approval.requested","agentId":"main","tool":"Bash","time":1}"#],
+                     modified: now.addingTimeInterval(-3600))
+        let session = try XCTUnwrap(session(now: now))
+        XCTAssertEqual(session.state, .waiting)
+        XCTAssertEqual(session.waitingFor, "Bash")
+    }
+
+    func testADeadPidIsNoSession() throws {
+        let now = Date()
+        _ = try wire([#"{"type":"turn.prompt","agentId":"main","time":1}"#], modified: now)
+        let dead = KimiActivity.session(sessionDir: directory, pid: 16_777_000, startedAt: nil,
+                                        workDir: "/tmp/some-project", staleAfter: 90, now: now)
+        XCTAssertNil(dead)
+    }
+
+    /// The monitor's own cwd lookup, checked against the process it runs in.
+    func testReadsAProcessWorkingDirectory() {
+        let cwd = SessionFocus.currentDirectory(of: getpid())
+        XCTAssertEqual(cwd?.hasPrefix("/"), true)
+        XCTAssertEqual(URL(fileURLWithPath: cwd ?? "").lastPathComponent,
+                       URL(fileURLWithPath: FileManager.default.currentDirectoryPath).lastPathComponent)
+    }
+}

--- a/Tests/KimiUsageTests.swift
+++ b/Tests/KimiUsageTests.swift
@@ -1,0 +1,137 @@
+import XCTest
+@testable import Codenotch
+
+/// The managed account's windows, pinned to the live response (user id
+/// redacted) — the same figures the CLI's `/usage` leads with.
+final class KimiUsageTests: XCTestCase {
+    /// Verbatim from `GET /coding/v1/usages`, 2026-09-11.
+    private let payload = """
+    {"user":{"userId":"…","region":"REGION_OVERSEA","membership":{"level":"LEVEL_ADVANCED"}},\
+    "usage":{"limit":"100","used":"2","remaining":"98","resetTime":"2026-09-15T19:39:34.389610Z"},\
+    "limits":[{"window":{"duration":300,"timeUnit":"TIME_UNIT_MINUTE"},\
+    "detail":{"limit":"100","used":"8","remaining":"92","resetTime":"2026-09-11T16:39:34.389610Z"}}],\
+    "parallel":{"limit":"30"}}
+    """
+
+    func testReadsTheWeeklySummaryAndTheFiveHourWindow() throws {
+        let read = try KimiUsage.read(fromJSON: payload)
+        XCTAssertEqual(read.windows.map(\.id), ["weekly", "rolling"])
+        XCTAssertEqual(read.windows.map(\.label), ["Weekly limit", "5h limit"])
+        XCTAssertEqual(read.windows.map(\.duration), [604800, 18000])
+        let fractions = read.windows.compactMap(\.usedFraction)
+        XCTAssertEqual(fractions, [0.02, 0.08], accuracy: 0.0001)
+    }
+
+    /// Counts arrive as decimal strings, and the 5-hour window ships as 300
+    /// minutes — normalised to hours, as the CLI does.
+    func testStringCountsAndAMinuteWindowAreUnderstood() throws {
+        let read = try KimiUsage.read(fromJSON: payload)
+        let rolling = try XCTUnwrap(read.windows.first { $0.id == "rolling" })
+        XCTAssertEqual(rolling.usedFraction ?? -1, 0.08, accuracy: 0.0001)
+        XCTAssertEqual(rolling.duration, 5 * 3600)
+    }
+
+    /// The reset carries microseconds, which the plain ISO8601 formatter
+    /// refuses — reading only that form silently loses every reset time.
+    func testReadsAFractionalResetTime() throws {
+        let read = try KimiUsage.read(fromJSON: payload)
+        let weekly = try XCTUnwrap(read.windows.first { $0.id == "weekly" })
+        let at = try XCTUnwrap(weekly.resetsAt)
+        let plain = ISO8601DateFormatter().date(from: "2026-09-15T19:39:34Z")!
+        XCTAssertEqual(at.timeIntervalSince1970, plain.timeIntervalSince1970, accuracy: 1)
+    }
+
+    func testReadsTheMembershipTierAsThePlan() throws {
+        let read = try KimiUsage.read(fromJSON: payload)
+        XCTAssertEqual(read.plan, "Advanced")
+    }
+
+    /// A window whose unit Codenotch cannot name is dropped rather than
+    /// mislabelled; the weekly summary carries no window of its own and is a
+    /// week by the CLI's own assumption.
+    func testAnUnnamedWindowIsDroppedNotInvented() throws {
+        let json = """
+        {"usage":{"limit":"100","used":"2"},\
+        "limits":[{"window":{"duration":1,"timeUnit":"TIME_UNIT_DAY"},\
+        "detail":{"limit":"10","used":"1"}}]}
+        """
+        let read = try KimiUsage.read(fromJSON: json)
+        XCTAssertEqual(read.windows.map(\.id), ["weekly"])
+        XCTAssertEqual(read.windows[0].duration, 604800)
+    }
+
+    /// An account that meters nothing — no summary, no limits — is not a
+    /// reading, and it must not be shown as one.
+    func testAnEmptyPayloadIsNothingMetered() {
+        for json in ["{}", #"{"usage":{},"limits":[]}"#] {
+            XCTAssertThrowsError(try KimiUsage.read(fromJSON: json)) { error in
+                guard case UsageProviderError.nothingMetered = error else {
+                    return XCTFail("expected nothingMetered, got \(error)")
+                }
+            }
+        }
+    }
+
+    func testGarbageIsABadResponse() {
+        XCTAssertThrowsError(try KimiUsage.read(fromJSON: "not json")) { error in
+            guard case UsageProviderError.badResponse = error else {
+                return XCTFail("expected badResponse, got \(error)")
+            }
+        }
+    }
+}
+
+/// The token is borrowed from the CLI's own sign-in, and `expires_at` is
+/// epoch seconds — a file without one is not a session to trust.
+final class KimiCredentialsTests: XCTestCase {
+    private func file(_ text: String) throws -> URL {
+        let url = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("kimi-credentials-\(UUID().uuidString).json")
+        try text.write(to: url, atomically: true, encoding: .utf8)
+        return url
+    }
+
+    func testReadsTheTokenAndItsExpiry() throws {
+        let url = try file(#"{"access_token":"k-live","refresh_token":"r","expires_at":1789139960,"token_type":"Bearer"}"#)
+        defer { try? FileManager.default.removeItem(at: url) }
+        let credentials = try KimiCredentials.load(from: url)
+        XCTAssertEqual(credentials.accessToken, "k-live")
+        XCTAssertEqual(credentials.expiresAt.timeIntervalSince1970, 1789139960, accuracy: 0.5)
+    }
+
+    func testAMissingFileIsNeedsAuth() {
+        XCTAssertThrowsError(try KimiCredentials.load(
+            from: URL(fileURLWithPath: NSTemporaryDirectory())
+                .appendingPathComponent("kimi-no-such-file.json"))) { error in
+            guard case UsageProviderError.needsAuth = error else {
+                return XCTFail("expected needsAuth, got \(error)")
+            }
+        }
+    }
+
+    func testAnEmptyTokenIsMissing() throws {
+        let url = try file(#"{"access_token":"","expires_at":1789139960}"#)
+        defer { try? FileManager.default.removeItem(at: url) }
+        XCTAssertThrowsError(try KimiCredentials.load(from: url)) { error in
+            guard case UsageProviderError.needsAuth = error else {
+                return XCTFail("expected needsAuth, got \(error)")
+            }
+        }
+    }
+
+    func testAMissingExpiryIsNotTrusted() throws {
+        let url = try file(#"{"access_token":"k-live"}"#)
+        defer { try? FileManager.default.removeItem(at: url) }
+        XCTAssertThrowsError(try KimiCredentials.load(from: url)) { error in
+            guard case UsageProviderError.needsAuth = error else {
+                return XCTFail("expected needsAuth, got \(error)")
+            }
+        }
+    }
+
+    func testAnExpiredTokenReportsExpired() throws {
+        let url = try file(#"{"access_token":"k-live","expires_at":1}"#)
+        defer { try? FileManager.default.removeItem(at: url) }
+        XCTAssertTrue(try KimiCredentials.load(from: url).isExpired)
+    }
+}

--- a/Tests/TerminalTabFocusTests.swift
+++ b/Tests/TerminalTabFocusTests.swift
@@ -1,0 +1,58 @@
+import XCTest
+@testable import Codenotch
+
+/// Path normalisation and AppleScript escaping behind exact-tab focus.
+final class TerminalTabFocusTests: XCTestCase {
+    /// The kernel can report `/private/tmp/…` where the terminal's own title
+    /// says `/tmp/…` — both spellings have to be tried.
+    func testPathCandidatesCoverThePrivatePrefix() {
+        let fromPrivate = TerminalTabFocus.cmuxPathCandidates("/private/tmp/x")
+        XCTAssertTrue(fromPrivate.contains("/tmp/x"))
+        let plain = TerminalTabFocus.cmuxPathCandidates("/tmp/x")
+        XCTAssertTrue(plain.contains("/private/tmp/x"))
+    }
+
+    func testPathCandidatesAreUniqueAndStartWithTheOriginal() {
+        let candidates = TerminalTabFocus.cmuxPathCandidates("/tmp/x")
+        XCTAssertEqual(candidates.first, "/tmp/x")
+        XCTAssertEqual(Set(candidates).count, candidates.count)
+    }
+
+    /// A quote or backslash in a folder name must not break the script.
+    func testAppleScriptEscaping() {
+        XCTAssertEqual(TerminalTabFocus.appleScriptEscaped(#"a\b "q""#), #"a\\b \"q\""#)
+    }
+
+    func testAnUnsupportedTerminalIsNotSelected() {
+        XCTAssertFalse(TerminalTabFocus.selectTab(bundleID: "dev.warp.Warp-Stable",
+                                                  pid: getpid(), tty: "ttys014", cwd: "/tmp"))
+        XCTAssertFalse(TerminalTabFocus.selectTab(bundleID: nil,
+                                                  pid: getpid(), tty: "ttys014", cwd: "/tmp"))
+    }
+
+    func testNoSurfaceAndNoCwdMeansNoCmuxTab() {
+        // A pid whose tree carries no CMUX_SURFACE_ID and no fallback cwd.
+        XCTAssertFalse(TerminalTabFocus.selectTab(bundleID: "com.cmuxterm.app",
+                                                  pid: 1, tty: nil, cwd: nil))
+    }
+
+    /// The runner's own environment block is readable and NUL-parsed.
+    func testReadsAProcessEnvironment() {
+        let entries = TerminalTabFocus.environment(of: getpid())
+        XCTAssertFalse(entries.isEmpty)
+        XCTAssertTrue(entries.contains { $0.hasPrefix("PATH=") })
+    }
+
+    /// The test runner's own tty and cwd, when they exist, read like ps
+    /// prints them.
+    func testReadsTheControllingTerminalName() {
+        if let tty = SessionFocus.tty(of: getpid()) {
+            XCTAssertTrue(tty.hasPrefix("ttys"), "unexpected tty name \(tty)")
+        }
+    }
+
+    func testReadsAProcessWorkingDirectory() {
+        let cwd = SessionFocus.currentDirectory(of: getpid())
+        XCTAssertEqual(cwd?.hasPrefix("/"), true)
+    }
+}


### PR DESCRIPTION
## Summary

Adds **Kimi** (Kimi Code CLI) as a provider — usage rings for the 5-hour rate window and weekly quota, plus live session tracking — and makes **every session row in the tooltip clickable**, jumping to the *exact terminal tab* the session runs in, not just the app.

## Changes

**Add Kimi usage rings** (`Sources/Providers/Kimi*.swift`)
- Reads the CLI's own OAuth session from `~/.kimi-code/credentials/kimi-code.json` (`KIMI_CODE_HOME` honoured) and queries the same `/usages` endpoint the CLI's `/usage` leads with.
- Headline ring = rolling 5-hour rate window; second ring = weekly quota; membership level shown as the plan. Read-only, same bargain as Grok: the 15-minute token is the CLI's to refresh, so an expired one reports `credentialExpired` rather than racing the CLI for the file.
- Defined geometric-K glyph (same approach as GLM's Z), README row, setup copy.

**Follow running Kimi Code sessions** (`Sources/Sessions/KimiActivityMonitor.swift`)
- Kimi writes no live-session registry, so discovery finds `kimi-code` processes and matches each one's cwd to `session_index.jsonl`; state comes from the session's `wire.jsonl` (turn boundaries and `approval.requested`/`resolved` with ms timestamps): busy / waiting / success / idle, with loop records counting as busy so a long turn's own `turn.prompt` scrolling out of the tail doesn't misreport.
- The pid goes into the session, so rows can be jumped to; the second line names the owning app, the way Claude's rows name the surface.

**Jump to a session's exact terminal tab on click** (`TerminalTabFocus.swift`, `SessionFocus.swift`, tooltip/notch wiring)
- Session rows are clickable for any provider whose sessions carry a pid (Kimi, Claude, Grok).
- **cmux**: selects the exact surface found by the `CMUX_SURFACE_ID` the session's own process tree carries in its environment — its socket CLI refuses clients that aren't inside a cmux terminal session (manaflow-ai/cmux#3089), so the AppleScript interface answers instead, with working-directory matching as fallback. **Terminal.app / iTerm2**: tab matched by tty. Everything else keeps the plain app raise.
- The completion-peek click uses the same jump. Claude sessions whose state comes from the transcript now keep their pid, so those rows are clickable at all. Card clicks no longer fall through to the pin toggle.

## Impact

Before: hovering showed sessions but clicking did nothing; the peek click raised only the app. After: one click lands you in the exact tab (verified on cmux with multiple same-directory Claude sessions, which cwd matching alone could not tell apart). AppleScript terminals ask for a one-time Automation consent; cmux needs none beyond that.

## Verification

- New tests: `Tests/KimiUsageTests.swift`, `Tests/KimiActivityTests.swift`, `Tests/TerminalTabFocusTests.swift` (pinned live-recorded payloads; wire state machine; env/tty/path parsing).
- Verified end-to-end on a live machine: real fetch against a signed-in Kimi account, session state tracking, and repeated exact-tab jumps (including same-cwd disambiguation via `CMUX_SURFACE_ID`).
- Note: this machine has no full Xcode, so `make test` could not be run here; the suites above were mirrored in a compiled harness (43/43 pass) and the app module typechecks clean. CI should confirm.

## Checklist
- [x] Self-reviewed
- [x] Manual testing performed
- [x] Documentation updated (README provider table)
- [x] No breaking changes
