### PR TITLE
Add a Models pane for choosing what the notch shows

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,12 +71,20 @@ Most providers borrow a credential or session from a tool already on your Mac.
 DeepSeek is the explicit browser-login exception: it never reads a browser's
 cookies or credentials, and only makes requests after you choose **Sign in to
 DeepSeek** from Codenotch.
-Ollama Cloud accepts an API key in Settings. Switching a provider off stops its
-usage polling and forgets its readings; borrowed accounts stay signed in to
-the tools that own them.
+Ollama Cloud accepts an API key in Settings. Disconnecting a provider in
+**Settings → Accounts** stops its usage polling and forgets its readings;
+borrowed accounts stay signed in to the tools that own them.
+
+**Settings → Models** lets you show or hide assistants and loaded Ollama or
+LM Studio model cells to keep the notch focused. These choices are remembered
+across launches. Hidden items keep their connections, monitoring and readings.
+Each local runtime also has a switch for all of its model cells; switching it
+off preserves the individual model choices for when you show it again. Hiding
+a model does not unload it from Ollama or LM Studio.
 
 **Local Ollama is detected automatically.** Configure its address or stop monitoring in **Settings → Ollama**.
-Each loaded model gets a notch cell; reorder or hide it in **Settings → Accounts**.
+Each loaded model gets a notch cell; hide or show it in **Settings → Models**
+and reorder visible cells in **Settings → Accounts**.
 Hover for RAM/VRAM, unload time, context limit and quantization.
 
 For generation speed (**tok/s**) and live **Thinking**, enable **Measure speed and thinking**
@@ -108,11 +116,10 @@ set to require an API token, paste one in Settings → LM Studio (or export `LM_
 one, requests are sent with no Authorization header at all.
 See [LM Studio details](docs/plans/2026-09-10-lm-studio-provider-plan.md).
 
-Settings lists the connected providers in the order the notch draws them, and
-you can drag one by its handle to move it. The order is remembered across
-launches. A provider you switch back on joins the end of that list rather than
-reclaiming an older position, so nothing you cannot currently see jumps ahead
-of something you placed deliberately.
+**Settings → Accounts** manages connections and lists the connected providers;
+drag a visible item by its handle to change the notch order. The order is
+remembered across launches. Hiding and showing an item in Models preserves its
+position. Reconnecting a provider in Accounts adds it to the end of the notch.
 
 It also answers **"is it still working?"** — a thin arc spins inside a
 provider's ring while a session is busy, and becomes a pulsing amber ring when

--- a/Sources/App/AppDelegate.swift
+++ b/Sources/App/AppDelegate.swift
@@ -136,6 +136,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                        })]
                     + webProviders,
                 disconnected: preferences.disconnectedProviders,
+                hiddenNotchProviders: preferences.hiddenNotchProviders,
                 // Passed at construction, not left to the sink below, for the
                 // same reason `disconnected` is: the sink delivers a run loop
                 // turn later, so without this every launch draws the built-in
@@ -391,6 +392,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             preferences.$disconnectedProviders
                 .receive(on: RunLoop.main)
                 .sink { [weak store] in store?.disconnected = $0 }
+                .store(in: &cancellables)
+
+            preferences.$hiddenNotchProviders
+                .receive(on: RunLoop.main)
+                .sink { [weak store] in store?.hiddenNotchProviders = $0 }
                 .store(in: &cancellables)
 
             preferences.$ollamaEndpoint

--- a/Sources/Localizable.xcstrings
+++ b/Sources/Localizable.xcstrings
@@ -11476,6 +11476,383 @@
           }
         }
       }
+    },
+    "Models": {
+      "extractionState": "manual",
+      "localizations": {
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modèles"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "モデル"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modelos"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "模型"
+          }
+        }
+      }
+    },
+    "Choose which assistants and local models appear in the notch. Hidden items keep monitoring, and your choices are saved automatically.": {
+      "extractionState": "manual",
+      "localizations": {
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Choisissez les assistants et les modèles locaux qui apparaissent dans l'encoche. Les éléments masqués restent surveillés, et vos choix sont enregistrés automatiquement."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ノッチに表示するアシスタントとローカルモデルを選べます。非表示にした項目も監視は続き、選択は自動的に保存されます。"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Escolha quais assistentes e modelos locais aparecem no notch. Os itens ocultos continuam sendo monitorados, e suas escolhas são salvas automaticamente."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "选择哪些助手和本地模型出现在刘海里。隐藏的项目仍会继续监测，你的选择会自动保存。"
+          }
+        }
+      }
+    },
+    "Assistants": {
+      "extractionState": "manual",
+      "localizations": {
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Assistants"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アシスタント"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Assistentes"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "助手"
+          }
+        }
+      }
+    },
+    "Loaded models appear here automatically when runtime monitoring is enabled.": {
+      "extractionState": "manual",
+      "localizations": {
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Les modèles chargés apparaissent ici automatiquement lorsque la surveillance du runtime est activée."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ランタイムの監視がオンなら、読み込まれたモデルがここに自動で表示されます。"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Os modelos carregados aparecem aqui automaticamente quando o monitoramento do runtime está ativado."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "开启运行时监测后，已加载的模型会自动出现在这里。"
+          }
+        }
+      }
+    },
+    "No models available": {
+      "extractionState": "manual",
+      "localizations": {
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aucun modèle disponible"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "利用できるモデルがありません"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nenhum modelo disponível"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "没有可用的模型"
+          }
+        }
+      }
+    },
+    "Connect an assistant in Accounts or enable a local runtime to get started.": {
+      "extractionState": "manual",
+      "localizations": {
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connectez un assistant dans Comptes ou activez un runtime local pour commencer."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "まずはアカウントでアシスタントを接続するか、ローカルランタイムを有効にしてください。"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Conecte um assistente em Contas ou ative um runtime local para começar."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "先在账号里连接一个助手，或启用一个本地运行时。"
+          }
+        }
+      }
+    },
+    "Connect in Accounts to show this assistant.": {
+      "extractionState": "manual",
+      "localizations": {
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connectez-le dans Comptes pour afficher cet assistant."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "このアシスタントを表示するには、アカウントで接続してください。"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Conecte em Contas para mostrar este assistente."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在账号里连接后才能显示这个助手。"
+          }
+        }
+      }
+    },
+    "Enable monitoring in the runtime's settings to show its models.": {
+      "extractionState": "manual",
+      "localizations": {
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activez la surveillance dans les réglages du runtime pour afficher ses modèles."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "モデルを表示するには、ランタイムの設定で監視を有効にしてください。"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ative o monitoramento nos ajustes do runtime para mostrar seus modelos."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在该运行时的设置里开启监测，才能显示它的模型。"
+          }
+        }
+      }
+    },
+    "Show loaded models. Individual choices are kept when this is off.": {
+      "extractionState": "manual",
+      "localizations": {
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Afficher les modèles chargés. Les choix individuels sont conservés lorsque ceci est désactivé."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "読み込まれたモデルを表示します。オフにしても個別の設定は保持されます。"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mostrar os modelos carregados. As escolhas individuais são mantidas quando esta opção está desativada."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "显示已加载的模型。关闭后，单个模型的选择仍会保留。"
+          }
+        }
+      }
+    },
+    "Show or hide this item in the notch without changing its connection.": {
+      "extractionState": "manual",
+      "localizations": {
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Afficher ou masquer cet élément dans l'encoche sans modifier sa connexion."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "接続はそのままに、この項目をノッチで表示/非表示にします。"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mostrar ou ocultar este item no notch sem alterar sua conexão."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在刘海里显示或隐藏这一项，不改变它的连接。"
+          }
+        }
+      }
+    },
+    "Drag visible items by their handles to reorder the notch. Choose which items appear in Models.": {
+      "extractionState": "manual",
+      "localizations": {
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Faites glisser les éléments visibles par leur poignée pour réordonner l'encoche. Choisissez les éléments affichés dans Modèles."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "表示中の項目はハンドルをドラッグしてノッチの順番を変えられます。表示する項目はモデルで選べます。"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Arraste os itens visíveis pelas alças para reordenar o notch. Escolha quais itens aparecem em Modelos."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "拖动可见项目的手柄即可改刘海的顺序。在模型里选择显示哪些项目。"
+          }
+        }
+      }
+    },
+    "Hidden from the notch. Show it again in Models.": {
+      "extractionState": "manual",
+      "localizations": {
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Masqué de l'encoche. Réaffichez-le dans Modèles."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ノッチでは非表示です。モデルで再表示できます。"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Oculto no notch. Mostre-o novamente em Modelos."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已从刘海隐藏。可在模型里重新显示。"
+          }
+        }
+      }
+    },
+    "Choose whether this item appears in Models.": {
+      "extractionState": "manual",
+      "localizations": {
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Choisissez dans Modèles si cet élément apparaît."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "この項目を表示するかはモデルで選べます。"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Escolha em Modelos se este item aparece."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在模型里选择这一项是否显示。"
+          }
+        }
+      }
     }
   },
   "version": "1.0"

--- a/Sources/Model/UsageStore.swift
+++ b/Sources/Model/UsageStore.swift
@@ -11,6 +11,9 @@ final class UsageStore: ObservableObject {
     }
     /// Settings and every display share the same ordered, visible model cells.
     @Published private(set) var notchSnapshots: [ProviderSnapshot] = []
+    /// Keep discovered cells in their existing order while some are hidden.
+    /// Re-enabling a model should restore its place without a fresh poll.
+    private var notchCells: [ProviderSnapshot] = []
     /// Providers with a fetch in flight, so the cell can show it happening.
     @Published private(set) var refreshing: Set<String> = []
     /// Providers whose last fetch was refused by macOS, cleared as soon as one
@@ -27,6 +30,15 @@ final class UsageStore: ObservableObject {
     @Published private(set) var needsRenewal: Set<String> = []
 
     private let providers: [UsageProvider]
+    /// Hiding is only a display projection; raw readings, archives and polling
+    /// continue unchanged. A runtime ID hides all of its model cells.
+    @Published var hiddenNotchProviders: Set<String> = [] {
+        didSet {
+            guard hiddenNotchProviders != oldValue else { return }
+            updateNotchSnapshots()
+        }
+    }
+
     /// Provider IDs block fetching before credential access. Model IDs only hide
     /// their cells so disabling one model does not stop the shared runtime.
     @Published var disconnected: Set<String> = [] {
@@ -145,6 +157,7 @@ final class UsageStore: ObservableObject {
         refreshDeadline: TimeInterval = 60,
         archive: UsageArchive = UsageArchive(),
         disconnected: Set<String> = [],
+        hiddenNotchProviders: Set<String> = [],
         order: [String] = [],
         pollingNow: @escaping () -> Date = Date.init
     ) {
@@ -165,6 +178,7 @@ final class UsageStore: ObservableObject {
         // `lastGood` is still empty, so it wrote an empty archive and destroyed
         // every remembered reading on any launch with a provider switched off.
         _disconnected = Published(initialValue: disconnected)
+        _hiddenNotchProviders = Published(initialValue: hiddenNotchProviders)
         _order = Published(initialValue: order)
         lastGood = archive.load()
         for provider in providers where provider.kind == .localRuntime {
@@ -195,14 +209,18 @@ final class UsageStore: ObservableObject {
     }
 
     private func updateNotchSnapshots() {
-        let cells = ProviderOrder.cells(from: snapshots, keeping: notchSnapshots)
-        notchSnapshots = ProviderOrder.arrange(cells, by: order, id: \.id)
-            .filter { !disconnected.contains($0.id) }
+        let cells = ProviderOrder.cells(from: snapshots, keeping: notchCells)
+        notchCells = ProviderOrder.arrange(cells, by: order, id: \.id)
+        notchSnapshots = notchCells.filter {
+            !disconnected.contains($0.id)
+                && !hiddenNotchProviders.contains($0.id)
+                && !hiddenNotchProviders.contains($0.providerID)
+        }
     }
 
     /// Model discovery does not need to re-read any cloud account's credential.
     var localModelSummaries: [ProviderSummary] {
-        ProviderOrder.cells(from: snapshots, keeping: notchSnapshots).compactMap { cell in
+        notchCells.compactMap { cell in
             guard let model = cell.localModel else { return nil }
             let runtime = providers.first { $0.id == cell.providerID }?.displayName ?? cell.displayName
             return ProviderSummary(kind: .localRuntime, localModel: model,

--- a/Sources/Settings/ModelsSettingsPane.swift
+++ b/Sources/Settings/ModelsSettingsPane.swift
@@ -1,0 +1,98 @@
+import SwiftUI
+
+/// Visibility is independent of account access: a quieter notch should not
+/// require signing in again or discarding a provider's last good reading.
+struct ModelsSettingsPane: View {
+    @ObservedObject var preferences: Preferences
+    let providers: [ProviderSummary]
+
+    private var assistants: [ProviderSummary] {
+        providers.filter { $0.kind == .usage }
+    }
+
+    private var runtimes: [ProviderSummary] {
+        providers.filter { $0.kind == .localRuntime && $0.localModel == nil }
+    }
+
+    var body: some View {
+        Form {
+            Section {
+                Text(L10n.t("Choose which assistants and local models appear in the notch. Hidden items keep monitoring, and your choices are saved automatically."))
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            if !assistants.isEmpty {
+                Section(L10n.t("Assistants")) {
+                    ForEach(assistants) { provider in
+                        ModelVisibilityRow(preferences: preferences, provider: provider)
+                    }
+                }
+            }
+
+            ForEach(runtimes) { runtime in
+                Section(runtime.name) {
+                    ModelVisibilityRow(preferences: preferences, provider: runtime)
+
+                    let models = providers.filter { $0.localModel != nil && $0.sourceProviderID == runtime.id }
+                    ForEach(models) { model in
+                        ModelVisibilityRow(preferences: preferences, provider: model)
+                            .padding(.leading, 24)
+                            .disabled(!preferences.isConnected(runtime.id) || !preferences.isShownInNotch(runtime.id))
+                    }
+                    if models.isEmpty {
+                        Text(L10n.t("Loaded models appear here automatically when runtime monitoring is enabled."))
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                }
+            }
+
+            if providers.isEmpty {
+                ContentUnavailableView(L10n.t("No models available"), systemImage: "square.stack.3d.up",
+                                       description: Text(L10n.t("Connect an assistant in Accounts or enable a local runtime to get started.")))
+            }
+        }
+        .formStyle(.grouped)
+    }
+}
+
+private struct ModelVisibilityRow: View {
+    @ObservedObject var preferences: Preferences
+    let provider: ProviderSummary
+
+    var body: some View {
+        Toggle(isOn: Binding(
+            get: { preferences.isShownInNotch(provider.id) },
+            set: { preferences.setShownInNotch($0, for: provider.id) }
+        )) {
+            HStack(spacing: 10) {
+                ProviderGlyphView(glyph: provider.glyph, size: 16)
+                    .foregroundStyle(preferences.isShownInNotch(provider.id) ? .primary : .secondary)
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(provider.name)
+                        .lineLimit(2)
+                    if provider.localModel == nil, !preferences.isConnected(provider.id) {
+                        Text(provider.kind == .usage
+                             ? L10n.t("Connect in Accounts to show this assistant.")
+                             : L10n.t("Enable monitoring in the runtime's settings to show its models."))
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .fixedSize(horizontal: false, vertical: true)
+                    } else if provider.localModel == nil, provider.kind == .localRuntime {
+                        Text(L10n.t("Show loaded models. Individual choices are kept when this is off."))
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                }
+            }
+        }
+        .toggleStyle(.switch)
+        .controlSize(.small)
+        .help(L10n.t("Show or hide this item in the notch without changing its connection."))
+        .accessibilityIdentifier("model-visibility-\(provider.id)")
+    }
+}

--- a/Sources/Settings/Preferences.swift
+++ b/Sources/Settings/Preferences.swift
@@ -13,6 +13,12 @@ final class Preferences: ObservableObject {
         didSet { defaults.set(Array(disconnectedProviders), forKey: Keys.disconnected) }
     }
 
+    /// Display choices are separate from connections: hidden providers keep
+    /// polling, and hidden local models keep running.
+    @Published var hiddenNotchProviders: Set<String> {
+        didSet { defaults.set(Array(hiddenNotchProviders), forKey: Keys.hiddenNotchProviders) }
+    }
+
     @Published var ollamaMetricsEnabled: Bool {
         didSet { defaults.set(ollamaMetricsEnabled, forKey: Keys.ollamaMetricsEnabled) }
     }
@@ -264,6 +270,7 @@ final class Preferences: ObservableObject {
     private enum Keys {
         /// The old name. Kept so existing choices survive the rename.
         static let disconnected = "hiddenProviders"
+        static let hiddenNotchProviders = "hiddenNotchProviders"
         static let ollamaEndpoint = "ollamaEndpoint"
         static let lmstudioEndpoint = "lmstudioEndpoint"
         static let introducedOllama = "introducedOllama"
@@ -386,6 +393,7 @@ final class Preferences: ObservableObject {
         }
         let disconnected = Set(defaults.stringArray(forKey: Keys.disconnected) ?? [])
         self.disconnectedProviders = disconnected
+        self.hiddenNotchProviders = Set(defaults.stringArray(forKey: Keys.hiddenNotchProviders) ?? [])
         self.ollamaMetricsEnabled = defaults.object(forKey: Keys.ollamaMetricsEnabled) as? Bool
             ?? (defaults.bool(forKey: Keys.introducedOllama)
                 && !disconnected.contains("ollama-local"))
@@ -499,6 +507,31 @@ final class Preferences: ObservableObject {
         } else {
             disconnectedProviders.insert(providerID)
         }
+    }
+
+    func isShownInNotch(_ providerID: String) -> Bool {
+        !hiddenNotchProviders.contains(providerID)
+            && !(Self.isLocalModelID(providerID) && disconnectedProviders.contains(providerID))
+    }
+
+    func setShownInNotch(_ shown: Bool, for providerID: String) {
+        if shown {
+            hiddenNotchProviders.remove(providerID)
+            // Earlier versions stored local model visibility with connection
+            // choices. Restore those cells without reconnecting any provider.
+            if Self.isLocalModelID(providerID) {
+                disconnectedProviders.remove(providerID)
+            }
+        } else {
+            hiddenNotchProviders.insert(providerID)
+        }
+    }
+
+    /// Matched on the shape every runtime builds its cells with
+    /// (`<runtime>:model:<model>`), not on a list of runtime names — the next
+    /// local runtime added should inherit this without touching Preferences.
+    private static func isLocalModelID(_ id: String) -> Bool {
+        id.contains(":model:")
     }
 
     /// Record a new order, keeping the ids that are not on this Mac today.

--- a/Sources/Settings/SettingsView.swift
+++ b/Sources/Settings/SettingsView.swift
@@ -26,13 +26,14 @@ extension View {
 /// crossing-and-notification machinery it switches is Notifications' to
 /// explain.
 private enum SettingsSection: String, CaseIterable, Identifiable, Hashable {
-    case accounts, ollama, lmstudio, appearance, notifications, general
+    case accounts, models, ollama, lmstudio, appearance, notifications, general
 
     var id: String { rawValue }
 
     var title: String {
         switch self {
         case .accounts:      return L10n.t("Accounts")
+        case .models:        return L10n.t("Models")
         case .ollama:        return "Ollama"   // a product name, the same in every language
         case .lmstudio:      return "LM Studio"
         case .appearance:    return L10n.t("Appearance")
@@ -44,6 +45,7 @@ private enum SettingsSection: String, CaseIterable, Identifiable, Hashable {
     var icon: String {
         switch self {
         case .accounts:      return "person.crop.circle.fill"
+        case .models:        return "square.stack.3d.up.fill"
         case .ollama:        return "desktopcomputer"
         case .lmstudio:      return "cpu"
         case .appearance:    return "paintbrush.fill"
@@ -58,6 +60,7 @@ private enum SettingsSection: String, CaseIterable, Identifiable, Hashable {
     var tint: Color {
         switch self {
         case .accounts:      return .blue
+        case .models:        return .green
         case .ollama:        return .teal
         case .lmstudio:      return .purple
         case .appearance:    return .indigo
@@ -417,6 +420,7 @@ struct SettingsView: View {
     private func paneContent(for section: SettingsSection) -> some View {
         switch section {
         case .accounts:      accountsPane
+        case .models:        ModelsSettingsPane(preferences: preferences, providers: accounts)
         case .ollama:
             if let usageStore {
                 Form {
@@ -453,7 +457,8 @@ struct SettingsView: View {
                                signOut: signOut, signIn: signIn,
                                switchAccount: switchAccount, retry: retry,
                                refresh: { usageStore?.reevaluate(providerID: $0) },
-                               isOrderable: true,
+                               isOrderable: preferences.isShownInNotch(account.id)
+                                   && preferences.isShownInNotch(account.sourceProviderID ?? account.id),
                                drag: drag,
                                cursorRefresh: cursorRefresh,
                                onDrop: { cursorRefresh += 1 },
@@ -466,7 +471,7 @@ struct SettingsView: View {
                         .foregroundStyle(.tertiary)
                         .fixedSize(horizontal: false, vertical: true)
                 } else if !connected.isEmpty {
-                    Text(L10n.t("The notch draws these in this order. Drag one by its handle to move it."))
+                    Text(L10n.t("Drag visible items by their handles to reorder the notch. Choose which items appear in Models."))
                         .font(.caption)
                         .foregroundStyle(.tertiary)
                         .fixedSize(horizontal: false, vertical: true)
@@ -922,11 +927,15 @@ struct SettingsView: View {
     }
 
     private var connected: [ProviderSummary] {
-        ringAccounts.filter { preferences.isConnected($0.id) }
+        ringAccounts.filter {
+            preferences.isConnected($0.id) && ($0.localModel == nil || preferences.isShownInNotch($0.id))
+        }
     }
 
     private var notConnected: [ProviderSummary] {
-        ringAccounts.filter { !preferences.isConnected($0.id) }
+        ringAccounts.filter {
+            !preferences.isConnected($0.id) || ($0.localModel != nil && !preferences.isShownInNotch($0.id))
+        }
     }
 
     /// Nothing to read from anywhere. On a first launch that is the normal
@@ -1179,8 +1188,15 @@ private struct AccountRow: View {
     /// quiet as it was before there was anything to drag.
     @State private var isHovering = false
 
-    private var isConnected: Bool { preferences.isConnected(provider.id) }
+    private var isConnected: Bool {
+        preferences.isConnected(provider.id)
+            && (provider.localModel == nil || preferences.isShownInNotch(provider.id))
+    }
     private var isMuted: Bool { preferences.isMutedAlerts(for: provider.id) }
+    private var isShownInNotch: Bool {
+        preferences.isShownInNotch(provider.id)
+            && preferences.isShownInNotch(provider.sourceProviderID ?? provider.id)
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 6) {
@@ -1230,7 +1246,7 @@ private struct AccountRow: View {
                 }
                 .help(isOrderable
                       ? L10n.t("Drag to reorder. The notch draws the rings in this order.")
-                      : L10n.t("Switch this on to give it a ring in the notch."))
+                      : L10n.t("Choose whether this item appears in Models."))
                 // Two mechanisms, neither of which covers both halves.
                 // `pointerStyle` draws the hand on an ordinary hover but cannot
                 // re-evaluate under a pointer that has not moved, which is the
@@ -1315,6 +1331,13 @@ private struct AccountRow: View {
             detail
                 .font(.caption)
                 .padding(.leading, 48)
+
+            if isConnected, !isShownInNotch {
+                Text(L10n.t("Hidden from the notch. Show it again in Models."))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .padding(.leading, 48)
+            }
 
             // Outside `detail` on purpose. That chain shows the account summary
             // whenever there is an account, and an aged-out token still has
@@ -1605,8 +1628,13 @@ private struct AccountRow: View {
     /// readings as well as stopping the next one.
     private var binding: Binding<Bool> {
         Binding(
-            get: { preferences.isConnected(provider.id) },
+            get: { isConnected },
             set: { wantsOn in
+                if provider.localModel != nil {
+                    preferences.setShownInNotch(wantsOn, for: provider.id)
+                    if wantsOn { didConnect() }
+                    return
+                }
                 if wantsOn {
                     preferences.setConnected(true, for: provider.id)
                     // After the switch, not before: where it belongs depends on

--- a/Tests/ModelVisibilityTests.swift
+++ b/Tests/ModelVisibilityTests.swift
@@ -1,0 +1,211 @@
+import XCTest
+@testable import Codenotch
+
+@MainActor
+final class ModelVisibilityTests: XCTestCase {
+    private func isolatedDefaults() -> UserDefaults {
+        let name = "ModelVisibilityTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: name)!
+        addTeardownBlock { defaults.removePersistentDomain(forName: name) }
+        return defaults
+    }
+
+    func testVisibilityPersistsIndependentlyOfConnectionsAndProfiles() {
+        let defaults = isolatedDefaults()
+        let preferences = Preferences(defaults: defaults)
+        preferences.setConnected(false, for: "codex-work")
+        preferences.setProviderOrder(["codex-work", "codex"])
+
+        XCTAssertTrue(preferences.isShownInNotch("codex"))
+        preferences.setShownInNotch(false, for: "codex")
+        XCTAssertTrue(preferences.isConnected("codex"))
+        XCTAssertTrue(preferences.isShownInNotch("codex-work"))
+
+        let restored = Preferences(defaults: defaults)
+        XCTAssertFalse(restored.isShownInNotch("codex"))
+        XCTAssertTrue(restored.isShownInNotch("codex-new-profile"))
+        XCTAssertEqual(restored.providerOrder, ["codex-work", "codex"])
+        restored.setShownInNotch(true, for: "codex-work")
+        XCTAssertFalse(restored.isConnected("codex-work"), "Showing a provider must not reconnect it")
+        restored.setShownInNotch(true, for: "codex")
+        XCTAssertTrue(Preferences(defaults: defaults).hiddenNotchProviders.isEmpty)
+    }
+
+    func testLegacyLocalModelChoicesCanBeRestoredWithoutReconnectingTheirRuntime() {
+        let defaults = isolatedDefaults()
+        // The third is a runtime that does not exist yet: visibility keys off the
+        // shared `<runtime>:model:<model>` shape, not a list of known runtimes.
+        let ids = ["ollama-local:model:qwen3:8b", "lmstudio:model:qwen3:8b", "mlx:model:phi-4"]
+        defaults.set(ids + ["ollama-local", "lmstudio", "codex"], forKey: "hiddenProviders")
+        let preferences = Preferences(defaults: defaults)
+
+        for id in ids {
+            XCTAssertFalse(preferences.isShownInNotch(id))
+            preferences.setShownInNotch(true, for: id)
+            XCTAssertTrue(preferences.isShownInNotch(id))
+        }
+        XCTAssertEqual(preferences.disconnectedProviders, ["ollama-local", "lmstudio", "codex"])
+        XCTAssertEqual(Preferences(defaults: defaults).disconnectedProviders, preferences.disconnectedProviders)
+
+        preferences.setShownInNotch(false, for: ids[0])
+        XCTAssertFalse(Preferences(defaults: defaults).isShownInNotch(ids[0]))
+        XCTAssertFalse(preferences.disconnectedProviders.contains(ids[0]))
+    }
+
+    func testHideAndShowImmediatelyPreserveReadingsArchivesAndOrder() async {
+        let first = VisibilityProvider(id: "codex"), second = VisibilityProvider(id: "codex-work")
+        let archive = UsageArchive(defaults: isolatedDefaults())
+        let store = UsageStore(providers: [first, second], archive: archive, order: [second.id, first.id])
+        await store.refresh()
+        let readings = store.snapshots
+        let remembered = archive.load()[first.id]
+
+        store.hiddenNotchProviders = [first.id]
+        XCTAssertEqual(store.notchSnapshots.map(\.id), [second.id])
+        XCTAssertEqual(store.snapshots, readings)
+        XCTAssertEqual(archive.load()[first.id]?.snapshot, remembered?.snapshot)
+        XCTAssertEqual(archive.load()[first.id]?.fetchedAt, remembered?.fetchedAt)
+        XCTAssertTrue(store.disconnected.isEmpty)
+        XCTAssertEqual(store.providerSummaries.map(\.id), [second.id, first.id])
+
+        store.hiddenNotchProviders = []
+        XCTAssertEqual(store.notchSnapshots.map(\.id), [second.id, first.id])
+        XCTAssertEqual(store.notchSnapshots, readings)
+        XCTAssertEqual(first.calls, 1)
+        XCTAssertEqual(second.calls, 1)
+    }
+
+    func testHiddenProviderLoadsItsArchiveAndContinuesToRefresh() async {
+        let defaults = isolatedDefaults()
+        let provider = VisibilityProvider(id: "codex")
+        let archive = UsageArchive(defaults: defaults)
+        let original = UsageStore(providers: [provider], archive: archive)
+        await original.refresh()
+        let preferences = Preferences(defaults: defaults)
+        preferences.setShownInNotch(false, for: provider.id)
+        let restored = Preferences(defaults: defaults)
+        let store = UsageStore(providers: [provider], archive: archive,
+                               hiddenNotchProviders: restored.hiddenNotchProviders)
+
+        XCTAssertTrue(store.notchSnapshots.isEmpty, "Hidden archived cells must not flash during launch")
+        XCTAssertTrue(store.snapshots.first?.hasReading == true)
+        XCTAssertNotNil(archive.load()[provider.id])
+        await store.refresh()
+        XCTAssertEqual(provider.calls, 2)
+        XCTAssertTrue(store.notchSnapshots.isEmpty)
+        XCTAssertEqual(archive.load()[provider.id]?.snapshot, store.snapshots.first)
+
+        store.hiddenNotchProviders = []
+        XCTAssertEqual(store.notchSnapshots, store.snapshots)
+        XCTAssertEqual(provider.calls, 2)
+    }
+
+    func testHidingAnInFlightProviderKeepsAndArchivesItsResult() async {
+        let provider = VisibilityProvider(id: "codex")
+        let started = expectation(description: "Provider request started")
+        provider.started = started
+        let archive = UsageArchive(defaults: isolatedDefaults())
+        let store = UsageStore(providers: [provider], archive: archive)
+        let refresh = Task { await store.refresh() }
+        await fulfillment(of: [started], timeout: 2)
+
+        store.hiddenNotchProviders = [provider.id]
+        XCTAssertTrue(store.refreshing.contains(provider.id))
+        provider.finish()
+        await refresh.value
+        XCTAssertTrue(store.notchSnapshots.isEmpty)
+        XCTAssertTrue(store.snapshots.first?.hasReading == true)
+        XCTAssertNotNil(archive.load()[provider.id])
+        XCTAssertTrue(store.refreshing.isEmpty)
+    }
+
+    func testLocalModelsAndRuntimesHideIndependentlyAndKeepDiscovery() async {
+        let ollama = VisibilityProvider(id: "ollama-local", kind: .localRuntime)
+        let studio = VisibilityProvider(id: "lmstudio", kind: .localRuntime)
+        ollama.models = [model("qwen3:8b"), model("llama3.1:8b")]
+        studio.models = [model("qwen3:8b")]
+        let store = UsageStore(providers: [ollama, studio], archive: UsageArchive(defaults: isolatedDefaults()))
+        await store.refresh()
+        let original = store.notchSnapshots.map(\.id)
+        let hidden = "ollama-local:model:qwen3:8b"
+
+        store.hiddenNotchProviders = [hidden]
+        XCTAssertEqual(store.notchSnapshots.map(\.id), ["ollama-local:model:llama3.1:8b", "lmstudio:model:qwen3:8b"])
+        XCTAssertEqual(store.localModelSummaries.map(\.id), original)
+        store.hiddenNotchProviders = []
+        XCTAssertEqual(store.notchSnapshots.map(\.id), original, "A restored model keeps its place")
+        XCTAssertEqual(ollama.calls, 1)
+        XCTAssertEqual(studio.calls, 1)
+
+        store.hiddenNotchProviders = [ollama.id, "lmstudio:model:qwen3:8b"]
+        XCTAssertTrue(store.notchSnapshots.isEmpty)
+        ollama.models.append(model("gemma3:4b"))
+        await store.refresh()
+        XCTAssertEqual(ollama.calls, 2)
+        XCTAssertEqual(studio.calls, 2)
+        XCTAssertTrue(store.notchSnapshots.isEmpty, "A hidden runtime also hides newly discovered models")
+        XCTAssertEqual(store.localModelSummaries.count, 4)
+        XCTAssertEqual(store.snapshots.first?.localRuntime?.models, ollama.models)
+        XCTAssertTrue(store.disconnected.isEmpty)
+
+        store.hiddenNotchProviders = [hidden]
+        XCTAssertEqual(store.notchSnapshots.map(\.id), ["ollama-local:model:llama3.1:8b", "ollama-local:model:gemma3:4b", "lmstudio:model:qwen3:8b"])
+        XCTAssertEqual(ollama.calls, 2)
+    }
+
+    func testEverythingCanBeHiddenAndRestoredWhileDisconnectedProvidersStayOff() async {
+        let enabled = VisibilityProvider(id: "codex"), disconnected = VisibilityProvider(id: "claude")
+        let store = UsageStore(providers: [enabled, disconnected], archive: UsageArchive(defaults: isolatedDefaults()),
+                               disconnected: [disconnected.id], hiddenNotchProviders: [enabled.id, disconnected.id])
+        await store.refresh()
+        XCTAssertTrue(store.notchSnapshots.isEmpty)
+        XCTAssertEqual(enabled.calls, 1)
+        XCTAssertEqual(disconnected.calls, 0)
+
+        store.hiddenNotchProviders = []
+        XCTAssertEqual(store.notchSnapshots.map(\.id), [enabled.id])
+        XCTAssertEqual(store.disconnected, [disconnected.id])
+        XCTAssertEqual(disconnected.calls, 0)
+    }
+
+    private func model(_ name: String) -> LocalRuntimeReading.Model {
+        .init(name: name, memoryBytes: nil, contextLength: nil, quantizationLevel: nil)
+    }
+}
+
+@MainActor
+private final class VisibilityProvider: UsageProvider {
+    nonisolated let id: String
+    nonisolated let kind: ProviderKind
+    nonisolated let displayName = "Test provider"
+    nonisolated let glyph = ProviderGlyph.claude
+    var calls = 0
+    var models: [LocalRuntimeReading.Model] = []
+    var started: XCTestExpectation?
+    private var continuation: CheckedContinuation<Void, Never>?
+
+    init(id: String, kind: ProviderKind = .usage) {
+        self.id = id
+        self.kind = kind
+    }
+
+    func fetchSnapshot() async throws -> ProviderSnapshot {
+        calls += 1
+        if let started {
+            await withCheckedContinuation {
+                continuation = $0
+                started.fulfill()
+            }
+        }
+        return ProviderSnapshot(id: id, displayName: displayName, glyph: glyph,
+                                fidelity: .official, status: .ok,
+                                windows: kind == .usage ? [LimitWindow(id: "session", label: "Session", usedFraction: 0.42)] : [],
+                                kind: kind, localRuntime: kind == .localRuntime ? LocalRuntimeReading(models: models) : nil)
+    }
+
+    func finish() {
+        started = nil
+        continuation?.resume()
+        continuation = nil
+    }
+}


### PR DESCRIPTION
## Why

The list of assistants Codenotch can read keeps growing, and today the only way
to take one out of the notch is to disconnect it in **Accounts** — which stops
its polling and forgets its last good reading. "I don't want to look at this
one" and "I don't want Codenotch reading this account" are different wishes,
and only the second one is currently expressible.

## What this adds

**Settings → Models**: one switch per assistant, and one switch per loaded
Ollama / LM Studio model grouped under its runtime. Each runtime also has a
switch for all of its cells at once; turning it off keeps the individual model
choices for when it comes back on.

Visibility is a display projection and nothing else. A hidden item keeps its
credential, its polling, its archived readings and its position in the order —
`UsageStore` now keeps the arranged cell list (`notchCells`) and filters it into
`notchSnapshots`, so showing something again restores its place without a fresh
poll. Hiding a model does not unload it from Ollama or LM Studio.

## Built to survive the next provider

Nothing in the pane is keyed to a provider name. It groups whatever
`providerSummaries` reports by `ProviderKind`, so an assistant added in a later
release appears in Models on its own, with no new case to write. The single
place that has to recognise a local model cell matches the shared
`<runtime>:model:<model>` id shape that `UsageModel` and `LMStudioMetrics`
already build, rather than a list of known runtimes — adding the next local
runtime touches none of this. There's a regression test using a runtime that
does not exist (`mlx:model:phi-4`) to keep it that way.

## Compatibility

The per-model switch in **Accounts** stays where it is and now writes the new
preference, with a caption pointing at Models when a row is hidden. Local model
visibility used to be stored alongside the connection choices in
`hiddenProviders`; showing a model from either pane clears that legacy entry
without reconnecting its runtime, so nobody's existing choices are lost or
silently turned into sign-outs.

Reordering stays in **Accounts** and is unchanged: drag a visible row by its
handle, and a provider reconnected there still joins the end of the list.

## Tests

`Tests/ModelVisibilityTests.swift`:

- visibility persists separately from connections and survives a relaunch;
- hiding never touches readings, the archive, the order, or an in-flight fetch;
- a hidden provider still loads its archive and still refreshes on schedule;
- runtimes and their models hide independently while model discovery continues;
- the legacy migration restores a model belonging to an unknown runtime.

## Copy

All new strings go through `L10n.t` and carry fr / ja / pt-BR / zh-Hans
translations in `Sources/Localizable.xcstrings`. README updated for the new pane.

## What I could not verify

I don't have Xcode on this machine (Command Line Tools only), so `make test`
cannot build the app target locally. The changed files pass `swiftc -parse` and
`xcodegen generate` picks up both new files, but CI on this PR is the first real
build. Happy to fix anything it turns up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
