### PR TITLE
Show on each Windows ring the window the Mac app shows

### DIFF
--- a/windows/codenotch/src/config.rs
+++ b/windows/codenotch/src/config.rs
@@ -6,15 +6,11 @@ use std::path::PathBuf;
 pub const SCALE_MIN: f64 = 0.40;
 pub const SCALE_MAX: f64 = 1.00;
 
-/// One half of the tray icon: which provider, and which of its windows.
-/// `window` is a window id as the provider reports it ("session", "weekly_all", "primary"…), or
-/// the empty string / "top" meaning "whichever of its windows is fullest" — the same rule the
-/// notch ring uses, and the only choice that keeps working when a provider changes its windows.
+/// One half of the tray icon, or one ring on the notch: which provider. It shows that provider's
+/// ring, so the tray and the notch can never disagree. (A `window` key from older builds is ignored.)
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct TraySlot {
     pub provider: String,
-    #[serde(default)]
-    pub window: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -60,11 +56,15 @@ pub struct Config {
     /// kept so an existing config migrates cleanly.
     #[serde(default)]
     pub notch_providers: Vec<String>,
-    /// What each ring on the notch shows: the provider, and which of its windows. An empty list
-    /// means every provider, each showing whichever of its windows is fullest — the original
-    /// behaviour. Same shape as the tray slots so the two settings read alike.
+    /// Which providers get a ring on the notch, in order. An empty list means every provider.
     #[serde(default)]
     pub notch_slots: Vec<TraySlot>,
+    /// Antigravity's lane on the ring, as the Mac app's "Notch reads": "automatic", "5h" or "weekly"
+    #[serde(default = "default_antigravity_limit")]
+    pub antigravity_limit: String,
+    /// The model family that choice looks at, as the Mac app's "Model data": "gemini" or "3p"
+    #[serde(default = "default_antigravity_model")]
+    pub antigravity_model: String,
     /// false = the pill is kept off the screen edge entirely; the tray icon is then the only way in
     #[serde(default = "yes")]
     pub notch_visible: bool,
@@ -92,6 +92,12 @@ fn default_tray_mode() -> String {
 fn default_tray_providers() -> Vec<String> {
     vec!["claude".into(), "codex".into()]
 }
+fn default_antigravity_limit() -> String {
+    "automatic".into()
+}
+fn default_antigravity_model() -> String {
+    "gemini".into()
+}
 
 fn default_port() -> u16 {
     48666
@@ -116,6 +122,8 @@ impl Default for Config {
             tray_slots: Vec::new(), // filled in by load(), from tray_providers
             notch_providers: Vec::new(), // empty = show them all
             notch_slots: Vec::new(),     // filled in by load(), from notch_providers
+            antigravity_limit: default_antigravity_limit(),
+            antigravity_model: default_antigravity_model(),
             notch_visible: true,
             tray_visible: true,
         }
@@ -151,24 +159,22 @@ pub fn load() -> Config {
         cfg.tray_mode = "off".into();
     }
 
-    // Migration: before slots existed the icon was a plain provider list, each showing whichever of
-    // its windows was fullest. That is exactly a slot with an empty `window`, so nobody's choice is
-    // lost and nobody has to reconfigure anything.
+    // Migration: before slots existed the icon was a plain provider list, one reading each. That
+    // is exactly a list of slots, so nobody's choice is lost and nobody has to reconfigure anything.
     if cfg.tray_slots.is_empty() {
         cfg.tray_slots = cfg
             .tray_providers
             .iter()
-            .map(|p| TraySlot { provider: p.clone(), window: String::new() })
+            .map(|p| TraySlot { provider: p.clone() })
             .collect();
     }
 
-    // Same migration for the notch: a plain provider list becomes slots that each show whichever
-    // window is fullest, which is exactly what the list used to mean.
+    // Same migration for the notch.
     if cfg.notch_slots.is_empty() {
         cfg.notch_slots = cfg
             .notch_providers
             .iter()
-            .map(|p| TraySlot { provider: p.clone(), window: String::new() })
+            .map(|p| TraySlot { provider: p.clone() })
             .collect();
     }
 

--- a/windows/codenotch/src/main.rs
+++ b/windows/codenotch/src/main.rs
@@ -594,23 +594,75 @@ fn set_scale(app: AppHandle, scale: f64) {
 
 // ---------------- tray icon readings ----------------
 
-/// The headline percentage of a reading: its fullest window, as a whole number 0-100.
-///
-/// Deliberately the same rule as `headlineOf` in ui/notch.html, so the tray icon and the ring can
-/// never disagree: consider only metered windows — a `count` window (Antigravity's requests today,
-/// say) has no published denominator, so its `used` is not a share of anything and averaging or
-/// maximising over it would invent a number.
-fn headline_pct(s: &usage::UsageSnapshot) -> Option<u32> {
-    let top = s
-        .windows
-        .iter()
+/// The tightest metered window, ties going to the lower id so the choice never flickers. A `count`
+/// window (Antigravity's requests today) has no published denominator, so it is never a candidate.
+fn tightest<'a>(
+    windows: impl Iterator<Item = &'a usage::LimitWindow>,
+) -> Option<&'a usage::LimitWindow> {
+    windows
         .filter(|w| w.count.is_none())
-        .map(|w| w.used)
-        .fold(f64::NAN, f64::max);
-    if top.is_nan() {
-        return None;
+        .max_by(|a, b| a.used.total_cmp(&b.used).then_with(|| b.id.cmp(&a.id)))
+}
+
+/// The window a provider's ring shows, declared per provider as the macOS providers declare
+/// `headlineID`: a window dropping out of a reply shows a dash instead of promoting another one
+/// into its place. `headlineOf` in ui/notch.html is the same rule, so the ring and the tray agree.
+fn ring_window<'a>(
+    provider: &str,
+    windows: &'a [usage::LimitWindow],
+    antigravity_limit: &str,
+    antigravity_model: &str,
+) -> Option<&'a usage::LimitWindow> {
+    let by_id = |id: &str| windows.iter().find(|w| w.id == id);
+    match provider {
+        "claude" => by_id("session"),
+        "codex" => windows.first(),
+        "cursor" => by_id("included").or_else(|| by_id("api")),
+        _ => antigravity_lane(windows, antigravity_limit, antigravity_model),
     }
-    Some((top * 100.0).round().clamp(0.0, 100.0) as u32)
+}
+
+/// Antigravity's lane, chosen as the Mac app's "Notch reads" and "Model data" choose it: within the
+/// model family (or every lane, if none belongs to it), the tightest lane of the chosen cadence; on
+/// Automatic, the tightest lane that still has room, or the tightest of all once every one is spent.
+fn antigravity_lane<'a>(
+    windows: &'a [usage::LimitWindow],
+    limit: &str,
+    model: &str,
+) -> Option<&'a usage::LimitWindow> {
+    let family: Vec<_> = windows.iter().filter(|w| lane_family(w) == model).collect();
+    let lanes = if family.is_empty() { windows.iter().collect() } else { family };
+    if limit != "automatic" {
+        if let Some(w) = tightest(lanes.iter().copied().filter(|w| lane_is(w, limit))) {
+            return Some(w);
+        }
+    }
+    tightest(lanes.iter().copied().filter(|w| w.used < 1.0))
+        .or_else(|| tightest(lanes.iter().copied()))
+        .or_else(|| lanes.first().copied())
+}
+
+/// "gemini" or "3p", from the language server's `gemini-5h` ids or the CLI's "Gemini Models …" ones
+fn lane_family(w: &usage::LimitWindow) -> &'static str {
+    let id = w.id.to_lowercase();
+    if id.starts_with("gemini") {
+        "gemini"
+    } else if id.starts_with("3p") || id.starts_with("claude") {
+        "3p"
+    } else {
+        ""
+    }
+}
+
+/// Whether a lane is the 5-hour or the weekly one, by the words the Mac app looks for
+fn lane_is(w: &usage::LimitWindow, limit: &str) -> bool {
+    let text = format!("{} {}", w.id, w.label).to_lowercase();
+    match limit {
+        "weekly" => text.contains("weekly"),
+        _ => ["5h", "5-hour", "five hour", "five-hour", "hourly", "session"]
+            .iter()
+            .any(|k| text.contains(k)),
+    }
 }
 
 /// Ids match the ones the page uses, so the tray, the settings window and the notch all agree.
@@ -624,41 +676,34 @@ fn snapshot_of(app: &AppHandle, id: &str) -> usage::UsageSnapshot {
     }
 }
 
-/// What one half of the icon should show. An empty (or "top") window id means "whichever of this
-/// provider's windows is fullest", which is the notch's own rule and the only choice that survives
-/// a provider adding or renaming its windows.
-fn reading_for_slot(app: &AppHandle, slot: &config::TraySlot) -> Option<u32> {
-    let snap = snapshot_of(app, &slot.provider);
+/// A provider's ring as a whole percentage, for the tray icon and the settings picker. A count
+/// window has no percentage to draw, so it is a dash.
+fn ring_pct(app: &AppHandle, provider: &str) -> Option<u32> {
+    let snap = snapshot_of(app, provider);
     if snap.status == "absent" {
         return None;
     }
-    if slot.window.is_empty() || slot.window == "top" {
-        return headline_pct(&snap);
-    }
-    // A pinned window missing from this snapshot falls back to the fullest one, which is what the
-    // notch does in the same situation. Without this a provider that renamed or dropped a window
-    // would leave the icon showing a dash while the notch still showed a number.
-    snap.windows
-        .iter()
-        .find(|w| w.id == slot.window && w.count.is_none())
+    let (limit, model) = {
+        let st = app.state::<AppState>();
+        let c = st.cfg.lock().unwrap();
+        (c.antigravity_limit.clone(), c.antigravity_model.clone())
+    };
+    ring_window(provider, &snap.windows, &limit, &model)
+        .filter(|w| w.count.is_none())
         .map(|w| (w.used * 100.0).round().clamp(0.0, 100.0) as u32)
-        .or_else(|| headline_pct(&snap))
 }
 
-/// One provider and the windows it currently reports, for the settings window's pickers. Built
-/// from live readings rather than a hard-coded table, so a provider that gains a window shows it.
+/// What one half of the icon shows: that provider's ring.
+fn reading_for_slot(app: &AppHandle, slot: &config::TraySlot) -> Option<u32> {
+    ring_pct(app, &slot.provider)
+}
+
+/// One provider and its ring's current number, for the settings window's picker.
 #[derive(serde::Serialize)]
 struct TrayOption {
     id: String,
     label: String,
     status: String,
-    windows: Vec<TrayWindowOption>,
-}
-
-#[derive(serde::Serialize)]
-struct TrayWindowOption {
-    id: String,
-    label: String,
     used: Option<u32>,
 }
 
@@ -666,23 +711,11 @@ struct TrayWindowOption {
 fn get_tray_options(app: AppHandle) -> Vec<TrayOption> {
     TRAY_PROVIDER_IDS
         .iter()
-        .map(|id| {
-            let snap = snapshot_of(&app, id);
-            TrayOption {
-                id: (*id).to_string(),
-                label: provider_label(id).to_string(),
-                status: snap.status.clone(),
-                windows: snap
-                    .windows
-                    .iter()
-                    .filter(|w| w.count.is_none()) // a count window has no percentage to draw
-                    .map(|w| TrayWindowOption {
-                        id: w.id.clone(),
-                        label: w.label.clone(),
-                        used: Some((w.used * 100.0).round().clamp(0.0, 100.0) as u32),
-                    })
-                    .collect(),
-            }
+        .map(|id| TrayOption {
+            id: (*id).to_string(),
+            label: provider_label(id).to_string(),
+            status: snapshot_of(&app, id).status,
+            used: ring_pct(&app, id),
         })
         .collect()
 }
@@ -728,8 +761,41 @@ fn get_tray_preview(app: AppHandle, cfg: TrayConfig) -> Option<String> {
     trayicon::to_data_url(&rgba)
 }
 
-/// What each ring on the notch shows: the provider, and which of its windows. An empty list means
-/// every provider, each showing whichever window is fullest — the original behaviour.
+/// Antigravity's "Notch reads" and "Model data", as the Mac app has them.
+#[derive(serde::Serialize)]
+struct AntigravityPrefs {
+    limit: String,
+    model: String,
+}
+
+#[tauri::command]
+fn get_antigravity_prefs(app: AppHandle) -> AntigravityPrefs {
+    let st = app.state::<AppState>();
+    let c = st.cfg.lock().unwrap();
+    AntigravityPrefs { limit: c.antigravity_limit.clone(), model: c.antigravity_model.clone() }
+}
+
+/// Unknown values are refused rather than stored. The notch draws its own rings, so it is told.
+#[tauri::command]
+fn set_antigravity_prefs(app: AppHandle, limit: String, model: String) -> AntigravityPrefs {
+    let prefs = {
+        let st = app.state::<AppState>();
+        let mut c = st.cfg.lock().unwrap();
+        if ["automatic", "5h", "weekly"].contains(&limit.as_str()) {
+            c.antigravity_limit = limit;
+        }
+        if ["gemini", "3p"].contains(&model.as_str()) {
+            c.antigravity_model = model;
+        }
+        config::save(&c);
+        AntigravityPrefs { limit: c.antigravity_limit.clone(), model: c.antigravity_model.clone() }
+    };
+    let _ = app.emit("antigravity_prefs", &prefs);
+    repaint_tray(&app);
+    prefs
+}
+
+/// Which providers get a ring on the notch. An empty list means every provider.
 #[tauri::command]
 fn get_notch_slots(app: AppHandle) -> Vec<config::TraySlot> {
     let st = app.state::<AppState>();
@@ -1091,6 +1157,8 @@ fn main() {
             get_tray_preview,
             get_notch_slots,
             set_notch_slots,
+            get_antigravity_prefs,
+            set_antigravity_prefs,
             get_app_icon,
             get_ui_flags,
             set_ui_flags,
@@ -1174,7 +1242,8 @@ fn main() {
 
 #[cfg(test)]
 mod tests {
-    use super::{cursor_in_hot, HOT_PAD};
+    use super::{cursor_in_hot, ring_window, HOT_PAD};
+    use crate::usage::LimitWindow;
 
     /// Real values from the run.log in #106: a 2560×1600 display at 150 %.
     const PILL: [f64; 4] = [405.0, 183.5, 105.0, 323.0];
@@ -1243,5 +1312,76 @@ mod tests {
     fn an_unreadable_window_size_falls_back_to_the_rectangles() {
         assert!(cursor_in_hot(&[PILL], 450.0, 300.0, None));
         assert!(!cursor_in_hot(&[PILL], 100.0, 300.0, None));
+    }
+
+    fn win(id: &str, used: f64) -> LimitWindow {
+        LimitWindow { id: id.into(), used, ..Default::default() }
+    }
+
+    fn pick<'a>(provider: &str, windows: &'a [LimitWindow]) -> Option<&'a str> {
+        ring_window(provider, windows, "automatic", "gemini").map(|w| w.id.as_str())
+    }
+
+    fn lane<'a>(windows: &'a [LimitWindow], limit: &str, model: &str) -> Option<&'a str> {
+        ring_window("gemini", windows, limit, model).map(|w| w.id.as_str())
+    }
+
+    /// The four lanes Antigravity's language server reported on a real machine
+    fn bridge() -> [LimitWindow; 4] {
+        [win("gemini-weekly", 0.03), win("gemini-5h", 0.0), win("3p-weekly", 0.5), win("3p-5h", 0.9)]
+    }
+
+    #[test]
+    fn claude_means_the_session_even_when_the_week_is_fuller() {
+        assert_eq!(pick("claude", &[win("session", 0.10), win("weekly_all", 0.60)]), Some("session"));
+    }
+
+    #[test]
+    fn a_missing_declared_window_is_a_dash_not_a_stand_in() {
+        assert_eq!(pick("claude", &[win("weekly_all", 0.60)]), None);
+    }
+
+    #[test]
+    fn codex_means_its_first_window_and_cursor_its_included_usage() {
+        assert_eq!(pick("codex", &[win("primary", 0.2), win("secondary", 0.9)]), Some("primary"));
+        assert_eq!(pick("cursor", &[win("included", 0.3), win("api", 0.9)]), Some("included"));
+        assert_eq!(pick("cursor", &[win("api", 0.9), win("on_demand", 0.95)]), Some("api"));
+    }
+
+    #[test]
+    fn antigravity_reads_only_gemini_lanes_unless_told_otherwise() {
+        assert_eq!(lane(&bridge(), "automatic", "gemini"), Some("gemini-weekly"));
+        assert_eq!(lane(&bridge(), "automatic", "3p"), Some("3p-5h"));
+    }
+
+    #[test]
+    fn notch_reads_picks_the_five_hour_or_the_weekly_lane() {
+        assert_eq!(lane(&bridge(), "5h", "gemini"), Some("gemini-5h"));
+        assert_eq!(lane(&bridge(), "weekly", "3p"), Some("3p-weekly"));
+    }
+
+    #[test]
+    fn the_cli_names_its_lanes_differently_and_still_matches() {
+        let cli = [
+            win("Gemini Models Weekly Limit", 0.2),
+            win("Gemini Models Five Hour Limit", 0.1),
+            win("Claude and GPT models Five Hour Limit", 0.7),
+        ];
+        assert_eq!(lane(&cli, "5h", "gemini"), Some("Gemini Models Five Hour Limit"));
+        assert_eq!(lane(&cli, "automatic", "3p"), Some("Claude and GPT models Five Hour Limit"));
+    }
+
+    #[test]
+    fn a_spent_lane_leads_only_once_every_lane_is_spent() {
+        let one_spent = [win("gemini-5h", 1.0), win("gemini-weekly", 0.4)];
+        assert_eq!(lane(&one_spent, "automatic", "gemini"), Some("gemini-weekly"));
+        let all_spent = [win("gemini-weekly", 1.0), win("gemini-5h", 1.0)];
+        assert_eq!(lane(&all_spent, "automatic", "gemini"), Some("gemini-5h"));
+    }
+
+    #[test]
+    fn a_request_count_still_leads_when_it_is_all_there_is() {
+        let requests = LimitWindow { id: "requests".into(), count: Some(79), ..Default::default() };
+        assert_eq!(pick("gemini", std::slice::from_ref(&requests)), Some("requests"));
     }
 }

--- a/windows/codenotch/ui/notch.html
+++ b/windows/codenotch/ui/notch.html
@@ -239,9 +239,7 @@ function glyphHtml(p,small){
   return small?'':p.glyph; // fallback letter
 }
 // Provider table (order = top to bottom in the pill). `glyph` is the fallback letter used when no mark is available
-// What each ring shows: [{provider, window}]. null or an empty list means every provider, each
-// showing whichever of its windows is fullest, which is the original behaviour and the default.
-// An empty `window` on a slot means the same "fullest" rule for that one provider.
+// Which providers get a ring: [{provider}]. null or an empty list means every provider.
 let notchSlots=null;
 function slotFor(id){
   if(!Array.isArray(notchSlots)) return null;
@@ -261,18 +259,27 @@ function providers(){
   }
   return list;
 }
+// Antigravity's "Notch reads" and "Model data", as in the Mac app; chosen in settings
+let agPrefs={limit:'automatic',model:'gemini'};
+// The tightest metered window, ties going to the lower id so the choice never flickers
+function tightestOf(ws){
+  return ws.filter(w=>w.count==null).reduce((a,b)=>!a||b.used>a.used||(b.used===a.used&&b.id<a.id)?b:a,null);
+}
+function laneFamily(w){ const id=w.id.toLowerCase(); return id.startsWith('gemini')?'gemini':(id.startsWith('3p')||id.startsWith('claude'))?'3p':''; }
+function laneIs(w,limit){
+  const t=(w.id+' '+w.label).toLowerCase();
+  return limit==='weekly'?t.includes('weekly'):['5h','5-hour','five hour','five-hour','hourly','session'].some(k=>t.includes(k));
+}
+// The window a provider's ring shows: the same rule as ring_window in main.rs, which draws the tray
 function headlineOf(snap,id){
-  if(!snap.windows.length) return null;
-  const metered=snap.windows.filter(w=>w.count==null);
-  // A ring can be pinned to one window in settings; falling back to the fullest keeps working if
-  // that window disappears, rather than leaving the ring blank.
-  const slot=id?slotFor(id):null;
-  if(slot&&slot.window){
-    const pinned=metered.filter(w=>w.id===slot.window);
-    if(pinned.length) return pinned[0];
-  }
-  if(metered.length) return metered.reduce((a,b)=> b.used>a.used?b:a);
-  return snap.windows[0];
+  const ws=snap.windows; if(!ws.length) return null;
+  const byId=x=>ws.find(w=>w.id===x)||null;
+  if(id==='claude') return byId('session');
+  if(id==='codex') return ws[0];
+  if(id==='cursor') return byId('included')||byId('api');
+  const fam=ws.filter(w=>laneFamily(w)===agPrefs.model), lanes=fam.length?fam:ws;
+  if(agPrefs.limit!=='automatic'){ const w=tightestOf(lanes.filter(w=>laneIs(w,agPrefs.limit))); if(w) return w; }
+  return tightestOf(lanes.filter(w=>w.used<1))||tightestOf(lanes)||lanes[0];
 }
 function staleOf(snap){ if(snap.status==='stale') return true; return snap.fetched_at>0 && (Date.now()-snap.fetched_at)>5*60*1000; }
 let stateSnap={sessions:[],agg:'idle'};
@@ -282,11 +289,6 @@ function svgArc(r,frac,color,width,extra=''){
   return `<circle cx="28" cy="28" r="${r}" fill="none" stroke="${color}" stroke-width="${width}"
     stroke-dasharray="${(C*frac).toFixed(2)} ${C.toFixed(2)}" stroke-linecap="butt"
     transform="rotate(-90 28 28)" ${extra}/>`;
-}
-
-function headline(){ // the cell shows the most constrained window — the one that will stop you first
-  if(!usage.windows.length) return null;
-  return usage.windows.reduce((a,b)=> b.used>a.used?b:a);
 }
 
 function isStale(){
@@ -319,7 +321,7 @@ function renderRing(){
     if(p.snap.status==='needsAuth'||p.snap.status==='none') pct.textContent='—';
     else if(h && h.count!=null) pct.textContent='~'+h.count;
     else if(h) pct.textContent=(h.derived?'~':'')+Math.round(h.used*100)+'%';
-    else pct.textContent='…';
+    else pct.textContent=p.snap.windows.length?'—':'…'; // its declared window is missing: a dash, not a wait
     glyph.classList.toggle('dim', !!(h && h.used>=1));
     wrap.classList.toggle('dim', staleOf(p.snap));
   }
@@ -578,6 +580,8 @@ listen('notch_slots',e=>{
   renderRing();
   if(card.classList.contains('show')){renderCard();armWatchdog();}
 }).catch(()=>{});
+invoke('get_antigravity_prefs').then(p=>{if(p){agPrefs=p;renderRing();}}).catch(()=>{});
+listen('antigravity_prefs',e=>{if(e.payload){agPrefs=e.payload;renderRing();}}).catch(()=>{});
 listen('glyphs',e=>{glyphs=e.payload||glyphs;renderRing();if(card.classList.contains('show'))renderCard();}).catch(()=>{});
 listen('activity',e=>{activity=e.payload||activity;renderRing();if(card.classList.contains('show'))renderCard();}).catch(()=>{});
 invoke('get_activity').then(a=>{activity=a||activity;renderRing();}).catch(()=>{});

--- a/windows/codenotch/ui/settings.html
+++ b/windows/codenotch/ui/settings.html
@@ -194,9 +194,6 @@
   .picker{margin-top:14px;border-top:1px solid #1e1e1e;padding-top:12px}
   .p-head{font-size:11px;color:#808080;margin-bottom:8px}
   .p-head b{color:#e8e8ea}
-  .p-prov{margin-bottom:10px}
-  .p-prov-head{display:flex;align-items:baseline;gap:8px;padding:0 2px 4px;flex-wrap:wrap}
-  .p-prov-name{font-size:12px;font-weight:700;color:#e8e8ea}
   .p-status{font-size:10px;color:#808080;margin-left:auto;white-space:nowrap}
   .p-status.warn{color:#facc15}
   .p-item{
@@ -208,16 +205,14 @@
   .p-item.on{border-color:#8a8a8a;background:#1c1c1c}
   .p-item:focus-visible{outline:1px solid #8a8a8a;outline-offset:1px}
   .p-label{overflow:hidden;text-overflow:ellipsis;white-space:nowrap;min-width:0}
-  .p-any{color:#c8c8c8;font-style:italic}
   .p-pct{margin-left:auto;display:flex;align-items:center;gap:6px;font-size:11px;color:#b0b0b3;font-variant-numeric:tabular-nums;white-space:nowrap}
   .p-dot{width:7px;height:7px;border-radius:4px;flex:0 0 auto}
   .p-tick{width:12px;flex:0 0 auto;color:#fff;font-size:11px}
-  .p-empty{font-size:11px;color:#808080;padding:2px 2px 6px}
 
   /* Notch providers — the picker's rows again, ticked rather than chosen */
   .np-list{margin-top:12px}
   .np-row{margin-bottom:10px}
-  .np-win{width:100%;margin-top:4px}
+  .np-ag{display:flex;align-items:center;gap:8px;margin:6px 0 0 29px;font-size:11px;color:#808080}
   .np-right{margin-left:auto;display:flex;align-items:center;gap:8px;white-space:nowrap;min-width:0}
   .np-right .p-status{margin-left:0}
   .np-lock{font-size:10px;color:#808080;font-style:italic}
@@ -300,7 +295,7 @@
 
       <div class="block">
         <div class="b-head">What each part shows</div>
-        <div class="b-sub">Pick the tool, then the usage window you want drawn there.</div>
+        <div class="b-sub">Pick the tool; each part draws that tool's ring.</div>
         <div class="picker" id="picker"></div>
       </div>
     </section>
@@ -312,7 +307,7 @@
 
       <div class="block first">
         <div class="b-head">What appears on the pill</div>
-        <div class="b-sub">Click a name to switch its ring on or off. The list underneath each name chooses which usage window that ring counts.</div>
+        <div class="b-sub">Click a name to switch its ring on or off.</div>
         <div class="np-list" id="notch-list"></div>
         <div class="c-note dim" id="notch-note" style="margin-top:6px"></div>
       </div>
@@ -500,9 +495,9 @@ const RU_STATIC = {
   'The plain Codenotch logo is used.':'Используется обычный логотип Codenotch.', 'No numbers are drawn.':'Числа не отображаются.',
   'Actual size':'Фактический размер', 'This is how big it really is in the taskbar.':'Такой размер значок имеет в панели задач.',
   'Windows picks one of these depending on the display. If a number is unreadable here, it will be unreadable in the taskbar.':'Windows выбирает один из вариантов в зависимости от масштаба экрана. Если число не читается здесь, в панели задач оно тоже не будет читаться.',
-  'What each part shows':'Что показывает каждая часть', 'Pick the tool, then the usage window you want drawn there.':'Выберите инструмент, затем окно использования для этой части.',
+  'What each part shows':'Что показывает каждая часть', 'Pick the tool; each part draws that tool\'s ring.':'Выберите инструмент: каждая часть показывает его кольцо.',
   'The small black pill that floats against the right-hand edge of the screen. Each tool you tick gets one ring on it.':'Небольшая чёрная панель у правого края экрана. Каждый выбранный инструмент получает на ней своё кольцо.',
-  'What appears on the pill':'Что отображается на панели', 'Click a name to switch its ring on or off. The list underneath each name chooses which usage window that ring counts.':'Нажмите на название, чтобы включить или выключить кольцо. В списке под названием выбирается окно использования для этого кольца.',
+  'What appears on the pill':'Что отображается на панели', 'Click a name to switch its ring on or off.':'Нажмите на название, чтобы включить или выключить кольцо.',
   'Size':'Размер', 'How big the pill is drawn. The same slider sits at the foot of the pill\'s hover card, so it can be changed from either place.':'Размер панели. Такой же ползунок находится внизу карточки при наведении на панель.',
   'Whether the pill is on screen at all is a separate switch, under General → Behaviour.':'Видимость панели переключается отдельно в разделе «Общие → Поведение».',
   'When Codenotch runs, and what it puts on your screen.':'Когда запускается Codenotch и что он показывает на экране.',
@@ -516,9 +511,10 @@ const RU_STATIC = {
   'Files':'Файлы', 'Data folder':'Папка данных', 'Open folder':'Открыть папку', 'If something looks wrong':'Если что-то работает неправильно',
   'Put the notch back':'Вернуть панель', 'Reset position':'Сбросить положение', 'Saved':'Сохранено',
   'Numbers':'Числа', 'two readings':'два показания', 'Bars':'Полосы', '1 to 5 columns':'от 1 до 5 столбцов', 'Plain icon':'Обычный значок', 'just the logo':'только логотип',
-  'Whichever is fullest':'Самое заполненное', 'No windows reported':'Нет доступных окон', 'kept':'оставлено', 'Showing':'Показывается', 'Showing in':'Показывается в',
-  '"Whichever is fullest" starts working as soon as it reports one.':'«Самое заполненное» начнёт работать, как только появится окно использования.',
-  '"%@" is no longer available':'«%@» больше недоступен', '%@ no longer reports "%@"':'%@ больше не сообщает «%@»', '%@ — that slot now shows whichever window is fullest.':'%@ — теперь слот показывает самое заполненное окно.',
+  'kept':'оставлено', 'Showing':'Показывается', 'Showing in':'Показывается в',
+  'Notch reads':'Показания панели', 'Automatic':'Автоматически', '5-Hour Limit':'Лимит на 5 часов', 'Weekly Limit':'Недельный лимит',
+  'Gemini Models':'Модели Gemini', 'Claude and GPT models':'Модели Claude и GPT',
+  '"%@" is no longer available':'«%@» больше недоступен', '%@ — that slot now shows another provider.':'%@ — теперь слот показывает другого провайдера.',
   'One provider always stays ticked, so the pill is never empty.':'Хотя бы один провайдер всегда выбран, поэтому панель не бывает пустой.',
   'The taskbar icon shows the plain Codenotch logo.':'Значок в панели задач показывает обычный логотип Codenotch.',
   'Choose Numbers or Bars above to draw your usage into it.':'Выберите выше «Числа» или «Полосы», чтобы показывать в нём использование.',
@@ -710,22 +706,13 @@ function provLabel(id){
   const p = provOf(id);
   return (p && p.label) || FALLBACK_LABEL[id] || id;
 }
-function winsOf(id){
-  const p = provOf(id);
-  return (p && Array.isArray(p.windows)) ? p.windows : [];
-}
-function winLabel(pid, wid){
-  if(!wid) return ui('Whichever is fullest', 'Whichever is fullest');
-  const w = winsOf(pid).find(x => x.id === wid);
-  return w ? w.label : wid;
-}
 /* THE one source of truth for who the providers are: whatever get_tray_options answered, and the
    fallback names only until it does. The tray picker and the Notch section both read this list, so
    a provider is never named twice in this file. */
 function providerList(){
   return options.length
     ? options
-    : ORDER.map(id => ({ id, label:FALLBACK_LABEL[id], status:'', windows:[] }));
+    : ORDER.map(id => ({ id, label:FALLBACK_LABEL[id], status:'', used:null }));
 }
 /* The one place a status code turns into words ("not signed in"), shared for the same reason. */
 function statusText(p){
@@ -734,11 +721,11 @@ function statusText(p){
 }
 
 /* Which provider to reach for when a slot has to be invented or repaired: one that is actually
-   reporting windows first, then one that is at least healthy, then anything. */
+   reporting a number first, then one that is at least healthy, then anything. */
 function pickProvider(taken){
   const pool = providerList();
   const rank = o => {
-    const has = o.windows && o.windows.length ? 0 : 2;
+    const has = o.used != null ? 0 : 2;
     const ok = o.status === 'ok' ? 0 : 1;
     return has + ok;
   };
@@ -747,32 +734,21 @@ function pickProvider(taken){
   return list.length ? list[0].id : 'claude';
 }
 function defaultSlot(existing){
-  return { provider: pickProvider(existing.map(s => s.provider)), window: '' };
+  return { provider: pickProvider(existing.map(s => s.provider)) };
 }
 
 /* ---- configuration repair ----------------------------------------------
-   A saved slot can point at a provider that no longer exists, or at a window id a provider has
-   stopped reporting. Both fall back to "whichever is fullest" rather than breaking the icon.
-   One deliberate exception: when a provider reports NO windows at all (not signed in, say), the
-   stored window id is left alone — it is not evidence the choice is wrong, and throwing it away
-   would quietly lose the user's preference while they are signed out. */
+   A saved slot can point at a provider that no longer exists; it is replaced rather than left to
+   break the icon. */
 function fixSlot(s, notes){
   if(!s || typeof s !== 'object' || typeof s.provider !== 'string' || !s.provider){
-    return { provider: pickProvider([]), window: '' };
+    return { provider: pickProvider([]) };
   }
-  const provider = s.provider;
-  let win = typeof s.window === 'string' ? s.window : '';   // not named `window`: that is the global
-  if(options.length && !provOf(provider)){
-    notes.push(ui('"%@" is no longer available', '"%@" is no longer available').replace('%@', provider));
-    return { provider: pickProvider([]), window: '' };
+  if(options.length && !provOf(s.provider)){
+    notes.push(ui('"%@" is no longer available', '"%@" is no longer available').replace('%@', s.provider));
+    return { provider: pickProvider([]) };
   }
-  const wins = winsOf(provider);
-  if(win && win !== 'top' && wins.length && !wins.some(w => w.id === win)){
-    notes.push(ui('%@ no longer reports "%@"', '%@ no longer reports "%@"').replace('%@', provLabel(provider)).replace('%@', win));
-    win = '';
-  }
-  if(win === 'top') win = '';   // the Rust side treats "top" as "fullest"; store the plain form
-  return { provider: provider, window: win };
+  return { provider: s.provider };
 }
 function normalize(){
   if(['numbers', 'bars', 'off'].indexOf(cfg.mode) < 0) cfg.mode = 'off';
@@ -788,12 +764,12 @@ function normalize(){
   cfg.slots = slots;
   if(sel >= cfg.slots.length) sel = cfg.slots.length - 1;
   if(sel < 0) sel = 0;
-  repairNote = notes.length ? ui('%@ — that slot now shows whichever window is fullest.', '%@ — that slot now shows whichever window is fullest.').replace('%@', notes[0]) : '';
+  repairNote = notes.length ? ui('%@ — that slot now shows another provider.', '%@ — that slot now shows another provider.').replace('%@', notes[0]) : '';
 }
 
 /* ---- saving ------------------------------------------------------------ */
 function payload(){
-  return { mode: cfg.mode, slots: cfg.slots.map(s => ({ provider:s.provider, window:s.window })) };
+  return { mode: cfg.mode, slots: cfg.slots.map(s => ({ provider:s.provider })) };
 }
 function persist(quiet){
   invoke('set_tray_config', { cfg: payload() })
@@ -869,7 +845,7 @@ function renderRegions(){
   boxes.forEach((b, i) => {
     html += '<button class="region' + (i === sel ? ' on' : '') + '" data-i="' + i + '"'
       + ' style="left:' + b.left.toFixed(3) + '%;top:' + b.top + '%;width:' + b.width.toFixed(3) + '%;height:' + b.height + '%"'
-      + ' title="' + esc(slotName(i) + ': ' + provLabel(cfg.slots[i].provider) + ' — ' + winLabel(cfg.slots[i].provider, cfg.slots[i].window)) + '"'
+      + ' title="' + esc(slotName(i) + ': ' + provLabel(cfg.slots[i].provider)) + '"'
       + ' aria-label="' + esc(slotName(i)) + '" aria-pressed="' + (i === sel) + '">'
       + '<span class="r-num">' + (i + 1) + '</span></button>';
   });
@@ -903,7 +879,7 @@ function renderChips(){
   if(cfg.mode === 'off'){ host.innerHTML = ''; return; }
   let html = '';
   cfg.slots.forEach((s, i) => {
-    const text = provLabel(s.provider) + ' · ' + winLabel(s.provider, s.window);
+    const text = provLabel(s.provider);
     html += '<span class="chip' + (i === sel ? ' on' : '') + '">'
       + '<button class="chip-pick" data-chip="' + i + '" aria-pressed="' + (i === sel) + '">'
       + '<b>' + esc(slotName(i)) + '</b><span class="ctext">' + esc(text) + '</span></button>'
@@ -926,48 +902,28 @@ function renderPicker(){
       + esc(ui('Choose Numbers or Bars above to draw your usage into it.', 'Choose Numbers or Bars above to draw your usage into it.')) + '</div>';
     return;
   }
-  const cur = cfg.slots[sel] || { provider:'', window:'' };
+  const cur = cfg.slots[sel] || { provider:'' };
   let html = '<div class="p-head">' + esc(ui('Showing in', 'Showing in')) + ' <b>' + esc(slotName(sel)) + '</b>: '
-    + esc(provLabel(cur.provider) + ' — ' + winLabel(cur.provider, cur.window)) + '</div>';
+    + esc(provLabel(cur.provider)) + '</div>';
   if(repairNote) html += '<div class="c-note dim" style="margin-bottom:8px">' + esc(repairNote) + '</div>';
 
-  const list = providerList();
-
-  for(const p of list){
-    const st = statusText(p);
-    html += '<div class="p-prov"><div class="p-prov-head"><span class="p-prov-name">' + esc(p.label || p.id) + '</span>'
-      + (st ? '<span class="p-status warn">' + esc(st) + '</span>' : '') + '</div>';
-
-    // Always first, always available: the choice that survives a provider changing its windows.
-    const anyOn = cur.provider === p.id && !cur.window;
-    html += '<button class="p-item' + (anyOn ? ' on' : '') + '" data-p="' + esc(p.id) + '" data-w="">'
-      + '<span class="p-tick">' + (anyOn ? '&#10003;' : '') + '</span>'
-      + '<span class="p-label p-any">' + esc(ui('Whichever is fullest', 'Whichever is fullest')) + '</span></button>';
-
-    const wins = Array.isArray(p.windows) ? p.windows : [];
-    if(!wins.length){
-      html += '<div class="p-empty">' + esc(ui('No windows reported', 'No windows reported'))
-        + (st ? ' — ' + esc(st) + '.' : '.')
-        + ' ' + esc(ui('"Whichever is fullest" starts working as soon as it reports one.', '"Whichever is fullest" starts working as soon as it reports one.')) + '</div>';
-    }
-    for(const w of wins){
-      const on = cur.provider === p.id && cur.window === w.id;
-      const pct = (typeof w.used === 'number' && isFinite(w.used)) ? Math.round(w.used) : null;
-      html += '<button class="p-item' + (on ? ' on' : '') + '" data-p="' + esc(p.id) + '" data-w="' + esc(w.id) + '">'
-        + '<span class="p-tick">' + (on ? '&#10003;' : '') + '</span>'
-        + '<span class="p-label">' + esc(w.label || w.id) + '</span>'
-        + (pct === null ? ''
-          : '<span class="p-pct"><span class="p-dot" style="background:' + band(pct) + '"></span>' + pct + '%</span>')
-        + '</button>';
-    }
-    html += '</div>';
+  // One row per provider: a slot draws that provider's ring, so there is nothing else to choose
+  for(const p of providerList()){
+    const st = statusText(p), on = cur.provider === p.id;
+    const pct = (typeof p.used === 'number' && isFinite(p.used)) ? p.used : null;
+    html += '<button class="p-item' + (on ? ' on' : '') + '" data-p="' + esc(p.id) + '">'
+      + '<span class="p-tick">' + (on ? '&#10003;' : '') + '</span>'
+      + '<span class="p-label">' + esc(p.label || p.id) + '</span>'
+      + '<span class="p-pct">' + (st ? '<span class="p-status warn">' + esc(st) + '</span>' : '')
+      + (pct === null ? '' : '<span class="p-dot" style="background:' + band(pct) + '"></span>' + pct + '%')
+      + '</span></button>';
   }
   host.innerHTML = html;
 }
 
-function chooseSlot(provider, winId){
+function chooseSlot(provider){
   if(!cfg.slots[sel]) return;
-  cfg.slots[sel] = { provider: provider, window: winId || '' };
+  cfg.slots[sel] = { provider: provider };
   repairNote = '';          // the user has now made a deliberate choice; the repair notice is spent
   render();
   refreshPreview();
@@ -1018,25 +974,34 @@ document.getElementById('chips').addEventListener('click', e => {
 });
 document.getElementById('picker').addEventListener('click', e => {
   const b = e.target.closest('.p-item');
-  if(b) chooseSlot(b.dataset.p, b.dataset.w);
+  if(b) chooseSlot(b.dataset.p);
 });
 
 /* ---- the notch's rings --------------------------------------------------
-   The pill at the edge of the screen draws one ring per provider. What is saved is a list of
-   {provider, window} slots, exactly the shape the tray icon uses, so the two settings read alike.
-   An EMPTY list means "every provider, each showing whichever of its windows is fullest" — the
-   default, and the behaviour Codenotch has always had. An empty `window` on a slot means the same
-   fullest rule for that one provider. */
-let notchSlots = [];       // exactly what is stored: [] = all of them, all on "fullest"
+   The pill at the edge of the screen draws one ring per provider, each showing the window the Mac
+   app shows for it. What is saved is which providers are on, as {provider} slots, exactly the
+   shape the tray icon uses. An EMPTY list means every provider — the default. */
+let notchSlots = [];       // exactly what is stored: [] = all of them
+
+/* Antigravity is the one provider with a choice, as in the Mac app: "Notch reads" picks the lane's
+   cadence, "Model data" the model family whose lanes it reads. */
+const AG_LIMITS = [['automatic', 'Automatic'], ['5h', '5-Hour Limit'], ['weekly', 'Weekly Limit']];
+const AG_MODELS = [['gemini', 'Gemini Models'], ['3p', 'Claude and GPT models']];
+let agPrefs = { limit:'automatic', model:'gemini' };
+function agPicker(key, name, choices, value, enabled){
+  return '<label class="np-ag">' + esc(name) + '<select data-ag="' + key + '"' + (enabled ? '' : ' disabled') + '>'
+    + choices.map(([v, t]) => '<option value="' + v + '"' + (v === value ? ' selected' : '') + '>' + esc(ui(t, t)) + '</option>').join('')
+    + '</select></label>';
+}
 
 /* The effective slots, resolved against the providers that actually exist. A saved list that
    matches none of them is treated as "all" — the same fallback notch.html makes — so the pill is
    never drawn empty because of a stale name. */
 function notchOn(){
   const ids = providerList().map(p => p.id);
-  if(!notchSlots.length) return ids.map(id => ({ provider:id, window:'' }));
+  if(!notchSlots.length) return ids.map(id => ({ provider:id }));
   const on = notchSlots.filter(sl => sl && ids.indexOf(sl.provider) >= 0);
-  return on.length ? on : ids.map(id => ({ provider:id, window:'' }));
+  return on.length ? on : ids.map(id => ({ provider:id }));
 }
 function notchSlotOf(id){
   for(const sl of notchOn()){ if(sl.provider === id) return sl; }
@@ -1064,33 +1029,27 @@ function renderNotch(){
       + (st ? '<span class="p-status warn">' + esc(st) + '</span>' : '')
       + (only ? '<span class="np-lock">kept</span>' : '')
       + '</span></button>';
-    // The window picker only means anything for a ring that is actually drawn
-    let opts = '<option value="">' + esc(ui('Whichever is fullest', 'Whichever is fullest')) + '</option>';
-    for(const w of winsOf(p.id)){
-      const selAttr = (ticked && sl.window === w.id) ? ' selected' : '';
-      const pct = (w.used === null || w.used === undefined) ? '' : '  ' + w.used + '%';
-      opts += '<option value="' + esc(w.id) + '"' + selAttr + '>' + esc(w.label + pct) + '</option>';
+    if(p.id === 'gemini'){
+      html += agPicker('limit', ui('Notch reads', 'Notch reads'), AG_LIMITS, agPrefs.limit, ticked)
+        + agPicker('model', ui('Model data', 'Model data'), AG_MODELS, agPrefs.model, ticked);
     }
-    html += '<select class="np-win" data-npw="' + esc(p.id) + '"' + (ticked ? '' : ' disabled') + '>'
-      + opts + '</select></div>';
+    html += '</div>';
   }
   host.innerHTML = html;
-  const shown = on.map(sl => provLabel(sl.provider) + ' · ' + winLabel(sl.provider, sl.window));
-  note.textContent = ui('Showing', 'Showing') + ' ' + shown.join('   |   ')
-    + '.  ' + ui('One provider always stays ticked, so the pill is never empty.', 'One provider always stays ticked, so the pill is never empty.');
+  note.textContent = ui('Showing', 'Showing') + ' ' + on.map(sl => provLabel(sl.provider)).join(', ')
+    + '. ' + ui('One provider always stays ticked, so the pill is never empty.', 'One provider always stays ticked, so the pill is never empty.');
 }
 
-/* Everything ticked AND every window left on "fullest" is stored as an EMPTY list, not as four
-   slots. Empty means "all" to the Rust side, so a provider added in a future version turns up on
-   the notch by itself; a list of today's four ids would silently exclude it forever. */
+/* Everything ticked is stored as an EMPTY list, not as four slots. Empty means "all" to the Rust
+   side, so a provider added in a future version turns up on the notch by itself; a list of today's
+   four ids would silently exclude it forever. */
 function saveNotch(next){
   const ids = providerList().map(p => p.id);
-  const isDefault = next.length === ids.length && next.every(sl => !sl.window);
-  const store = isDefault ? [] : next;
+  const store = next.length === ids.length ? [] : next;
   const prev = notchSlots;
   notchSlots = store;
   renderNotch();
-  invoke('set_notch_slots', { slots: store.map(sl => ({ provider:sl.provider, window:sl.window || '' })) })
+  invoke('set_notch_slots', { slots: store.map(sl => ({ provider:sl.provider })) })
     .then(() => toast(ui('Saved', 'Saved')))
     .catch(e => {
       notchSlots = prev;     // nothing was saved, so put it back rather than show a lie
@@ -1111,14 +1070,9 @@ function toggleNotch(id){
     if(on.length <= 1){ toast(ui('At least one provider stays on the notch', 'At least one provider stays on the notch')); return; }
     on.splice(at, 1);
   } else {
-    on.push({ provider:id, window:'' });
+    on.push({ provider:id });
   }
   on.sort((a, b) => ids.indexOf(a.provider) - ids.indexOf(b.provider));  // fixed order, not click order
-  saveNotch(on);
-}
-
-function setNotchWindow(id, wid){
-  const on = notchOn().map(sl => sl.provider === id ? { provider:id, window:wid || '' } : sl);
   saveNotch(on);
 }
 
@@ -1127,8 +1081,12 @@ document.getElementById('notch-list').addEventListener('click', e => {
   if(b) toggleNotch(b.dataset.np);
 });
 document.getElementById('notch-list').addEventListener('change', e => {
-  const box = e.target.closest('[data-npw]');
-  if(box) setNotchWindow(box.dataset.npw, box.value);
+  const box = e.target.closest('[data-ag]');
+  if(!box) return;
+  const want = Object.assign({}, agPrefs, { [box.dataset.ag]: box.value });
+  invoke('set_antigravity_prefs', want)
+    .then(v => { agPrefs = v; renderNotch(); toast(ui('Saved', 'Saved')); })
+    .catch(err => { renderNotch(); strip('set_antigravity_prefs failed: ' + errText(err)); });
 });
 
 /* ---- notch size -------------------------------------------------------- */
@@ -1321,9 +1279,13 @@ function boot(){
   call('get_notch_slots', undefined, []).then(v => {
     notchSlots = Array.isArray(v)
       ? v.filter(x => x && typeof x.provider === 'string')
-          .map(x => ({ provider:x.provider, window: typeof x.window === 'string' ? x.window : '' }))
+          .map(x => ({ provider:x.provider }))
       : [];
     renderNotch();
+  });
+
+  call('get_antigravity_prefs', undefined, null).then(v => {
+    if(v && typeof v === 'object'){ agPrefs = v; renderNotch(); }
   });
 
   call('get_scale', undefined, null).then(v => {


### PR DESCRIPTION
The ring on the Windows notch shows whichever window is most used, and so does the tray icon since #115. So Claude's ring switches to the weekly limit as soon as it's fuller than the session, and disagrees with `/usage` and with the Mac app, which always lead with the current session. The Mac app dropped that rule on purpose (TASKS.md, "The headline that moved when a window reset").

Each ring now shows the window the macOS provider declares as `headlineID`:

| provider | ring shows |
|---|---|
| Claude | `session` |
| Codex | its first window (`primary`) |
| Cursor | `included`, else `api` |
| Antigravity | the Mac app's **Notch reads** (Automatic / 5-Hour / Weekly), within **Model data** (Gemini / Claude and GPT). Same defaults: Automatic and Gemini |

If the declared window is missing from a reply, the ring shows `—` rather than putting another window in its place.

Settings follows the Mac app:
- the window list under each ring is gone
- Antigravity's row gets the two pickers
- a tray slot shows its provider's ring
- a `window` saved by the previous build is ignored

The rule lives in `ring_window` in `main.rs`, which the tray uses. `headlineOf` in `notch.html` mirrors it.

Rebased on `main` after #141 landed Russian. The window lists this PR removes took their dictionary entries with them, and the two pickers it adds go through #141's `ui()` helper. Their Russian comes from the Mac's own catalog — "Notch reads" is «Показания панели», and the lane and model names are already translated there. "Model data" has no entry in that catalog, so it stays English here exactly as it does on the Mac.

Two captions shrink with the feature they described, and keep their Russian: #141 matches static text exactly, so a reworded caption silently loses its translation. Both RU_STATIC keys move to the new wording — one of them simply drops the sentence about the window list this PR removes.

## Test plan

- [x] `cargo test`: 34 pass, 8 of them new:
  - Claude's session beats a fuller week
  - a missing session shows a dash
  - Codex's and Cursor's windows
  - Antigravity's Gemini-only default
  - Notch reads
  - the `agy` CLI's lane names
  - a spent lane
  - a reading that is only a request count
- [x] `cargo clippy --all-targets`: the same 30 warnings as `main`.
- [x] Both pages' scripts parse (`node --check`).
- [x] Settings rendered in Russian in headless Edge, bridge stubbed: the pickers read «Показания панели» → «Автоматически» and «Модели Gemini», and both reworded captions are translated.
- [x] Live on Windows 11:
  - Claude's ring matches "Current session".
  - Settings → Notch shows the pickers only under Antigravity, and changing them moves its ring and the tray icon.
  - The tray picker lists providers with their ring numbers.
