### PR TITLE
 Make the Windows hover card read like the Mac's

### DIFF
--- a/windows/codenotch/src/agy_cli.rs
+++ b/windows/codenotch/src/agy_cli.rs
@@ -129,9 +129,16 @@ fn parse_quota(text: &str) -> Result<Vec<LimitWindow>, String> {
             .replace(" and ", "/")
             .replace(" Weekly Limit", " · Weekly")
             .replace(" Five Hour Limit", " · 5h");
+        // Grouped by model family and named by lane, as the Mac card shows them
+        let group = [" Weekly Limit", " Five Hour Limit"]
+            .iter()
+            .find_map(|s| label.strip_suffix(s))
+            .map(String::from);
+        let lane = crate::antigravity::lane_name(&label).filter(|_| group.is_some());
         out.push(LimitWindow {
+            label: lane.map_or(short_label, String::from),
+            group,
             id: label,
-            label: short_label,
             used: ((100.0 - remaining) / 100.0).clamp(0.0, 1.0),
             resets_at: Some(reset as u64),
             ..Default::default()
@@ -140,6 +147,7 @@ fn parse_quota(text: &str) -> Result<Vec<LimitWindow>, String> {
     if out.is_empty() {
         return Err("CLI returned no recognised quota windows".into());
     }
+    crate::antigravity::order_lanes(&mut out);
     Ok(out)
 }
 
@@ -517,23 +525,28 @@ mod tests {
         let windows = parse_quota(text).expect("valid sample quota");
         assert_eq!(windows.len(), 4);
 
-        assert_eq!(windows[0].id, "Gemini Models Weekly Limit");
-        assert_eq!(windows[0].label, "Gemini · Weekly");
-        assert!((windows[0].used - 0.06).abs() < 1e-5);
+        // Grouped by model and named by lane, 5-hour first, as the Mac card shows them
+        assert_eq!(windows[0].id, "Gemini Models Five Hour Limit");
+        assert_eq!(windows[0].label, "5-hour Limit");
+        assert_eq!(windows[0].group.as_deref(), Some("Gemini Models"));
+        assert!((windows[0].used - 0.22).abs() < 1e-5);
         assert!(windows[0].resets_at.is_some());
 
-        assert_eq!(windows[1].id, "Gemini Models Five Hour Limit");
-        assert_eq!(windows[1].label, "Gemini · 5h");
-        assert!((windows[1].used - 0.22).abs() < 1e-5);
+        assert_eq!(windows[1].id, "Gemini Models Weekly Limit");
+        assert_eq!(windows[1].label, "Weekly Limit");
+        assert_eq!(windows[1].group.as_deref(), Some("Gemini Models"));
+        assert!((windows[1].used - 0.06).abs() < 1e-5);
         assert!(windows[1].resets_at.is_some());
 
-        assert_eq!(windows[2].id, "Claude and GPT models Weekly Limit");
-        assert_eq!(windows[2].label, "Claude/GPT · Weekly");
+        assert_eq!(windows[2].id, "Claude and GPT models Five Hour Limit");
+        assert_eq!(windows[2].label, "5-hour Limit");
+        assert_eq!(windows[2].group.as_deref(), Some("Claude and GPT models"));
         assert_eq!(windows[2].used, 0.0);
         assert!(windows[2].resets_at.is_some());
 
-        assert_eq!(windows[3].id, "Claude and GPT models Five Hour Limit");
-        assert_eq!(windows[3].label, "Claude/GPT · 5h");
+        assert_eq!(windows[3].id, "Claude and GPT models Weekly Limit");
+        assert_eq!(windows[3].label, "Weekly Limit");
+        assert_eq!(windows[3].group.as_deref(), Some("Claude and GPT models"));
         assert_eq!(windows[3].used, 0.0);
         assert!(windows[3].resets_at.is_some());
 
@@ -560,7 +573,7 @@ mod tests {
         );
         let parsed = parse_quota(&clean).expect("parsed sanitized quota");
         assert_eq!(parsed.len(), 1);
-        assert_eq!(parsed[0].label, "Gemini · Weekly");
+        assert_eq!(parsed[0].label, "Weekly Limit");
     }
 
     #[test]

--- a/windows/codenotch/src/antigravity.rs
+++ b/windows/codenotch/src/antigravity.rs
@@ -297,16 +297,49 @@ pub fn windows_from_bridge(v: &serde_json::Value) -> Vec<LimitWindow> {
                 continue;
             }
             let bname = b.get("displayName").and_then(|x| x.as_str());
+            let id = b.get("bucketId").and_then(|x| x.as_str()).or(gname).unwrap_or("quota").to_string();
             out.push(LimitWindow {
-                id: b.get("bucketId").and_then(|x| x.as_str()).or(gname).unwrap_or("quota").to_string(),
-                label: gname.or(bname).unwrap_or("Usage").to_string(),
+                label: lane_name(&id).or(gname).or(bname).unwrap_or("Usage").to_string(),
+                group: gname.map(String::from),
+                id,
                 used: (1.0 - rem).clamp(0.0, 1.0),
                 resets_at: parse_iso(b.get("resetTime")),
                 ..Default::default()
             });
         }
     }
+    order_lanes(&mut out);
     out
+}
+
+/// "5-hour Limit" or "Weekly Limit", as the Mac card names Antigravity's lanes, from the language
+/// server's `gemini-5h` ids or the CLI's "Gemini Models Five Hour Limit" ones
+pub(crate) fn lane_name(id: &str) -> Option<&'static str> {
+    let id = id.to_lowercase();
+    if id.contains("weekly") {
+        Some("Weekly Limit")
+    } else if ["5h", "five hour", "hourly"].iter().any(|k| id.contains(k)) {
+        Some("5-hour Limit")
+    } else {
+        None
+    }
+}
+
+/// The Mac card's order: groups as the source lists them, and in each the 5-hour lane before the
+/// weekly one. The language server and the CLI both send weekly first.
+pub(crate) fn order_lanes(windows: &mut [LimitWindow]) {
+    let mut groups: Vec<Option<String>> = Vec::new();
+    for w in windows.iter() {
+        if !groups.contains(&w.group) {
+            groups.push(w.group.clone());
+        }
+    }
+    let rank = |w: &LimitWindow| match lane_name(&w.id) {
+        Some("5-hour Limit") => 0,
+        Some(_) => 1,
+        None => 2,
+    };
+    windows.sort_by_key(|w| (groups.iter().position(|g| *g == w.group), rank(w)));
 }
 
 // ---------------- 3. Credential path ----------------
@@ -608,6 +641,7 @@ fn read_once(rt: &mut Runtime, prev: &UsageSnapshot) -> UsageSnapshot {
         resets_at: None,
         count: Some(n as i64),
         derived: true,
+        ..Default::default()
     }];
     snap.note = match tier {
         Some(t) => format!("{t} · Google publishes no quota for this account"),
@@ -859,5 +893,30 @@ mod tests {
         std::fs::create_dir_all(h.flavour("antigravity-ide").join("brain")).unwrap();
         trajectory(&h.flavour("antigravity-cli"), "c", &[step("MODEL", chrono::Utc::now())]);
         assert_eq!(requests_in(&state_roots_in(&h.0), today()).0, 1);
+    }
+
+    #[test]
+    fn lanes_are_grouped_by_model_and_named_five_hour_first() {
+        // The shape the language server answered with on a real machine
+        let reply = serde_json::json!({ "response": { "groups": [
+            { "displayName": "Gemini Models", "buckets": [
+                { "bucketId": "gemini-weekly", "remainingFraction": 0.97 },
+                { "bucketId": "gemini-5h", "remainingFraction": 1.0 } ] },
+            { "displayName": "Claude and GPT models", "buckets": [
+                { "bucketId": "3p-weekly", "remainingFraction": 1.0 },
+                { "bucketId": "3p-5h", "remainingFraction": 1.0 } ] } ] } });
+        let lanes: Vec<String> = super::windows_from_bridge(&reply)
+            .into_iter()
+            .map(|w| format!("{} › {} ({})", w.group.unwrap_or_default(), w.label, w.id))
+            .collect();
+        assert_eq!(
+            lanes,
+            [
+                "Gemini Models › 5-hour Limit (gemini-5h)",
+                "Gemini Models › Weekly Limit (gemini-weekly)",
+                "Claude and GPT models › 5-hour Limit (3p-5h)",
+                "Claude and GPT models › Weekly Limit (3p-weekly)",
+            ]
+        );
     }
 }

--- a/windows/codenotch/src/main.rs
+++ b/windows/codenotch/src/main.rs
@@ -27,7 +27,7 @@ use tauri::{AppHandle, Emitter, Manager};
 pub const NOTCH_W: f64 = 340.0;
 /// Hand-bumped build tag, written to run.log at startup so a log can always be matched to the exe that wrote it.
 pub const BUILD: &str = "r31";
-pub const NOTCH_H: f64 = 460.0; // 300 clipped the card once it held three window blocks plus the session list
+pub const NOTCH_H: f64 = 520.0; // 300 clipped the card once it held three window blocks plus the session list; 460 clipped Antigravity's two model groups once the reading was stale and an agent was working
 
 pub struct AppState {
     pub store: Mutex<state::Store>,

--- a/windows/codenotch/src/main.rs
+++ b/windows/codenotch/src/main.rs
@@ -23,8 +23,9 @@ mod watcher;
 use std::sync::Mutex;
 use tauri::{AppHandle, Emitter, Manager};
 
-/// Logical size of the notch window: the 70 pt pill column on the right plus room for the hover card on the left.
-pub const NOTCH_W: f64 = 340.0;
+/// Logical size of the notch window: the 70 pt pill column on the right plus room for the hover card
+/// and its tail on the left. `fitZoom` in ui/notch.html divides by the same width.
+pub const NOTCH_W: f64 = 360.0;
 /// Hand-bumped build tag, written to run.log at startup so a log can always be matched to the exe that wrote it.
 pub const BUILD: &str = "r31";
 pub const NOTCH_H: f64 = 520.0; // 300 clipped the card once it held three window blocks plus the session list; 460 clipped Antigravity's two model groups once the reading was stale and an agent was working
@@ -1204,13 +1205,21 @@ mod tests {
     }
 
     #[test]
-    fn the_shipped_pill_and_card_have_no_cold_strip_between_them() {
-        // The 15 px gap is narrower than the 20 px the two pads bring, so the pads already bridge
-        // it and the bounding box never fires for the shipped layout. Pinned: if that stops being
-        // true the crossing starts depending on the bounding box, and the card blinks out mid-travel.
-        let x = (CARD[0] + CARD[2] + PILL[0]) / 2.0;
-        assert!(cursor_in_hot(&[PILL, CARD], x, 250.0, WINDOW));
-        const { assert!(PILL[0] - (CARD[0] + CARD[2]) < 2.0 * HOT_PAD) };
+    fn the_tail_leaves_no_cold_strip_between_the_pill_and_the_card() {
+        // The shipped layout at 150 %, from the CSS: the card stops 100 px from the edge and the
+        // tail spans the rest, its tip under the pill's edge. A pointer crossing along the tail is
+        // hot on one rectangle alone at every step, so it never leans on the bounding box.
+        const WIDE: Option<(f64, f64)> = Some((540.0, 690.0));
+        const WIDE_PILL: [f64; 4] = [435.0, 183.5, 105.0, 323.0];
+        const TAIL: [f64; 4] = [388.5, 318.0, 48.0, 54.0];
+        let y = TAIL[1] + TAIL[3] / 2.0;
+        for x in (CARD[0] + CARD[2]) as i32..WIDE_PILL[0] as i32 {
+            let x = x as f64;
+            assert!(
+                [WIDE_PILL, TAIL, CARD].iter().any(|r| cursor_in_hot(&[*r], x, y, WIDE)),
+                "cold at x={x}"
+            );
+        }
     }
 
     /// Far enough apart that the pads do not meet — the case the bounding box exists for.

--- a/windows/codenotch/src/usage.rs
+++ b/windows/codenotch/src/usage.rs
@@ -58,6 +58,10 @@ pub struct LimitWindow {
     /// The number is ours, not the vendor's (upstream fidelity=.derived) — the card adds a ~ prefix
     #[serde(default)]
     pub derived: bool,
+    /// The heading the window sits under on the card, for a provider that reports the same windows
+    /// for several things (Antigravity: a 5-hour and a weekly lane per model family). None = ungrouped
+    #[serde(default)]
+    pub group: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]

--- a/windows/codenotch/ui/notch.html
+++ b/windows/codenotch/ui/notch.html
@@ -87,6 +87,8 @@
   .w-track{height:4px;border-radius:2px;background:#2d2d2d;margin:6px 0 4px;overflow:hidden}
   .w-fill{height:100%;border-radius:2px}
   .w-used{font-size:11px;color:#808080}
+  .g-head{font-size:12px;font-weight:700;color:#e8e8ea;margin-top:12px}
+  .g-box{border:1px solid #242424;border-radius:10px;padding:0 10px 8px;margin-top:6px}
   .c-note{font-size:12px;color:#c8c8c8;line-height:1.5;margin-top:6px}
   .c-sessions{margin-top:12px;border-top:1px solid #1e1e1e;padding-top:8px}
   .s-row{display:flex;align-items:center;gap:6px;font-size:11px;color:#b0b0b3;padding:2px 0}
@@ -140,6 +142,9 @@ const RU_TEXT={
   'Weekly limit':'Недельный лимит',
   'Weekly Limit':'Недельный лимит',
   '5-Hour Limit':'Лимит на 5 часов',
+  '5-hour Limit':'Лимит на 5 часов',
+  'Gemini Models':'Модели Gemini',
+  'Claude and GPT models':'Модели Claude и GPT',
   'Monthly limit':'Месячный лимит',
   'Monthly Limit':'Месячный лимит',
   'Longer window':'Более длительный период',
@@ -362,7 +367,14 @@ function renderCard(){
   }else if(!snap.windows.length){
     html+=`<div class="c-note">${esc(textCopy(snap.note||'Waiting for first reading…'))}</div>`;
   }else{
+    // Windows that share a group (Antigravity's model families) sit in one box under its name, as on the Mac
+    let group=null;
     for(const w of snap.windows){
+      if((w.group||null)!==group){
+        if(group) html+=`</div>`;
+        group=w.group||null;
+        if(group) html+=`<div class="g-head">${esc(textCopy(group))}</div><div class="g-box">`;
+      }
       if(w.count!=null){
         html+=`<div class="win"><div class="w-row"><span class="w-label">${esc(textCopy(w.label))}</span></div>
           <div class="w-used">${w.count>0?`~${w.count} ${textCopy(w.count===1?'request today':'requests today')}`:textCopy('no requests today')}</div></div>`;
@@ -374,6 +386,7 @@ function renderCard(){
         <div class="w-used">${w.derived?'~':''}${Math.round(w.used*100)}% ${textCopy('Used')}</div>
       </div>`;
     }
+    if(group) html+=`</div>`;
     if(snap.note) html+=`<div class="c-note">${esc(textCopy(snap.note))}</div>`;
   }
   if(p.id==='claude'){ // live sessions (a full list with jump-to-session is a follow-up)

--- a/windows/codenotch/ui/notch.html
+++ b/windows/codenotch/ui/notch.html
@@ -63,7 +63,7 @@
 
   /* Hover card, shown to the left of the pill */
   #card{
-    position:absolute;left:10px;right:80px;top:50%;transform:translateY(-50%);--tail:50%;
+    position:absolute;left:10px;right:100px;top:50%;transform:translateY(-50%);
     /* Anchored on both sides = fluid width: whatever the WebView's real logical width, the card cannot
        extend past the window's left edge (a fixed max-width got clipped when the DPI disagreed).
        The 246 cap matches the upstream spec. */
@@ -73,10 +73,15 @@
     display:none;
   }
   #card.show{display:block}
-  #card::after{ /* solid triangle pointing at the pill */
-    content:"";position:absolute;right:-8px;top:var(--tail);transform:translateY(-50%);
-    border:8px solid transparent;border-right:none;border-left:10px solid #0a0a0a;
+  /* The tail, its point on the hovered ring: the Mac's curved wedge (TooltipTail), whose shoulders
+     leave the card tangent to its edge so the two read as one shape. An element of its own rather
+     than ::after, so the card's overflow cannot clip it and it can be reported as hot. It spans the
+     whole gap, its tip tucked 1 px under the pill's edge so the two meet. */
+  #tail{
+    position:absolute;right:69px;width:32px;height:36px;background:#0a0a0a;display:none;
+    clip-path:path('M0 0C0 9 18.56 13.68 32 18C18.56 22.32 0 27 0 36Z');
   }
+  #card.show + #tail{display:block}
   .c-head{display:flex;align-items:center;gap:8px;margin-bottom:4px}
   .c-title{font-size:14px;font-weight:700}
   .c-sub{font-size:11px;color:#808080;margin-bottom:10px}
@@ -111,6 +116,7 @@
 <body>
 <div id="root">
   <div id="card"></div>
+  <div id="tail"></div>
   <div id="pill"></div><!-- one .cell per provider, stacked vertically (upstream: data-driven, the same layout for 1–5 cells) -->
   <div id="notice"></div>
 </div>
@@ -422,13 +428,16 @@ function placeCard(){
   const H=innerHeight, ch=card.offsetHeight||0;
   let top=Math.round(cy-ch/2); top=Math.max(8,Math.min(top,H-ch-8));
   card.style.top=top+'px'; card.style.transform='none';
-  card.style.setProperty('--tail',Math.max(16,Math.min(ch-16,Math.round(cy-top)))+'px');
+  // The tail's point on the hovered ring (not the cell, which includes the label below it), kept off the card's rounded corners
+  const rr=(cell.querySelector('.ringwrap')||cell).getBoundingClientRect(), ry=rr.top+rr.height/2;
+  const th=tail.offsetHeight||36, ty=Math.max(top+16+th/2,Math.min(top+ch-16-th/2,ry));
+  tail.style.top=Math.round(ty-th/2)+'px';
 }
 
 function esc(s){const d=document.createElement('div');d.textContent=s||'';return d.innerHTML;}
 
 /* Hover: stays expanded while either the pill or the card is under the cursor; collapses after a 250 ms grace period (upstream motion rule) */
-const card=document.getElementById('card'), pill=document.getElementById('pill');
+const card=document.getElementById('card'), pill=document.getElementById('pill'), tail=document.getElementById('tail');
 let hideTimer=null;
 function showCard(){clearTimeout(hideTimer);card.classList.add('show');renderCard();armWatchdog();} // show first, then render: placeCard needs offsetHeight
 function hideCard(){card.classList.remove('show');reportHot();}
@@ -444,7 +453,7 @@ function rectOf(el){const r=el.getBoundingClientRect(),k=window.devicePixelRatio
    when the card opens: a stale pill rectangle is a pill that cannot be clicked. */
 function reportHot(){
   const open=card.classList.contains('show');
-  const rects=open?[rectOf(pill),rectOf(card)]:[rectOf(pill)];
+  const rects=open?[rectOf(pill),rectOf(tail),rectOf(card)]:[rectOf(pill)];
   callq('set_hot',{rects,expanded:open}).catch(()=>{});
 }
 /* ---- Notch size ---------------------------------------------------------
@@ -488,10 +497,10 @@ function loadScale(){
 function armWatchdog(){
   requestAnimationFrame(reportHot); // wait one frame so renderCard's new content is laid out before measuring
 }
-// Viewport fit (pure front-end fallback, independent of Rust): the window is 340 × primary scale physical px,
-// so if this page's CSS viewport is not 340 wide the WebView's DPR disagrees with the monitor; CSS zoom pulls the layout back to the design size.
+// Viewport fit (pure front-end fallback, independent of Rust): the window is NOTCH_W (360) × primary scale physical px,
+// so if this page's CSS viewport is not 360 wide the WebView's DPR disagrees with the monitor; CSS zoom pulls the layout back to the design size.
 function fitZoom(){
-  const z=innerWidth/340;
+  const z=innerWidth/360;
   document.documentElement.style.zoom=(Math.abs(z-1)>0.02)?String(z):'';
   return z;
 }


### PR DESCRIPTION
Two things on the Windows hover card didn't match the Mac, and both made it harder to read.

**Antigravity's lanes weren't told apart.** Antigravity reports a 5-hour and a weekly limit for Gemini models, and the same pair for Claude and GPT models. The card listed all four flat, each labelled with its group, so it read "Gemini Models" twice with nothing to say which lane was which. Now, as on the Mac:
- each model group is a heading, with its lanes in one box
- lanes are named **5-hour Limit** and **Weekly Limit**, 5-hour first
- both sources get this: the language server (`gemini-5h` IDs) and the `agy` CLI ("Gemini Models Five Hour Limit")

`LimitWindow` gains an optional `group`. A window without one draws as before, so the other providers don't change. The per-window lists in Settings (from #115) now show lane names without their group; #152 removes those lists.

Rebased on `main` after #141 landed Russian. The group heading and the lane names go through its `textCopy()`, and its dictionary gains the three labels this PR puts on the card — "5-hour Limit" and the two model group names — in the Mac catalog's own wording, so a Russian card reads «Лимит на 5 часов» under «Модели Gemini» rather than falling back to English.

**The tail never showed.** The card had a triangle meant to point at the hovered ring. It sat just outside the card, and the card's `overflow:hidden` clipped it. It's now an element of its own:
- drawn as the Mac's curved `TooltipTail` at the Windows card's scale, running from the card to the pill
- its tip on the hovered ring, not the middle of the cell and its label
- reported as part of the hot area, so crossing from the pill to the card along it stays hot at every step

The notch window grows from 340 × 460 to 360 × 520 logical pixels:
- **wider**, so the card keeps its 246 px width with the tail beside it. `fitZoom` divides by the same width.
- **taller**, because two groups plus a stale line and an activity row cut off the card's last row.

The extra area is transparent and click-through.

## Test plan

- [x] `cargo test`: 27 pass.
  - New: the language server's reply is grouped, named and ordered.
  - Updated: `agy_cli`'s parser tests, for the new names and order.
  - Rewritten: the click-through test, which now pins the tail layout.
- [x] `cargo clippy --all-targets`: the same 30 warnings as `main`.
- [x] Rendered `notch.html` in headless Edge with the bridge stubbed: grouped boxes, the tip on the hovered ring, and the worst case (stale plus working) fits.
- [x] The same render with the language set to Russian: «Модели Gemini» and «Модели Claude и GPT» over «Лимит на 5 часов» and «Недельный лимит».
- [x] Live on Windows 11 at 150 %: the grouped Antigravity card.
- [x] Live: the tail, hovering each ring and moving from the pill onto the card.
