### PR TITLE
Fix DeepSeek WebView origin validation

### DIFF
--- a/Sources/Providers/WebSessionProvider.swift
+++ b/Sources/Providers/WebSessionProvider.swift
@@ -137,6 +137,27 @@ final class WebSessionProvider: NSObject, UsageProvider {
 
     // MARK: - The browser
 
+    nonisolated static func matchesOrigin(_ url: URL?, expected origin: URL) -> Bool {
+        guard let url,
+              let scheme = url.scheme?.lowercased(),
+              let host = url.host?.lowercased(),
+              let expectedScheme = origin.scheme?.lowercased(),
+              let expectedHost = origin.host?.lowercased()
+        else { return false }
+        return scheme == expectedScheme
+            && host == expectedHost
+            && effectivePort(for: url) == effectivePort(for: origin)
+    }
+
+    private nonisolated static func effectivePort(for url: URL) -> Int? {
+        if let port = url.port { return port }
+        switch url.scheme?.lowercased() {
+        case "http": return 80
+        case "https": return 443
+        default: return nil
+        }
+    }
+
     private func makeWebViewIfNeeded() -> WKWebView {
         if let webView { return webView }
         let configuration = WKWebViewConfiguration()
@@ -175,11 +196,11 @@ final class WebSessionProvider: NSObject, UsageProvider {
 
     private func ensureLoaded() async throws {
         let webView = makeWebViewIfNeeded()
-        if isLoaded, webView.url != nil { return }
+        if isLoaded, Self.matchesOrigin(webView.url, expected: site.origin) { return }
         webView.load(URLRequest(url: site.origin))
         for _ in 0..<40 {
             try await Task.sleep(nanoseconds: 250_000_000)
-            if let host = webView.url?.host, host.contains(site.origin.host ?? ""), !webView.isLoading {
+            if Self.matchesOrigin(webView.url, expected: site.origin), !webView.isLoading {
                 isLoaded = true
                 return
             }
@@ -367,6 +388,7 @@ final class WebSessionProvider: NSObject, UsageProvider {
             for _ in 0..<240 {
                 try? await Task.sleep(nanoseconds: 1_000_000_000)
                 guard !Task.isCancelled, let self, let webView else { return }
+                guard Self.matchesOrigin(webView.url, expected: site.origin) else { continue }
                 let result = try? await webView.callAsyncJavaScript(
                     probe, arguments: [:], in: nil, contentWorld: .page
                 )

--- a/Tests/WebSessionSignInTests.swift
+++ b/Tests/WebSessionSignInTests.swift
@@ -42,4 +42,25 @@ final class WebSessionSignInTests: XCTestCase {
         XCTAssertFalse(UserDefaults.standard.bool(forKey: "deepseek.signedIn"),
                        "opening the sheet is not a sign-in for a site that can confirm one")
     }
+
+    func testDeepSeekOriginValidationRejectsContainingHostnames() {
+        let origin = Sites.deepSeek.origin
+        XCTAssertTrue(WebSessionProvider.matchesOrigin(origin, expected: origin))
+        XCTAssertTrue(WebSessionProvider.matchesOrigin(
+            URL(string: "HTTPS://PLATFORM.DEEPSEEK.COM:443/usage"), expected: origin
+        ))
+
+        for value in [
+            "https://platform.deepseek.com.attacker.example/",
+            "https://attacker-platform.deepseek.com/",
+            "http://platform.deepseek.com/",
+            "https://platform.deepseek.com:444/",
+            "https://[::1]/",
+            "https:/usage"
+        ] {
+            let url = URL(string: value)
+            XCTAssertNotNil(url, value)
+            XCTAssertFalse(WebSessionProvider.matchesOrigin(url, expected: origin), value)
+        }
+    }
 }


### PR DESCRIPTION
## Summary

- validate the loaded WebView URL with normalized, exact scheme and hostname comparisons
- compare effective ports so HTTPS and explicit `:443` are equivalent while non-default ports fail
- apply the same origin gate to cached loaded state and authentication probes
- add regression coverage for the expected DeepSeek origin and deceptive containing hostnames

## Verification

- `swiftc -parse Sources/Providers/WebSessionProvider.swift Tests/WebSessionSignInTests.swift`
- focused runtime origin matrix (expected/case/default-port pass; deceptive prefix/suffix, wrong scheme/port, IPv6, and missing host fail)
- independent ZCode read-only review: approved; `touchedFiles: []`, `readOnlyViolation: false`
- Full XCTest could not run locally because Xcode 26.6 hung in `SWBBuildService`; GitHub CI is awaiting maintainer approval.

Fixes #148
