### PR TITLE
Quiet clippy's sixteen doc-comment warnings in the Windows port

### DIFF
--- a/windows/codenotch/src/activity.rs
+++ b/windows/codenotch/src/activity.rs
@@ -17,6 +17,7 @@
 //!   - Antigravity: transcript.jsonl is appended during a run (each step is written only once it
 //!     completes, so status is always DONE and useless); written within the last 45 s = working
 //!     (the model can think for a long time between steps, hence the wide window).
+//!
 //! Polled every 2 s (upstream cadence), broadcast only on change. Cost discipline: database
 //! connections stay open, nothing is re-queried unless the file's mtime changed, the rollout tail
 //! is re-read only when its mtime changed, PowerShell runs only occasionally to find the network

--- a/windows/codenotch/src/codex.rs
+++ b/windows/codenotch/src/codex.rs
@@ -18,9 +18,9 @@
 //!      The reset is **resets_at, absolute seconds** (the documented resets_in_seconds is accepted
 //!      too). This is the number from the *last run* — reading a file always succeeds instantly, so
 //!      the reading is marked stale by the line's own timestamp (> 5 min).
-//!   Upstream finds the newest rollout through the thread index in state_5.sqlite; this port walks
-//!   the dated directories newest-first and picks by mtime, with no SQLite involved (and none of
-//!   the immutable/WAL pitfalls).
+//!      Upstream finds the newest rollout through the thread index in state_5.sqlite; this port
+//!      walks the dated directories newest-first and picks by mtime, with no SQLite involved (and
+//!      none of the immutable/WAL pitfalls).
 //!
 //! Credentials are borrowed, never managed: the numbers come from Codex's own sign-in and Codex's
 //! own endpoint. No sign-in and no session history at all means absent (no cell is shown).

--- a/windows/codenotch/src/cursor.rs
+++ b/windows/codenotch/src/cursor.rs
@@ -7,9 +7,12 @@
 //!      `WorkosCursorSessionToken=<authId>::<token>`. Non-secret identity cache:
 //!      `cursorAuth/cachedEmail`, `cursorAuth/stripeMembershipType` (only the plan is shown).
 //!   2. Endpoint: `GET https://cursor.com/api/usage-summary` (Cookie + Accept: application/json, 15 s).
-//!      Reply: { billingCycleEnd, membershipType, isUnlimited,
-//!              individualUsage: { plan: { totalPercentUsed, apiPercentUsed, used, limit, breakdown },
-//!                                 onDemand: { enabled, used, limit } } }
+//!      Reply:
+//!      ```text
+//!      { billingCycleEnd, membershipType, isUnlimited,
+//!        individualUsage: { plan: { totalPercentUsed, apiPercentUsed, used, limit, breakdown },
+//!                           onDemand: { enabled, used, limit } } }
+//!      ```
 //!      Cursor meters a percentage of the allowance, not requests: the dashboard's
 //!      "Included usage · N% used" is totalPercentUsed. On the free plan used/limit are always 0
 //!      (the allowance arrives as breakdown.bonus), so reading used/limit would report 10 % as 0 %.

--- a/windows/codenotch/src/glyphs.rs
+++ b/windows/codenotch/src/glyphs.rs
@@ -4,8 +4,9 @@
 //!   1. User override: `%APPDATA%\codenotch\glyphs\<id>.svg|.png`, or `glyphs\` next to the exe;
 //!   2. Built in: the `glyphs/*.svg` compiled into the exe, from npm `@lobehub/icons-static-svg`
 //!      1.95.0 (MIT), files unmodified; trademark notice in glyphs/NOTICE.md;
-//!   3. The installed application's own icon (PrivateExtractIconsW on the exe resources, 64 px → PNG);
-//!   none of those → the page falls back to a letter.
+//!   3. The installed application's own icon (PrivateExtractIconsW on the exe resources, 64 px → PNG).
+//!
+//! None of those → the page falls back to a letter.
 //! SVGs are inlined into the DOM as text (`fill="currentColor"` follows the CSS white/dimmed state);
 //! PNGs and app icons go through <img>. Ids match the page and upstream: claude / codex / cursor / gemini.
 

--- a/windows/codenotch/src/usage.rs
+++ b/windows/codenotch/src/usage.rs
@@ -6,6 +6,7 @@
 //!   - 401/403 → re-read the credential once and retry (Claude Code may have just refreshed the token) → still failing means needsAuth
 //!   - 429 → back off 60 s × 2^n capped at 15 min, Retry-After only raises it; the deadline is persisted
 //!   - never invent a percentage on failure: keep the last reading marked stale, and the UI shows how old it is
+//!
 //! Reply (snake_case): { limits:[{kind,percent,resets_at}], five_hour:{utilization,resets_at}, seven_day:{...} }
 //! limits is the forward-compatible main shape; five_hour/seven_day are merged in as a fallback (a window that just rolled over disappears from limits).
 

--- a/windows/codenotch/src/watcher.rs
+++ b/windows/codenotch/src/watcher.rs
@@ -5,6 +5,7 @@
 //!   - the file is being appended                              → running
 //!   - last line = plain assistant text, quiet for > 2.5 s     → done
 //!   - last line = assistant tool_use, quiet for > 20 s        → attention (waiting for approval; inferred, a slow tool can be misread)
+//!
 //! Arbitration: a session with fresh hook data in state.rs (within 5 min) ignores this inference
 //! (the CLI's hooks are more accurate).
 


### PR DESCRIPTION
cargo clippy --all-targets` reports 28 warnings on `windows/`. Sixteen of them say nothing about the code: `doc_lazy_continuation`, where a line following a list gets folded into the last item, because markdown reads it as a lazy continuation of that bullet. The module headers in this tree are the main documentation of how each provider is read, so a paragraph silently becoming part of the last bullet is a real loss of meaning — `usage.rs`'s reply shape currently renders as part of the "never invent a percentage" rule.

Now that #147 runs clippy on every pull request touching `windows/`, these sixteen are noise in front of the twelve that do concern code.

Each one is fixed the way that keeps the prose true, rather than whichever way silences the lint:

| file | what it was | fix |
|---|---|---|
| `usage.rs`, `activity.rs`, `watcher.rs` | a new paragraph after a bullet list | a blank `//!` line to close the list — indenting would have folded prose into the last bullet |
| `codex.rs` | a remark that really does continue item 2 | indented to item 2's column |
| `glyphs.rs` | a trailing "none of those →" clause after a numbered list | closed the list, and the clause joins the paragraph below it |
| `cursor.rs` | the JSON reply, aligned by hand | wrapped in a `text` fence. Clippy suggested five spaces, which would have flattened the alignment that shows the nesting |

Comments only. No code, no behaviour, no public API.

## Test plan

- [x] `cargo clippy --all-targets`: 28 warnings → **12**, and the twelve that remain are the code lints, unchanged.
- [x] The `text` fence adds no new warning, and rustdoc will not try to run it as a doctest.
- [x] `cargo test`: 26 pass, 1 ignored (the live `agy` test) — unchanged.
- [x] Read the six headers back: every list still reads as a list, and every paragraph as a paragraph.

The other twelve are code, and they are in a sibling PR. Kept separate because this one can be reviewed by reading the prose, while those want the tests and CI behind them. The two touch different regions of the same files and merge cleanly in either order; with both in, `windows/` is at **0** warnings — at which point `-D warnings` for the Windows job becomes an option, if you would rather a new warning failed the build than scrolled past.