### PR TITLE
Bring the Windows README up to date with the settings window and CI

### DIFF
--- a/windows/README.md
+++ b/windows/README.md
@@ -43,8 +43,10 @@ cargo build --release
 .\target\release\codenotch.exe doctor   # self-diagnosis: credentials, data sources, icons, hooks
 ```
 
-Tray menu: refresh now, reset position, open data folder (`%APPDATA%\codenotch` — logs,
-persisted readings, icon overrides), start with Windows, install/uninstall Claude Code hooks.
+Tray menu: **Settings…**, **Refresh usage now**, **Quit**. Everything else is in the settings
+window: the taskbar icon, which rings the notch shows, its size, start with Windows, the
+language, Claude Code hooks, reset position, and the data folder (`%APPDATA%\codenotch` —
+logs, persisted readings, icon overrides).
 
 ### Icons
 
@@ -59,10 +61,15 @@ The marks remain the trademarks of their owners.
 .
 ├── codenotch/          Tauri 2 app: window, tray, providers (usage.rs, codex.rs, cursor.rs, antigravity.rs),
 │   ├── src/            session engine (watcher.rs, state.rs, focus.rs), glyphs.rs, doctor.rs
-│   ├── ui/notch.html   the pill + hover card (single file, no framework)
+│   ├── ui/             notch.html — the pill + hover card; settings.html — the settings window
+│   │                   (both single files, no framework)
 │   └── glyphs/         provider marks (+ NOTICE.md)
 └── codenotch-hook/     <5 ms hook messenger Claude Code calls; forwards events to the app
 ```
+
+A pull request that touches `windows/` builds this tree and runs its tests and clippy:
+[`.github/workflows/windows.yml`](../.github/workflows/windows.yml). It is skipped inside
+forks, so the check appears once the pull request is open here.
 
 ## Relationship to upstream
 


### PR DESCRIPTION
Three things in `windows/README.md` describe a build that no longer exists.

**The tray menu.** The README lists it as "refresh now, reset position, open data folder, start with Windows, install/uninstall Claude Code hooks". Since #115 the menu is **Settings… · Refresh usage now · Quit**, and everything else moved into the settings window. Someone following the README looks for items that aren't there.

**The layout tree** names `ui/notch.html` as the app's only page. `ui/settings.html` has been beside it since #115 and is the larger of the two, so it's now listed.

**CI.** #147 added `.github/workflows/windows.yml`, which builds this tree and runs its tests and clippy on every pull request touching `windows/`. Nothing pointed at it from here, so a contributor had no way to know their PR gets a Windows check.

Documentation only — no code, no behaviour change.

## Test plan

- [x] Read back against the source: `tray.rs` builds exactly `settings`, `refresh`, `quit`, and the labels quoted are the `(_, …)` defaults in `i18n.rs`.
- [x] The moved items are the ones the settings window actually offers: `sw-autostart`, `sw-hooks`, `lang`, `btn-resetpos`, `btn-data`.
- [x] The workflow path and its `paths` filter match what #147 merged.
- [x] Markdown renders: the layout block is still a fenced code block and the new link resolves from `windows/` to the repo root.
