### PR TITLE
Take clippy's twelve code suggestions in the Windows port

### DIFF
--- a/windows/codenotch/src/activity.rs
+++ b/windows/codenotch/src/activity.rs
@@ -182,7 +182,7 @@ fn cursor_activity(ctx: &mut Ctx) -> Vec<Activity> {
                 since,
             });
         }
-        out.sort_by(|a, b| b.since.cmp(&a.since));
+        out.sort_by_key(|a| std::cmp::Reverse(a.since));
         Some(out)
     })
 }
@@ -435,7 +435,7 @@ fn claude_io_bytes() -> Option<(u64, u64)> {
     let mut other = 0u64;
     let mut read = 0u64;
     let mut n = 0;
-    for (pid, _name) in maps.name.iter() {
+    for pid in maps.name.keys() {
         if *pid != net_pid {
             continue;
         }
@@ -595,7 +595,7 @@ pub fn start(app: AppHandle) {
         let mut tick: u32 = 0;
         loop {
             // Presence checks (finding the exe, reading credentials) once a minute are plenty; the 2 s tick does only stats and a query
-            if tick % 30 == 0 {
+            if tick.is_multiple_of(30) {
                 pres = presence();
             }
             tick = tick.wrapping_add(1);

--- a/windows/codenotch/src/antigravity.rs
+++ b/windows/codenotch/src/antigravity.rs
@@ -351,7 +351,7 @@ fn read_credential_raw() -> Option<Vec<u8>> {
 fn decode_credential(raw: &[u8]) -> Option<Creds> {
     let mut text = String::from_utf8(raw.to_vec()).unwrap_or_else(|_| {
         // Some writers store the blob as UTF-16LE
-        let u16s: Vec<u16> = raw.chunks_exact(2).map(|c| u16::from_le_bytes([c[0], c[1]])).collect();
+        let u16s: Vec<u16> = raw.as_chunks::<2>().0.iter().map(|c| u16::from_le_bytes(*c)).collect();
         String::from_utf16_lossy(&u16s)
     });
     text = text.trim_matches('\0').trim().to_string();

--- a/windows/codenotch/src/config.rs
+++ b/windows/codenotch/src/config.rs
@@ -134,7 +134,7 @@ pub fn load() -> Config {
     let raw = std::fs::read_to_string(&path).ok();
     let mut cfg: Config = raw
         .as_deref()
-        .and_then(|t| serde_json::from_str(&t).ok())
+        .and_then(|t| serde_json::from_str(t).ok())
         .unwrap_or_default();
 
     // Discoverability without surprising anyone. `default_tray_mode` gives a NEW install the

--- a/windows/codenotch/src/glyphs.rs
+++ b/windows/codenotch/src/glyphs.rs
@@ -56,8 +56,7 @@ fn sanitize_svg(s: &str) -> String {
     let lo = out.to_ascii_lowercase();
     let mut res = String::with_capacity(out.len());
     let mut i = 0;
-    loop {
-        let Some(rel) = lo[i..].find(" on") else { break };
+    while let Some(rel) = lo[i..].find(" on") {
         let start = i + rel;
         let name_len = lo[start + 3..].bytes().take_while(|b| b.is_ascii_alphanumeric()).count();
         let eq = start + 3 + name_len;
@@ -98,7 +97,7 @@ pub fn user_dir() -> PathBuf {
 
 fn b64(bytes: &[u8]) -> String {
     const T: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
-    let mut out = String::with_capacity((bytes.len() + 2) / 3 * 4);
+    let mut out = String::with_capacity(bytes.len().div_ceil(3) * 4);
     for chunk in bytes.chunks(3) {
         let b = [chunk[0], *chunk.get(1).unwrap_or(&0), *chunk.get(2).unwrap_or(&0)];
         let n = ((b[0] as u32) << 16) | ((b[1] as u32) << 8) | b[2] as u32;
@@ -205,14 +204,16 @@ fn from_exe(p: &Path) -> Option<Glyph> {
             let (w, h) = (bm.bmWidth, bm.bmHeight);
             if w > 0 && h > 0 && w <= 512 && h <= 512 {
                 let hdc = GetDC(None);
-                let mut bi = BITMAPINFO::default();
-                bi.bmiHeader = BITMAPINFOHEADER {
-                    biSize: std::mem::size_of::<BITMAPINFOHEADER>() as u32,
-                    biWidth: w,
-                    biHeight: -h, // top-down
-                    biPlanes: 1,
-                    biBitCount: 32,
-                    biCompression: BI_RGB.0,
+                let mut bi = BITMAPINFO {
+                    bmiHeader: BITMAPINFOHEADER {
+                        biSize: std::mem::size_of::<BITMAPINFOHEADER>() as u32,
+                        biWidth: w,
+                        biHeight: -h, // top-down
+                        biPlanes: 1,
+                        biBitCount: 32,
+                        biCompression: BI_RGB.0,
+                        ..Default::default()
+                    },
                     ..Default::default()
                 };
                 let mut buf = vec![0u8; (w * h * 4) as usize];
@@ -220,8 +221,8 @@ fn from_exe(p: &Path) -> Option<Glyph> {
                 let _ = ReleaseDC(None, hdc);
                 if lines > 0 {
                     // BGRA → RGBA; old-style icons with all-zero alpha are treated as opaque
-                    let any_alpha = buf.chunks_exact(4).any(|px| px[3] != 0);
-                    for px in buf.chunks_exact_mut(4) {
+                    let any_alpha = buf.as_chunks::<4>().0.iter().any(|px| px[3] != 0);
+                    for px in buf.as_chunks_mut::<4>().0 {
                         px.swap(0, 2);
                         if !any_alpha {
                             px[3] = 255;

--- a/windows/codenotch/src/server.rs
+++ b/windows/codenotch/src/server.rs
@@ -39,7 +39,7 @@ pub fn start(app: AppHandle, port: u16) {
 }
 
 fn query_param(url: &str, key: &str) -> String {
-    let q = url.splitn(2, '?').nth(1).unwrap_or("");
+    let q = url.split_once('?').map(|x| x.1).unwrap_or("");
     for pair in q.split('&') {
         let mut it = pair.splitn(2, '=');
         if it.next() == Some(key) {

--- a/windows/codenotch/src/watcher.rs
+++ b/windows/codenotch/src/watcher.rs
@@ -103,7 +103,7 @@ pub fn roots() -> Vec<PathBuf> {
 
 /// Accept only real session transcripts: inside a .claude tree, excluding audit logs and sub-agents
 pub fn is_session_jsonl(p: &Path) -> bool {
-    if p.extension().map(|e| e == "jsonl").unwrap_or(false) == false {
+    if !p.extension().map(|e| e == "jsonl").unwrap_or(false) {
         return false;
     }
     let name = p.file_name().map(|s| s.to_string_lossy().to_string()).unwrap_or_default();


### PR DESCRIPTION
`cargo clippy --all-targets` reports 28 warnings on `windows/`. Twelve concern code, and each names a clearer way to say the same thing. None changes behaviour:

| file | was | now |
|---|---|---|
| `watcher.rs` | `...unwrap_or(false) == false` | `!...unwrap_or(false)` |
| `config.rs` | `from_str(&t)`, where `as_deref()` already gave a `&str` | `from_str(t)` |
| `server.rs` | `url.splitn(2, '?').nth(1)` | `url.split_once('?').map(\|x\| x.1)` |
| `glyphs.rs` | `(bytes.len() + 2) / 3`, rounding up by hand | `bytes.len().div_ceil(3)` |
| `glyphs.rs` | a `loop` whose only exit was a let-else `break` | `while let Some(rel) = ...` |
| `glyphs.rs` | `bi.bmiHeader = ...` after `BITMAPINFO::default()` | the header built in the initializer |
| `glyphs.rs` | `chunks_exact(4)` / `chunks_exact_mut(4)` over BGRA pixels | `as_chunks::<4>()` / `as_chunks_mut::<4>()`, which types a pixel as `[u8; 4]` |
| `antigravity.rs` | `chunks_exact(2)` then `from_le_bytes([c[0], c[1]])` | `as_chunks::<2>()`, so the pair is already an array |
| `activity.rs` | `sort_by(\|a, b\| b.since.cmp(&a.since))` | `sort_by_key(\|a\| Reverse(a.since))`, keeping newest first |
| `activity.rs` | `for (pid, _name) in maps.name.iter()` | `for pid in maps.name.keys()` |
| `activity.rs` | `tick % 30 == 0` | `tick.is_multiple_of(30)` |

`as_chunks` and `is_multiple_of` are stable since 1.88 and 1.87, which raises no minimum here: `darling`, `image`, `plist` and `time` in the lock file already require 1.88, so any toolchain that compiles this crate has both. The crate declares no `rust-version` — worth adding one if you'd rather pin it, but that felt like a separate decision.

## Test plan

- [x] `cargo test`: 26 pass, 1 ignored (the live `agy` test) — unchanged. The `sort_by_key`, `split_once` and UTF-16 `as_chunks` rewrites are the ones a test would catch.
- [x] `cargo clippy --all-targets`: 28 → **16** on this branch, 0 errors, and every warning left is `doc_lazy_continuation`.
- [x] Checked by hand where a rewrite could shift meaning: the sort stays newest-first (`Reverse`), `as_chunks().0` keeps `chunks_exact`'s habit of ignoring a short tail, the `while let` loop had no other exit, and `bi` is still `mut` for `GetDIBits`.

The sibling PR removes those 16, all of them `doc_lazy_continuation` in the module headers. The two touch different regions of the same files and merge cleanly in either order. With both in, `windows/` is at **0** warnings — at which point `-D warnings` for the Windows job becomes possible, if you want new warnings to fail the build rather than scroll past.