### PR TITLE
Track SwiftPM resolution for reproducible macOS builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,3 +34,6 @@ jobs:
       # read fixtures rather than keychains — see `make test-ci`.
       - name: Run unit tests
         run: make test-ci
+
+      - name: Verify SwiftPM resolution
+        run: make verify-deps

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ endif
 
 PROJECT := Codenotch.xcodeproj
 SCHEME  := Codenotch
+RESOLVED_PACKAGES := $(PROJECT)/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
 ARCH    ?= $(shell uname -m)
 DEST    ?= platform=macOS,arch=$(ARCH)
 
@@ -53,10 +54,12 @@ DEV_SIGN := CODE_SIGN_IDENTITY="Apple Development" CODE_SIGN_STYLE=Manual \
 endif
 endif
 
-.PHONY: gen build test test-ci run install clean
+.PHONY: gen build test test-ci verify-deps run install clean
 
 gen:
 	xcodegen generate
+	mkdir -p $(dir $(RESOLVED_PACKAGES))
+	cp Package.resolved $(RESOLVED_PACKAGES)
 
 build: gen
 	xcodebuild -project $(PROJECT) -scheme $(SCHEME) -destination '$(DEST)' \
@@ -73,6 +76,15 @@ test-ci: gen
 	xcodebuild -project $(PROJECT) -scheme $(SCHEME) -destination '$(DEST)' \
 		-configuration Debug test \
 		CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
+
+verify-deps:
+	rm -rf $(PROJECT)
+	$(MAKE) gen
+	xcodebuild -resolvePackageDependencies -project $(PROJECT) -scheme $(SCHEME)
+	@diff -u Package.resolved $(RESOLVED_PACKAGES) || { \
+		echo "SwiftPM resolution drifted; intentionally update Package.resolved and commit it if dependencies changed."; \
+		exit 1; \
+	}
 
 run: build
 	@APP=$$(xcodebuild -project $(PROJECT) -scheme $(SCHEME) -destination '$(DEST)' \

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,51 @@
+{
+  "originHash" : "f2c082e01c441724bfcd49e025677691786d54131b2c0ab45d6a03e072705d65",
+  "pins" : [
+    {
+      "identity" : "sparkle",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/sparkle-project/Sparkle",
+      "state" : {
+        "revision" : "ac2def288cbff5cfc7df3ffef6abdf45b72bcb0a",
+        "version" : "2.9.6"
+      }
+    },
+    {
+      "identity" : "swift-atomics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-atomics.git",
+      "state" : {
+        "revision" : "0442cb5a3f98ab802acb777929fdb446bda11a34",
+        "version" : "1.3.1"
+      }
+    },
+    {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections.git",
+      "state" : {
+        "revision" : "a0cb0954ecb21e4e31b0070e6ed5674e8556685a",
+        "version" : "1.6.0"
+      }
+    },
+    {
+      "identity" : "swift-nio",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio",
+      "state" : {
+        "revision" : "a931f2c1de8dd49381ce3bf2e279d033f68d8865",
+        "version" : "2.102.0"
+      }
+    },
+    {
+      "identity" : "swift-system",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-system.git",
+      "state" : {
+        "revision" : "869129b7bf4ecc57b97d0193ad29690ca2134750",
+        "version" : "1.8.1"
+      }
+    }
+  ],
+  "version" : 3
+}


### PR DESCRIPTION
## Summary

`project.yml` pins `SwiftNIO` and `Sparkle` to floating `from:` lower bounds, and the `Package.resolved` that Xcode actually writes/reads (nested inside the gitignored `Codenotch.xcodeproj`) was never tracked. Two clean checkouts at different times could therefore resolve different dependency graphs — confirmed directly: a fresh resolution today picked Sparkle 2.9.6 even though `project.yml`'s floor is 2.6.0.

## Resolution strategy

- Commit the resolved dependency graph as `Package.resolved` at the repo root (mirrors the existing `windows/Cargo.lock` precedent next to `windows/Cargo.toml`).
- `make gen` now copies that tracked file into `Codenotch.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved` right after `xcodegen generate`, before anything resolves packages — Xcode/SwiftPM then treats the seeded file as an existing lock rather than re-resolving from the floating floors.
- A new `make verify-deps` target (wired into CI) deletes the generated project, regenerates it, explicitly resolves packages, and diffs the result against the tracked root file — failing the build if resolution drifts, with a message telling the contributor to intentionally update and commit `Package.resolved` if they meant to change dependencies.
- `.gitignore`'s `*.xcodeproj` rule is untouched; only the new root-level file becomes tracked, so the generated project stays fully out of source control.
- `project.yml`'s `from:` floors are unchanged — no dependency was upgraded beyond what natural first-resolution already produced.

## Changed files

- `Package.resolved` (new) — tracked resolution: SwiftNIO 2.102.0, Sparkle 2.9.6, and transitive `swift-atomics`, `swift-collections`, `swift-system`.
- `Makefile` — `gen` seeds the tracked lock into the generated project; new `verify-deps` target.
- `.github/workflows/ci.yml` — new "Verify SwiftPM resolution" step running `make verify-deps`.

## Verification

- `xcodegen generate` run in-place (project already exists): no-op on the nested `Package.resolved` (byte-identical, confirmed via `shasum`).
- Simulated clean checkout: delete `Codenotch.xcodeproj`, `make gen`, `xcodebuild -resolvePackageDependencies` → resolves the exact pinned graph, `diff` against the tracked file produces no output (exit 0).
- `make verify-deps` — exit 0.
- `make test-ci` — **1325 tests, 0 failures (3 skipped), `** TEST SUCCEEDED **`.**
- `git status` after generation confirms no `.xcodeproj`/`.xcworkspace`/`DerivedData`/`build` artifacts are tracked or staged.

## Limitations

- Local `make test-ci` runs intermittently stalled in Xcode 26.6's `SWBBuildService` at the same toolchain-probe step already documented in #156's PR description; restarting the build service resolved it locally, and it's unrelated to dependency resolution. GitHub's `macos-26` CI runner should not carry this stale daemon state.

Fixes #161
