### PR TITLE
Improve recenter button feedback

### DIFF
--- a/Sources/Settings/SettingsView.swift
+++ b/Sources/Settings/SettingsView.swift
@@ -156,6 +156,10 @@ struct SettingsView: View {
     /// A gesture for this sitting, not a setting: the sidebar comes back on
     /// the next open, the same way a window's own sidebar toggle behaves.
     @State private var isSidebarVisible = true
+    /// A short-lived acknowledgement for the recenter action. The notch may
+    /// already be centred, in which case the action has no visible movement;
+    /// the acknowledgement keeps the button from feeling inert.
+    @State private var didRecentre = false
     /// Switching off has to reach the store's archive, not just the preference
     /// — see `UsageStore.signOut(providerID:)`.
     let signOut: (String) -> Void
@@ -654,8 +658,26 @@ struct SettingsView: View {
                         .foregroundStyle(.secondary)
                         .fixedSize(horizontal: false, vertical: true)
                     Spacer()
-                    Button(L10n.t("Recentre"), action: resetPosition)
-                        .controlSize(.small)
+                    Button {
+                        resetPosition()
+                        withAnimation(.easeInOut(duration: 0.15)) {
+                            didRecentre = true
+                        }
+                        Task { @MainActor in
+                            try? await Task.sleep(nanoseconds: 1_200_000_000)
+                            guard !Task.isCancelled else { return }
+                            withAnimation(.easeInOut(duration: 0.15)) {
+                                didRecentre = false
+                            }
+                        }
+                    } label: {
+                        Label(
+                            L10n.t("Recentre"),
+                            systemImage: didRecentre ? "checkmark" : "arrow.counterclockwise"
+                        )
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .controlSize(.small)
                 }
 
                 // The arc above the notch. Hiding it loses nothing that cannot


### PR DESCRIPTION
## Summary

Improve the visual feedback of the “Recentre” button in Settings.

When the button is clicked, it now:

- Uses a prominent button style
- Changes the icon from `arrow.counterclockwise` to `checkmark`
- Animates the feedback transition
- Automatically restores the original icon after 1.2 seconds

This makes the action feel responsive even when the window is already centered and does not visibly move.

## Testing

- [x] Ran the test suite with `xcodebuild`
- [x] 1326 tests passed
- [x] 3 tests skipped
- [x] 0 failures

## Notes


## Related commit

`c9c584bf0ebe99eed903b9109a7ae52b3ba4d64e`

<img width="366" height="41" alt="image" src="https://github.com/user-attachments/assets/7a1f81f8-fc8e-4312-afe6-cb3443725f86" />
