### PR TITLE
Suppress hover during option drag

### DIFF
--- a/Sources/Notch/NotchPanel.swift
+++ b/Sources/Notch/NotchPanel.swift
@@ -16,6 +16,7 @@ final class NotchPanel: NSPanel {
     /// event — not a cumulative offset, so the caller decides what "along the
     /// edge" means for the current one. Chosen over a plain click-and-hold
     /// threshold so an ordinary click never risks being read as a tiny nudge.
+    var onDragStart: (() -> Void)?
     var onDrag: ((CGFloat, CGFloat) -> Void)?
     /// The ⌥-drag ended. Where to persist the offset the drags above moved to.
     var onDragEnd: (() -> Void)?
@@ -39,6 +40,7 @@ final class NotchPanel: NSPanel {
             onClick?(event.locationInWindow)
             return
         }
+        onDragStart?()
         trackOptionDrag()
     }
 

--- a/Sources/Notch/NotchWindowController.swift
+++ b/Sources/Notch/NotchWindowController.swift
@@ -78,6 +78,11 @@ final class NotchWindowController {
     private var visibility: NotchVisibility = .onHover
     /// Whether we have pushed the pointing hand onto the cursor stack.
     private var isPointing = false
+    /// Option-drag moves the whole notch under the pointer. Hovering rings
+    /// while that happens is accidental — the pointer necessarily crosses
+    /// them as the panel follows it — so cursor tracking is suspended until
+    /// the drag ends.
+    private var isOptionDragging = false
 
     /// Determines whether a full-screen application window is active on this notch's display.
     /// Default implementation queries WindowServer and NSWorkspace; overridable for testing.
@@ -254,10 +259,12 @@ final class NotchWindowController {
             let hosting = NotchHostingView(rootView: NotchRootView(model: model))
             panel.contextMenuProvider = { [weak self] in self?.contextMenu() }
             panel.onClick = { [weak self] point in self?.handleClick(at: point) }
+            panel.onDragStart = { [weak self] in self?.beginOptionDrag() }
             panel.onDrag = { [weak self] dx, dy in self?.dragged(dx: dx, dy: dy) }
             panel.onDragEnd = { [weak self] in
                 guard let self else { return }
                 self.onReposition?(self.model.alongOffset)
+                self.endOptionDrag()
             }
 
             // The hosting view goes *inside* a plain container rather than
@@ -317,6 +324,26 @@ final class NotchWindowController {
     private func dragged(dx: CGFloat, dy: CGFloat) {
         model.alongOffset += model.edge.isVertical ? dy : dx
         relocate()
+    }
+
+    private func beginOptionDrag() {
+        guard !isOptionDragging else { return }
+        isOptionDragging = true
+        clearHoverWork?.cancel()
+        clearHoverWork = nil
+        foldWork?.cancel()
+        foldWork = nil
+        model.hoveredIndex = nil
+        model.isHoveringSettings = false
+        model.isHoveringMove = false
+        setPointing(false)
+        updateInteractiveRects()
+    }
+
+    private func endOptionDrag() {
+        guard isOptionDragging else { return }
+        isOptionDragging = false
+        cursorMoved()
     }
 
     // MARK: - Hit regions
@@ -497,7 +524,7 @@ final class NotchWindowController {
     }
 
     private func cursorMoved() {
-        guard let panel else { return }
+        guard let panel, !isOptionDragging else { return }
         let local = localCursor(in: panel.frame)
         let overTooltip = model.hoveredIndex
             .flatMap(tooltipRect(index:))


### PR DESCRIPTION
## Summary

Suppress hover effects while repositioning the notch with an Option-drag.

During an Option-drag:

- Cancel pending hover and fold actions
- Clear the current hover state
- Disable the pointing-hand cursor
- Ignore cursor movement until the drag ends
- Resume normal hover tracking after repositioning

## Testing


## Commit

`abc6ff67ae1f4007fad4f0e7dc183e96b632737b`