### PR TITLE
fix: deliver usage reset and limit alerts when they happen

### DIFF
--- a/Sources/App/AppDelegate.swift
+++ b/Sources/App/AppDelegate.swift
@@ -652,7 +652,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             SessionChime.play(preferences.usageResetSoundName)
         }
         guard preferences.announceUsageReset else { return }
-        fleet.showResetAlert(event, duration: 5.0)
+        if !fleet.showResetAlert(event, duration: 5.0) {
+            UsageAlertNotifications.deliver(event)
+        }
     }
 
     @MainActor
@@ -695,7 +697,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         if preferences.limitReachedSound {
             SessionChime.play(preferences.limitReachedSoundName)
         }
-        fleet.showResetAlert(event, duration: 6.0)
+        if !fleet.showResetAlert(event, duration: 6.0) {
+            UsageAlertNotifications.deliver(event)
+        }
     }
 
     @MainActor

--- a/Sources/Model/ThresholdNotifier.swift
+++ b/Sources/Model/ThresholdNotifier.swift
@@ -121,8 +121,10 @@ enum UsageAlertNotifications {
             // Same threading as the crossing alerts: one pile per provider.
             content.threadIdentifier = event.providerID
 
+            // The kind rather than the window label: the label is display text
+            // and changes with the language, and an identifier should not.
             let request = UNNotificationRequest(
-                identifier: "\(event.providerID).\(event.windowLabel).\(Int(Date().timeIntervalSince1970))",
+                identifier: "\(event.providerID).\(event.kind).\(Int(Date().timeIntervalSince1970))",
                 content: content, trigger: nil)
             center.add(request)
         }

--- a/Sources/Model/ThresholdNotifier.swift
+++ b/Sources/Model/ThresholdNotifier.swift
@@ -94,3 +94,37 @@ enum ThresholdAlerts {
         }
     }
 }
+
+/// The out-of-notch end of the usage reset and limit alerts.
+///
+/// The card in the notch is the primary form; this is what is owed when there
+/// is no notch open to put it in — a hidden notch used to swallow the alert
+/// silently, which for a weekly limit is the one alert worth not missing.
+enum UsageAlertNotifications {
+    static func deliver(_ event: UsageAlertEvent) {
+        let center = UNUserNotificationCenter.current()
+        center.requestAuthorization(options: [.alert]) { granted, _ in
+            guard granted else { return }
+
+            let content = UNMutableNotificationContent()
+            let window = event.windowLabel.lowercased()
+            switch event.kind {
+            case .reset:
+                content.title = L10n.t("\(event.providerName) has reset")
+                content.body = L10n.t("Its \(window) limit is available again.")
+            case .sessionLimitReached, .weeklyLimitReached:
+                content.title = L10n.t("\(event.providerName) limit reached")
+                content.body = event.resetsAt.map {
+                    L10n.t("Its \(window) limit is spent — resets \($0.formatted(date: .omitted, time: .shortened))")
+                } ?? L10n.t("Its \(window) limit is spent.")
+            }
+            // Same threading as the crossing alerts: one pile per provider.
+            content.threadIdentifier = event.providerID
+
+            let request = UNNotificationRequest(
+                identifier: "\(event.providerID).\(event.windowLabel).\(Int(Date().timeIntervalSince1970))",
+                content: content, trigger: nil)
+            center.add(request)
+        }
+    }
+}

--- a/Sources/Model/UsageStore.swift
+++ b/Sources/Model/UsageStore.swift
@@ -291,7 +291,7 @@ final class UsageStore: ObservableObject {
             isBusy: isBusy(),
             sinceLastAttempt: waited,
             idleInterval: idleRefreshInterval,
-            resetDue: hasWindowRolledOver(since: lastAttempt, at: now)
+            resetDue: Self.hasWindowRolledOver(in: snapshots, since: lastAttempt, at: now)
         ) else { return }
         refreshNow()
     }
@@ -303,7 +303,10 @@ final class UsageStore: ObservableObject {
     /// interval there is what made the alert arrive minutes late. It fires once
     /// per rollover: the refresh it asks for puts `lastAttempt` past the
     /// boundary, so the next tick no longer sees it.
-    private func hasWindowRolledOver(since last: Date?, at now: Date) -> Bool {
+    ///
+    /// Pure, for the reason `shouldRefresh` is: the boundary it looks for is a
+    /// date, and a test of it should not need a store or a clock.
+    static func hasWindowRolledOver(in snapshots: [ProviderSnapshot], since last: Date?, at now: Date) -> Bool {
         guard let last else { return false }
         return snapshots.contains { snapshot in
             snapshot.windows.contains { window in

--- a/Sources/Model/UsageStore.swift
+++ b/Sources/Model/UsageStore.swift
@@ -285,23 +285,44 @@ final class UsageStore: ObservableObject {
 
     /// Decides whether this tick is worth a request at all.
     private func tick() {
-        let waited = lastAttempt.map { pollingNow().timeIntervalSince($0) } ?? .greatestFiniteMagnitude
+        let now = pollingNow()
+        let waited = lastAttempt.map { now.timeIntervalSince($0) } ?? .greatestFiniteMagnitude
         guard Self.shouldRefresh(
             isBusy: isBusy(),
             sinceLastAttempt: waited,
-            idleInterval: idleRefreshInterval
+            idleInterval: idleRefreshInterval,
+            resetDue: hasWindowRolledOver(since: lastAttempt, at: now)
         ) else { return }
         refreshNow()
     }
 
-    /// Poll at full rate while something is running; otherwise wait out the
-    /// idle interval. Pure, so the schedule can be tested without a clock.
+    /// True when a window's `resetsAt` fell between the last attempt and now.
+    ///
+    /// That boundary is the one moment the numbers are certain to have moved,
+    /// and it is the moment a reset alert is owed — waiting out the idle
+    /// interval there is what made the alert arrive minutes late. It fires once
+    /// per rollover: the refresh it asks for puts `lastAttempt` past the
+    /// boundary, so the next tick no longer sees it.
+    private func hasWindowRolledOver(since last: Date?, at now: Date) -> Bool {
+        guard let last else { return false }
+        return snapshots.contains { snapshot in
+            snapshot.windows.contains { window in
+                guard let resetsAt = window.resetsAt else { return false }
+                return resetsAt > last && resetsAt <= now
+            }
+        }
+    }
+
+    /// Poll at full rate while something is running or a window has just rolled
+    /// over; otherwise wait out the idle interval. Pure, so the schedule can be
+    /// tested without a clock.
     static func shouldRefresh(
         isBusy: Bool,
         sinceLastAttempt: TimeInterval,
-        idleInterval: TimeInterval
+        idleInterval: TimeInterval,
+        resetDue: Bool = false
     ) -> Bool {
-        isBusy || sinceLastAttempt >= idleInterval
+        isBusy || resetDue || sinceLastAttempt >= idleInterval
     }
 
     func refreshNow() {

--- a/Sources/Notch/NotchFleet.swift
+++ b/Sources/Notch/NotchFleet.swift
@@ -254,10 +254,15 @@ final class NotchFleet {
     }
 
     /// Shows a usage reset notification modal on every panel.
-    func showResetAlert(_ event: UsageResetEvent, duration: TimeInterval = 5.0) {
+    /// Returns whether at least one notch had somewhere to show the card. With
+    /// every notch hidden the alert would otherwise vanish without a trace.
+    @discardableResult
+    func showResetAlert(_ event: UsageResetEvent, duration: TimeInterval = 5.0) -> Bool {
+        var shown = false
         for controller in controllers.values {
-            controller.showResetAlert(event, duration: duration)
+            shown = controller.showResetAlert(event, duration: duration) || shown
         }
+        return shown
     }
 
     func setRefreshing(_ ids: Set<String>) {

--- a/Sources/Notch/NotchWindowController.swift
+++ b/Sources/Notch/NotchWindowController.swift
@@ -983,10 +983,14 @@ final class NotchWindowController {
     }
 
     /// Open the notch and show a usage reset notification modal card.
-    func showResetAlert(_ event: UsageResetEvent, duration: TimeInterval = 5.0) {
+    ///
+    /// Returns whether the card was actually shown: a hidden notch has nowhere
+    /// to put it, and the caller owes the user another way of hearing about it.
+    @discardableResult
+    func showResetAlert(_ event: UsageResetEvent, duration: TimeInterval = 5.0) -> Bool {
         guard visibility != .hidden, let panel else {
             Log.usage.debug("reset alert skipped: notch hidden")
-            return
+            return false
         }
         model.activeResetAlert = event
         peek(for: duration, focusing: nil)
@@ -1002,6 +1006,7 @@ final class NotchWindowController {
                 }
             }
         }
+        return true
     }
 
     /// How long after a peek folds a click still counts as answering it. Covers

--- a/Sources/Providers/ClaudeOAuthProvider.swift
+++ b/Sources/Providers/ClaudeOAuthProvider.swift
@@ -263,9 +263,27 @@ actor ClaudeOAuthProvider: UsageProvider {
             Log.usage.debug("\(self.id, privacy: .public): claude desktop snapshot is too old to show as live")
             return nil
         }
+        // Inside the freshness window but describing a period that has already
+        // ended. Desktop can hold such an entry for half an hour, which is long
+        // enough to hide a reset entirely.
+        guard !Self.hasExpiredWindow(reading.windows, at: now) else {
+            lastDesktopMiss = now
+            Log.usage.debug("\(self.id, privacy: .public): claude desktop snapshot describes a window that has already reset")
+            return nil
+        }
         lastDesktopMiss = nil
         Log.usage.debug("\(self.id, privacy: .public): read \(reading.windows.count) windows from the claude desktop cache entry \(reading.entry.lastPathComponent, privacy: .public)")
         return reading.windows
+    }
+
+    /// Whether any window in a reading names a reset time that has already
+    /// passed — which makes the whole reading a description of a period that is
+    /// over, however recently it was written.
+    static func hasExpiredWindow(_ windows: [LimitWindow], at now: Date) -> Bool {
+        windows.contains { window in
+            guard let resetsAt = window.resetsAt else { return false }
+            return resetsAt <= now
+        }
     }
 
     /// What `claude "/usage"` last said, or nil to mean "use the token path".
@@ -282,7 +300,14 @@ actor ClaudeOAuthProvider: UsageProvider {
         // A cached answer is only reused inside the interval. Past it the
         // reading is stale, and handing it back as `.ok` would be claiming a
         // freshness it does not have.
-        if let last = lastCLIWindows, now.timeIntervalSince(last.at) < cliRefreshInterval {
+        //
+        // A reading whose window has already rolled over is stale whatever its
+        // age: it describes a period that is over. Reusing one is what made a
+        // reset show up minutes after it happened, so it drops through to the
+        // live sources instead.
+        if let last = lastCLIWindows,
+           now.timeIntervalSince(last.at) < cliRefreshInterval,
+           !Self.hasExpiredWindow(last.windows, at: now) {
             return last.windows
         }
         if let lastCLIAttempt, now.timeIntervalSince(lastCLIAttempt) < cliRefreshInterval {

--- a/Tests/ClaudeOAuthProviderTests.swift
+++ b/Tests/ClaudeOAuthProviderTests.swift
@@ -401,10 +401,29 @@ final class ClaudeOAuthProviderTests: XCTestCase {
             [.modificationDate: Date().addingTimeInterval(-age)], ofItemAtPath: file.path)
     }
 
-    private static let cliUsage = """
-    Current session: 38% used · resets Sep 7 at 2:59pm (Asia/Jakarta)
-    Current week (all models): 4% used · resets Sep 14 at 5:59am (Asia/Jakarta)
-    """
+    /// A reading of two windows that are both still running.
+    ///
+    /// Dated from the clock rather than pinned, because a reading whose window
+    /// has already rolled over is deliberately *not* reused — that is what
+    /// stops a reset from staying hidden behind a cached number — and a fixed
+    /// date would quietly turn these into tests of that instead.
+    private static var cliUsage: String {
+        let now = Date()
+        return """
+        Current session: 38% used · resets \(jakarta(now.addingTimeInterval(3 * 3600))) (Asia/Jakarta)
+        Current week (all models): 4% used · resets \(jakarta(now.addingTimeInterval(6 * 86_400))) (Asia/Jakarta)
+        """
+    }
+
+    /// The wording `claude "/usage"` prints, in the zone the line names.
+    private static func jakarta(_ date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(identifier: "Asia/Jakarta")
+        formatter.dateFormat = "MMM d 'at' h:mma"
+        return formatter.string(from: date).replacingOccurrences(of: "AM", with: "am")
+            .replacingOccurrences(of: "PM", with: "pm")
+    }
 
     private static func cli(answering text: String) -> ClaudeUsageCLI {
         cli { text }
@@ -650,5 +669,44 @@ extension ClaudeKeychainPromptTests {
         clock.now = clock.now.addingTimeInterval(ClaudeKeychain.promptWindow + 1)
         _ = try k.load()
         XCTAssertEqual(interactive, [false])
+    }
+}
+
+/// A cached reading can be minutes old and still be wrong in the one way that
+/// matters: the window it describes has already rolled over. Claude Desktop's
+/// entry is considered live for half an hour, which is long enough to hide a
+/// reset completely.
+final class ClaudeExpiredWindowTests: XCTestCase {
+    private func window(resetsAt: Date?) -> LimitWindow {
+        LimitWindow(id: "session", label: "5-hour limit", usedFraction: 0.8, resetsAt: resetsAt)
+    }
+
+    func testAWindowPastItsResetIsExpired() {
+        let now = Date()
+        XCTAssertTrue(ClaudeOAuthProvider.hasExpiredWindow(
+            [window(resetsAt: now.addingTimeInterval(-1))], at: now))
+    }
+
+    func testAWindowStillRunningIsNotExpired() {
+        let now = Date()
+        XCTAssertFalse(ClaudeOAuthProvider.hasExpiredWindow(
+            [window(resetsAt: now.addingTimeInterval(60))], at: now))
+    }
+
+    /// Plenty of providers never say when the window turns over. Silence is not
+    /// a reason to throw the reading away.
+    func testAWindowWithoutAResetTimeIsNotExpired() {
+        XCTAssertFalse(ClaudeOAuthProvider.hasExpiredWindow([window(resetsAt: nil)], at: Date()))
+        XCTAssertFalse(ClaudeOAuthProvider.hasExpiredWindow([], at: Date()))
+    }
+
+    /// One stale window is enough: the reading is written in one pass, so a
+    /// rolled-over session window dates the weekly one beside it too.
+    func testOneExpiredWindowDatesTheWholeReading() {
+        let now = Date()
+        XCTAssertTrue(ClaudeOAuthProvider.hasExpiredWindow([
+            window(resetsAt: now.addingTimeInterval(86_400)),
+            window(resetsAt: now.addingTimeInterval(-30))
+        ], at: now))
     }
 }

--- a/Tests/UsageResetWatcherTests.swift
+++ b/Tests/UsageResetWatcherTests.swift
@@ -90,3 +90,28 @@ final class UsageResetWatcherTests: XCTestCase {
         XCTAssertEqual(alerts[1].providerID, "cursor")
     }
 }
+
+/// A hidden notch has nowhere to put the card, and used to swallow the alert
+/// without a word — so the caller has to be able to tell, and reach for a
+/// system notification instead.
+@MainActor
+final class ResetAlertVisibilityTests: XCTestCase {
+    private let event = UsageResetEvent(
+        providerID: "claude",
+        providerName: "Claude",
+        windowLabel: "5-hour limit",
+        glyph: .claude,
+        previousFraction: 0.95,
+        currentFraction: 0.0,
+        resetsAt: Date().addingTimeInterval(5 * 3600)
+    )
+
+    /// Deliberately only the hidden case. Showing a real panel here perturbs the
+    /// arrival-animation timing `EdgeArrivalTests` measures, and the branch that
+    /// matters — the one that used to lose the alert — is this one.
+    func testAControllerWithNoPanelSaysItDidNotShow() {
+        let controller = NotchWindowController()
+        XCTAssertFalse(controller.showResetAlert(event, duration: 0.1))
+        XCTAssertNil(controller.model.activeResetAlert)
+    }
+}

--- a/Tests/UsageResponseTests.swift
+++ b/Tests/UsageResponseTests.swift
@@ -359,6 +359,65 @@ final class RefreshScheduleTests: XCTestCase {
     }
 }
 
+/// Which readings count as "a window just turned over". The schedule above is
+/// only as prompt as this answer is.
+@MainActor
+final class WindowRolloverTests: XCTestCase {
+    private let last = Date(timeIntervalSince1970: 1_787_900_000)
+    private var now: Date { last.addingTimeInterval(60) }
+
+    private func snapshot(resetsAt: Date?...) -> [ProviderSnapshot] {
+        [ProviderSnapshot(
+            id: "claude", displayName: "Claude", glyph: .claude,
+            fidelity: .official, status: .ok,
+            windows: resetsAt.enumerated().map { index, date in
+                LimitWindow(id: "w\(index)", label: "Current session",
+                            usedFraction: 0.68, resetsAt: date)
+            }
+        )]
+    }
+
+    func testAWindowThatTurnedOverSinceTheLastAttemptIsDue() {
+        XCTAssertTrue(UsageStore.hasWindowRolledOver(
+            in: snapshot(resetsAt: last.addingTimeInterval(30)), since: last, at: now))
+    }
+
+    /// The boundary is still ahead: nothing has changed yet, and polling now
+    /// would spend a request to be told so.
+    func testAWindowStillRunningIsNotDue() {
+        XCTAssertFalse(UsageStore.hasWindowRolledOver(
+            in: snapshot(resetsAt: now.addingTimeInterval(30)), since: last, at: now))
+    }
+
+    /// The one that keeps this from becoming a permanent full-rate poll: once a
+    /// refresh has been attempted past the boundary, the same rollover must not
+    /// ask for another.
+    func testARolloverIsOnlyDueOnce() {
+        let windows = snapshot(resetsAt: last.addingTimeInterval(30))
+        XCTAssertTrue(UsageStore.hasWindowRolledOver(in: windows, since: last, at: now))
+        XCTAssertFalse(UsageStore.hasWindowRolledOver(in: windows, since: now, at: now.addingTimeInterval(60)))
+    }
+
+    func testAWindowWithoutAResetTimeIsNeverDue() {
+        XCTAssertFalse(UsageStore.hasWindowRolledOver(in: snapshot(resetsAt: nil), since: last, at: now))
+    }
+
+    /// A first run has nothing to compare against and must not read a rollover
+    /// into a window it is seeing for the first time.
+    func testNothingIsDueBeforeTheFirstAttempt() {
+        XCTAssertFalse(UsageStore.hasWindowRolledOver(
+            in: snapshot(resetsAt: last.addingTimeInterval(30)), since: nil, at: now))
+    }
+
+    /// Secondary windows count too: a weekly limit rolling over is the alert
+    /// people wait for most, and it is never the headline.
+    func testASecondaryWindowCountsAsWell() {
+        XCTAssertTrue(UsageStore.hasWindowRolledOver(
+            in: snapshot(resetsAt: now.addingTimeInterval(86_400), last.addingTimeInterval(30)),
+            since: last, at: now))
+    }
+}
+
 /// Some failures say something about the account rather than about the network.
 /// Dimming an old number through one of those would keep showing a figure that
 /// is no longer true — and, after an endpoint change, one from a source we no

--- a/Tests/UsageResponseTests.swift
+++ b/Tests/UsageResponseTests.swift
@@ -343,6 +343,20 @@ final class RefreshScheduleTests: XCTestCase {
             idleInterval: idle
         ))
     }
+
+    /// The moment a limit window rolls over is the moment the reset alert is
+    /// owed, and it lands squarely inside the idle stretch — you are not running
+    /// anything precisely because you were waiting for it. Waiting out the idle
+    /// interval there is what made the alert arrive minutes late.
+    @MainActor
+    func testARolledOverWindowPollsInsideTheIdleInterval() {
+        XCTAssertTrue(UsageStore.shouldRefresh(
+            isBusy: false, sinceLastAttempt: 60, idleInterval: idle, resetDue: true
+        ))
+        XCTAssertFalse(UsageStore.shouldRefresh(
+            isBusy: false, sinceLastAttempt: 60, idleInterval: idle, resetDue: false
+        ))
+    }
 }
 
 /// Some failures say something about the account rather than about the network.


### PR DESCRIPTION
Follow-up to #144, whose commits you merged by hand as d88721c. The alerts
themselves work; what did not was *when* they arrived.

## Summary

- A reset or limit alert could not appear until a poll revealed it, and the poll
  was waiting out the five-minute idle interval — an interval in force at exactly
  the wrong moment, since nothing is running while you sit out a spent limit.
- Even once it polled, the answer could come back from a cache: the CLI reading is
  reused for five minutes and Claude Desktop's entry counts as live for thirty, so
  a pre-reset number could stand for half an hour.
- A hidden notch had nowhere to put the card and dropped it with a debug line, so
  the alert was not late but gone.

No interval default changes, and the 429 backoff is untouched. Nothing extra is
asked outside the one moment a window turns over.

## Changes

**`UsageStore`** — a window whose `resetsAt` fell between the last attempt and now
is its own reason to poll, alongside `isBusy`. The 60s timer already runs; only the
idle gate was holding it, so the alert now lands within one tick of the real
boundary. It fires once per rollover, because the refresh it asks for moves
`lastAttempt` past the boundary. `hasWindowRolledOver` is pure for the reason
`shouldRefresh` says it is.

**`ClaudeOAuthProvider`** — age is the wrong question for a reading whose window has
already rolled over: it describes a period that is over however recently it was
written. Both the CLI cache and the Desktop entry now drop through to the live
sources in that case. The Desktop path still stamps `lastDesktopMiss`, so this
costs no extra directory scans.

**`NotchWindowController` / `NotchFleet` / `AppDelegate`** — the card reports whether
it was actually shown, and when no notch took it the event goes out as a system
notification instead, threaded per provider like the threshold alerts beside it.
The card stays the primary form.

## Test plan

- [x] `make test` — 1338 tests, 3 skipped, 0 failures
- [x] `WindowRolloverTests` — due once and only once, not due before the boundary,
      not due before the first attempt, `resetsAt` absent, secondary windows count
- [x] `ClaudeExpiredWindowTests` — past, future, absent, and one stale window
      dating a whole reading
- [x] `RefreshScheduleTests.testARolledOverWindowPollsInsideTheIdleInterval`
- [x] `ResetAlertVisibilityTests` — a controller with no panel reports it did not show
- [x] Existing CLI spawn-rate tests now date their fixture from the clock; pinned to
      a past date they had quietly become tests of the expiry rule above

## Two things worth your eye

- `hasExpiredWindow` drops a whole Desktop reading when any one window has rolled
  over, so a still-valid weekly window goes with the spent session one. That leaves
  the last good reading to `UsageStore`, dimmed and dated — the degrade path the
  comment at `ClaudeOAuthProvider` line 227 already argues for. Say the word if you
  would rather it kept the untouched windows.
- `lastAttempt` is global and is also stamped by a single-provider refresh, so one
  provider's manual refresh can consume another's rollover boundary and delay that
  alert by up to one idle interval. Pre-existing; I did not add state for it.

Separately, `EdgeArrivalTests.testItLandsFoldedAndThenOpens` is flaky under load on
my machine — it fails on `main` untouched and passes when run alone. Not from this
branch, but you may want to know.
