### PR TITLE
Add a German localization

### DIFF
--- a/Sources/Info.plist
+++ b/Sources/Info.plist
@@ -16,6 +16,7 @@
 	<array>
 		<string>en</string>
 		<string>fr</string>
+		<string>de</string>
 		<string>ja</string>
 		<string>pt-BR</string>
 		<string>ru</string>

--- a/Sources/Localizable.xcstrings
+++ b/Sources/Localizable.xcstrings
@@ -33,6 +33,12 @@
             "state": "translated",
             "value": "刚刚"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "gerade eben"
+          }
         }
       }
     },
@@ -67,6 +73,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "%lld 分钟"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld Min"
           }
         }
       }
@@ -103,6 +115,12 @@
             "state": "translated",
             "value": "%lld 小时"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld Std"
+          }
         }
       }
     },
@@ -137,6 +155,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "%lld 小时 %lld 分钟"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld Std %lld Min"
           }
         }
       }
@@ -173,6 +197,12 @@
             "state": "translated",
             "value": "%@前"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "vor %@"
+          }
         }
       }
     },
@@ -207,6 +237,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "正在重置…"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wird zurückgesetzt…"
           }
         }
       }
@@ -243,6 +279,12 @@
             "state": "translated",
             "value": "%lld 分钟后重置"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zurücksetzung in %lld Min."
+          }
         }
       }
     },
@@ -277,6 +319,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Сброс: %@"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zurücksetzung %@"
           }
         }
       }
@@ -313,6 +361,12 @@
             "state": "translated",
             "value": "%lld%% 已用 · %lld%% 剩余"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld%% verwendet · %lld%% übrig"
+          }
         }
       }
     },
@@ -347,6 +401,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "剩余 1"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 übrig"
           }
         }
       }
@@ -383,6 +443,12 @@
             "state": "translated",
             "value": "剩余 %lld"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld übrig"
+          }
         }
       }
     },
@@ -417,6 +483,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "已用 1"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 verwendet"
           }
         }
       }
@@ -453,6 +525,12 @@
             "state": "translated",
             "value": "已用 %lld"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld verwendet"
+          }
         }
       }
     },
@@ -487,6 +565,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "暂无读数"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kein Messwert"
           }
         }
       }
@@ -523,6 +607,12 @@
             "state": "translated",
             "value": "%@，直到 %@"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ bis %@"
+          }
         }
       }
     },
@@ -557,6 +647,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "登录 Claude Code 以读取用量"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Melde dich bei Claude Code an, um deine Nutzung zu lesen"
           }
         }
       }
@@ -593,6 +689,12 @@
             "state": "translated",
             "value": "在 ~/.claude-%@ 登录 Claude Code 以读取用量"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Melde dich in ~/.claude-%@ bei Claude Code an, um deine Nutzung zu lesen"
+          }
         }
       }
     },
@@ -627,6 +729,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "在 Cursor 编辑器中登录以读取用量"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Melde dich im Editor bei Cursor an"
           }
         }
       }
@@ -663,6 +771,12 @@
             "state": "translated",
             "value": "登录 Codex 以读取用量"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Melde dich bei Codex an, um deine Nutzung zu lesen"
+          }
         }
       }
     },
@@ -697,6 +811,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "登录 Antigravity 以读取用量"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Melde dich bei Antigravity an, um deine Nutzung zu lesen"
           }
         }
       }
@@ -733,6 +853,12 @@
             "state": "translated",
             "value": "Настройте ключ GLM Coding Plan в инструменте разработки, чтобы читать использование"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Richte einen GLM-Coding-Plan-Schlüssel für ein Coding-Tool ein, um deine Nutzung zu lesen"
+          }
         }
       }
     },
@@ -767,6 +893,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Подключите тариф Go в OpenCode, чтобы читать использование"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verbinde den Go-Tarif in OpenCode, um deine Nutzung zu lesen"
           }
         }
       }
@@ -803,6 +935,12 @@
             "state": "translated",
             "value": "登录 %@ 以读取用量"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Melde dich bei %@ an, um deine Nutzung zu lesen"
+          }
         }
       }
     },
@@ -837,6 +975,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Codenotch не получил доступ к сохранённому входу %@. Нажмите это кольцо, повторите запрос и выберите «Разрешать всегда»."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Codenotch wurde der Zugriff auf die gespeicherte Anmeldung von %@ verweigert. Klicke auf diesen Ring, um erneut zu fragen, und wähle „Immer erlauben“."
           }
         }
       }
@@ -873,6 +1017,12 @@
             "state": "translated",
             "value": "Не удалось прочитать использование — %@"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nutzung konnte nicht gelesen werden — %@"
+          }
         }
       }
     },
@@ -907,6 +1057,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "正在等待首次读数…"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wartet auf den ersten Messwert…"
           }
         }
       }
@@ -943,6 +1099,12 @@
             "state": "translated",
             "value": "当前会话"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aktuelle Sitzung"
+          }
         }
       }
     },
@@ -978,6 +1140,12 @@
             "state": "translated",
             "value": "全部模型"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alle Modelle"
+          }
         }
       }
     },
@@ -1009,6 +1177,12 @@
           }
         },
         "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Opus"
+          }
+        },
+        "de": {
           "stringUnit": {
             "state": "translated",
             "value": "Opus"
@@ -1048,6 +1222,12 @@
             "state": "translated",
             "value": "Sonnet"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sonnet"
+          }
         }
       }
     },
@@ -1082,6 +1262,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "套餐用量"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enthaltene Nutzung"
           }
         }
       }
@@ -1118,6 +1304,12 @@
             "state": "translated",
             "value": "API 用量"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API-Nutzung"
+          }
         }
       }
     },
@@ -1152,6 +1344,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "按需用量"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bei Bedarf"
           }
         }
       }
@@ -1188,6 +1386,12 @@
             "state": "translated",
             "value": "5 小时额度"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "5-Std.-Limit"
+          }
         }
       }
     },
@@ -1222,6 +1426,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "每周额度"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wochenlimit"
           }
         }
       }
@@ -1258,6 +1468,12 @@
             "state": "translated",
             "value": "每月额度"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Monatslimit"
+          }
         }
       }
     },
@@ -1292,6 +1508,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "每日额度"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tageskontingent"
           }
         }
       }
@@ -1328,6 +1550,12 @@
             "state": "translated",
             "value": "更长周期"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Längeres Zeitfenster"
+          }
         }
       }
     },
@@ -1362,6 +1590,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "%lld 分钟额度"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld-Min.-Limit"
           }
         }
       }
@@ -1398,6 +1632,12 @@
             "state": "translated",
             "value": "%lld 小时额度"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld-Std.-Limit"
+          }
         }
       }
     },
@@ -1432,6 +1672,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "%lld 天额度"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld-Tage-Limit"
           }
         }
       }
@@ -1468,6 +1714,12 @@
             "state": "translated",
             "value": "每周"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wöchentlich"
+          }
         }
       }
     },
@@ -1502,6 +1754,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "MCP（1 个月）"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MCP (1 Monat)"
           }
         }
       }
@@ -1538,6 +1796,12 @@
             "state": "translated",
             "value": "用量（%lld 小时）"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nutzung (%lld Std.)"
+          }
         }
       }
     },
@@ -1572,6 +1836,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "用量（%lld 周）"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nutzung (%lld Wo.)"
           }
         }
       }
@@ -1608,6 +1878,12 @@
             "state": "translated",
             "value": "用量"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nutzung"
+          }
         }
       }
     },
@@ -1642,6 +1918,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Pro 搜索"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pro-Suchen"
           }
         }
       }
@@ -1678,6 +1960,12 @@
             "state": "translated",
             "value": "研究"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recherche"
+          }
         }
       }
     },
@@ -1713,6 +2001,12 @@
             "state": "translated",
             "value": "智能体研究"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Agentische Recherche"
+          }
         }
       }
     },
@@ -1744,6 +2038,12 @@
           }
         },
         "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Labs"
+          }
+        },
+        "de": {
           "stringUnit": {
             "state": "translated",
             "value": "Labs"
@@ -1783,6 +2083,12 @@
             "state": "translated",
             "value": "免费查询"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kostenlose Anfragen"
+          }
         }
       }
     },
@@ -1817,6 +2123,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "今日请求 · 未公布额度"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Anfragen heute · kein Limit veröffentlicht"
           }
         }
       }
@@ -1853,6 +2165,12 @@
             "state": "translated",
             "value": "今日暂无请求"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "heute keine Anfragen"
+          }
         }
       }
     },
@@ -1887,6 +2205,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "今日约 %lld 次请求"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "~%lld Anfrage heute"
           }
         }
       }
@@ -1923,6 +2247,12 @@
             "state": "translated",
             "value": "今日约 %lld 次请求"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "~%lld Anfragen heute"
+          }
         }
       }
     },
@@ -1954,6 +2284,12 @@
           }
         },
         "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Grok Build"
+          }
+        },
+        "de": {
           "stringUnit": {
             "state": "translated",
             "value": "Grok Build"
@@ -1993,6 +2329,12 @@
             "state": "translated",
             "value": "%@ 用量"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@-Nutzung"
+          }
         }
       }
     },
@@ -2027,6 +2369,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "还有 %lld 个"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "und %lld weitere"
           }
         }
       }
@@ -2063,6 +2411,12 @@
             "state": "translated",
             "value": "工作中"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "arbeitend"
+          }
         }
       }
     },
@@ -2097,6 +2451,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "等待中"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "wartend"
           }
         }
       }
@@ -2133,6 +2493,12 @@
             "state": "translated",
             "value": "空闲"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "untätig"
+          }
         }
       }
     },
@@ -2167,6 +2533,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "工作中"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Arbeitend"
           }
         }
       }
@@ -2203,6 +2575,12 @@
             "state": "translated",
             "value": "桌面端"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desktop"
+          }
         }
       }
     },
@@ -2234,6 +2612,12 @@
           }
         },
         "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VS Code"
+          }
+        },
+        "de": {
           "stringUnit": {
             "state": "translated",
             "value": "VS Code"
@@ -2273,6 +2657,12 @@
             "state": "translated",
             "value": "Agent"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Agent"
+          }
         }
       }
     },
@@ -2307,6 +2697,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "终端"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Terminal"
           }
         }
       }
@@ -2343,6 +2739,12 @@
             "state": "translated",
             "value": "未命名对话"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unbenannter Chat"
+          }
         }
       }
     },
@@ -2377,6 +2779,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "始终显示"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Immer anzeigen"
           }
         }
       }
@@ -2413,6 +2821,12 @@
             "state": "translated",
             "value": "悬停时显示"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bei Hover anzeigen"
+          }
         }
       }
     },
@@ -2447,6 +2861,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "隐藏"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ausblenden"
           }
         }
       }
@@ -2483,6 +2903,12 @@
             "state": "translated",
             "value": "刘海保持展开，所有读数都看得见。"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die Notch bleibt offen, mit allen Messwerten sichtbar."
+          }
         }
       }
     },
@@ -2517,6 +2943,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "屏幕边缘一颗小胶囊，指针移过去就会展开。"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eine kleine Pille am Bildschirmrand, die sich öffnet, sobald du sie erreichst."
           }
         }
       }
@@ -2553,6 +2985,12 @@
             "state": "translated",
             "value": "屏幕上什么都没有。从「应用程序」再打开 Codenotch，才能回到这些设置。"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nichts auf dem Bildschirm. Öffne Codenotch erneut aus dem Programme-Ordner, um diese Einstellungen zurückzuholen."
+          }
         }
       }
     },
@@ -2587,6 +3025,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "程序坞"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dock"
           }
         }
       }
@@ -2623,6 +3067,12 @@
             "state": "translated",
             "value": "菜单栏"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Menüleiste"
+          }
         }
       }
     },
@@ -2657,6 +3107,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "都不显示"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keines von beidem"
           }
         }
       }
@@ -2693,6 +3149,12 @@
             "state": "translated",
             "value": "Codenotch 运行时，程序坞里有一个普通应用图标。"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ein normales App-Symbol im Dock, solange Codenotch läuft."
+          }
         }
       }
     },
@@ -2727,6 +3189,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "改在菜单栏放一个小图标，程序坞里没有。"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stattdessen ein kleines Symbol in der Menüleiste, und nichts im Dock."
           }
         }
       }
@@ -2763,6 +3231,12 @@
             "state": "translated",
             "value": "哪里都没有图标。从「应用程序」再打开 Codenotch，才能回到这些设置。"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nirgends ein Symbol. Öffne Codenotch erneut aus dem Programme-Ordner, um diese Einstellungen zurückzuholen."
+          }
         }
       }
     },
@@ -2797,6 +3271,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "右侧"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rechts"
           }
         }
       }
@@ -2833,6 +3313,12 @@
             "state": "translated",
             "value": "左侧"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Links"
+          }
         }
       }
     },
@@ -2867,6 +3353,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "顶部"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Oben"
           }
         }
       }
@@ -2903,6 +3395,12 @@
             "state": "translated",
             "value": "底部"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unten"
+          }
         }
       }
     },
@@ -2937,6 +3435,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Вдоль правого края, не занимая место у Dock."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Am rechten Rand entlang, mit Abstand zu einem Dock auf dieser Seite."
           }
         }
       }
@@ -2973,6 +3477,12 @@
             "state": "translated",
             "value": "Вдоль левого края, не занимая место у Dock."
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Am linken Rand entlang, mit Abstand zu einem Dock auf dieser Seite."
+          }
         }
       }
     },
@@ -3007,6 +3517,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Широкая панель сверху с показаниями рядом. На Mac с аппаратной выемкой она примыкает к ней, образуя единую форму."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ein breiter Balken oben quer über den Bildschirm, Messwerte nebeneinander. Auf einem Mac mit eigener Notch reicht er bis zu ihr heran, sodass beide wie eine Form wirken."
           }
         }
       }
@@ -3043,6 +3559,12 @@
             "state": "translated",
             "value": "Широкая панель над Dock с показаниями рядом."
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ein breiter Balken, der auf dem Dock aufliegt, Messwerte nebeneinander."
+          }
         }
       }
     },
@@ -3077,6 +3599,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "集成"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Integrationen"
           }
         }
       }
@@ -3113,6 +3641,12 @@
             "state": "translated",
             "value": "外观"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erscheinungsbild"
+          }
         }
       }
     },
@@ -3147,6 +3681,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "通用"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allgemein"
           }
         }
       }
@@ -3183,6 +3723,12 @@
             "state": "translated",
             "value": "显示"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Anzeigen"
+          }
         }
       }
     },
@@ -3217,6 +3763,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "边缘"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rand"
           }
         }
       }
@@ -3253,6 +3805,12 @@
             "state": "translated",
             "value": "应用图标"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "App-Symbol"
+          }
         }
       }
     },
@@ -3287,6 +3845,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "登录时打开 Codenotch"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Codenotch bei der Anmeldung öffnen"
           }
         }
       }
@@ -3323,6 +3887,12 @@
             "state": "translated",
             "value": "自动安装更新"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Updates automatisch installieren"
+          }
         }
       }
     },
@@ -3357,6 +3927,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "立即检查"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Jetzt prüfen"
           }
         }
       }
@@ -3393,6 +3969,12 @@
             "state": "translated",
             "value": "应用设计与开发"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "App konzipiert und entwickelt von"
+          }
         }
       }
     },
@@ -3427,6 +4009,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "连接一个助手以开始使用"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verbinde einen Assistenten, um loszulegen"
           }
         }
       }
@@ -3463,6 +4051,12 @@
             "state": "translated",
             "value": "Codenotch не выполняет вход — каждое показание берётся из уже авторизованного инструмента. Выход здесь прекращает чтение учётных данных и удаляет числа, но не выполняет выход из инструмента. macOS спрашивает разрешение один раз для каждого инструмента и при смене аккаунта; «Разрешать всегда» отключает повторные запросы."
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Codenotch meldet sich nie selbst an — jeder Messwert wird von dem Tool geliehen, das das Konto bereits besitzt. Sich hier abzumelden stoppt nur das Lesen der Zugangsdaten und vergisst die Zahlen, meldet dich aber nicht bei diesem Tool ab. macOS fragt beim ersten Mal einmal pro Tool nach, und erneut, sobald du dich bei einem anderen Konto anmeldest; „Immer erlauben“ hält es still."
+          }
         }
       }
     },
@@ -3497,6 +4091,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Codenotch читает использование из инструментов, уже авторизованных на этом Mac, и никогда не спрашивает пароль. Установите и авторизуйтесь в Claude Code (терминальном инструменте, не приложении Claude), Cursor, Codex, Antigravity, GLM, Grok или OpenCode — и кольцо появится на панели."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Codenotch liest die Nutzung von Tools, die auf diesem Mac bereits angemeldet sind — es fragt nie nach deinem Passwort. Installiere eines von Claude Code (das Terminal-Tool, nicht die Claude-App), Cursor, Codex, Antigravity, GLM, Grok oder OpenCode und melde dich an — der zugehörige Ring erscheint dann in der Notch."
           }
         }
       }
@@ -3533,6 +4133,12 @@
             "state": "translated",
             "value": "macOS один раз запросит доступ к сохранённым входам Claude Code и Antigravity. Выберите «Разрешать всегда» — обычное «Разрешить» приводит к повторному запросу."
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macOS fragt einmal um Erlaubnis, die gespeicherten Anmeldungen von Claude Code und Antigravity zu lesen. Wähle „Immer erlauben“ — bei einfachem „Erlauben“ fragt es jedes Mal erneut."
+          }
         }
       }
     },
@@ -3567,6 +4173,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Версия %@. Обновления устанавливаются в фоне и применяются при следующем запуске Codenotch."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Version %@. Updates werden im Hintergrund installiert und gelten ab dem nächsten Start von Codenotch."
           }
         }
       }
@@ -3603,6 +4215,12 @@
             "state": "translated",
             "value": "Выход выполнен — данные не читаются и не сохраняются."
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abgemeldet — es wird nichts gelesen, und es werden keine Messwerte behalten."
+          }
         }
       }
     },
@@ -3637,6 +4255,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Разрешить доступ…"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zugriff erlauben…"
           }
         }
       }
@@ -3673,6 +4297,12 @@
             "state": "translated",
             "value": "Переключить…"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wechseln…"
+          }
         }
       }
     },
@@ -3707,6 +4337,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Повторно запрашивает у macOS сохранённый вход %@. Выберите «Разрешать всегда», чтобы больше не видеть этот запрос."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fragt macOS erneut nach der gespeicherten Anmeldung von %@. Wähle „Immer erlauben“, damit nicht mehr nachgefragt wird."
           }
         }
       }
@@ -3743,6 +4379,12 @@
             "state": "translated",
             "value": "Выключите, чтобы прекратить чтение %@ и удалить его показания. %@"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ausschalten, um %@ nicht mehr zu lesen und dessen Messwerte zu vergessen. %@"
+          }
         }
       }
     },
@@ -3777,6 +4419,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Включите, чтобы снова войти и читать %@."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Einschalten, um dich anzumelden und %@ wieder zu lesen."
           }
         }
       }
@@ -3813,6 +4461,12 @@
             "state": "translated",
             "value": "macOS не разрешает Codenotch читать сохранённый вход %@. Выберите выше «Разрешить доступ…», затем «Разрешать всегда»."
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macOS erlaubt Codenotch nicht, die gespeicherte Anmeldung von %@ zu lesen. Wähle oben „Zugriff erlauben…“ und dann „Immer erlauben“."
+          }
         }
       }
     },
@@ -3847,6 +4501,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Открыть %@"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ öffnen"
           }
         }
       }
@@ -3883,6 +4543,12 @@
             "state": "translated",
             "value": "Открывает %@, где выполнен вход в этот аккаунт."
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Öffnet %@ — dort ist dieses Konto angemeldet."
+          }
         }
       }
     },
@@ -3917,6 +4583,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Открывает %@ в браузере. На этом сайте используется отдельный вход, не связанный с читаемыми здесь данными."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Öffnet %@ in deinem Browser. Diese Seite hat eine eigene Anmeldung, getrennt von den hier gelesenen Zugangsdaten."
           }
         }
       }
@@ -3953,6 +4625,12 @@
             "state": "translated",
             "value": "Настройки Codenotch"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Codenotch-Einstellungen"
+          }
         }
       }
     },
@@ -3987,6 +4665,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Что нового"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Neuheiten"
           }
         }
       }
@@ -4023,6 +4707,12 @@
             "state": "translated",
             "value": "Что нового в Codenotch"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Neuheiten in Codenotch"
+          }
         }
       }
     },
@@ -4057,6 +4747,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Версия %@"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Version %@"
           }
         }
       }
@@ -4093,6 +4789,12 @@
             "state": "translated",
             "value": "Продолжить"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fortfahren"
+          }
         }
       }
     },
@@ -4127,6 +4829,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "macOS отказала — попробуйте переместить Codenotch в /Applications."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macOS hat das abgelehnt — versuche, Codenotch nach /Applications zu verschieben."
           }
         }
       }
@@ -4163,6 +4871,12 @@
             "state": "translated",
             "value": "через %@"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "über %@"
+          }
         }
       }
     },
@@ -4197,6 +4911,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "登录 %@"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bei %@ anmelden"
           }
         }
       }
@@ -4233,6 +4953,12 @@
             "state": "translated",
             "value": "登录 %@ 以读取此账号。"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Melde dich bei %@ an, um dieses Konto zu lesen."
+          }
         }
       }
     },
@@ -4267,6 +4993,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "用 %@ 登录以读取此账号。"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Melde dich mit %@ an, um dieses Konto zu lesen."
           }
         }
       }
@@ -4303,6 +5035,12 @@
             "state": "translated",
             "value": "在 %@ 窗口里退出，才能换另一个账号。"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Melde dich im %@-Fenster ab, um ein anderes Konto zu verwenden."
+          }
         }
       }
     },
@@ -4337,6 +5075,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "在 %@ 里切换账号，刘海会跟上。"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Konto in %@ wechseln; die Notch folgt."
           }
         }
       }
@@ -4373,6 +5117,12 @@
             "state": "translated",
             "value": "在持有该账号的工具里切换，刘海会跟上。"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Konto in dem Tool wechseln, dem es gehört; die Notch folgt."
+          }
         }
       }
     },
@@ -4407,6 +5157,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "会退出 %@ — 这个会话属于 Codenotch。"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Meldet dich bei %@ ab — die Sitzung gehört Codenotch."
           }
         }
       }
@@ -4443,6 +5199,12 @@
             "state": "translated",
             "value": "你在 %@ 里仍然是登录状态 — 要结束会话，去 %@ 里操作。"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Du bleibst bei %@ angemeldet — beende diese Sitzung direkt in %@."
+          }
         }
       }
     },
@@ -4477,6 +5239,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Вход в инструмент, которому принадлежит аккаунт, сохраняется."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Du bleibst bei dem Tool angemeldet, dem das Konto gehört."
           }
         }
       }
@@ -4513,6 +5281,12 @@
             "state": "translated",
             "value": "用持有此账号的工具登录。"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Melde dich mit dem Tool an, dem dieses Konto gehört."
+          }
         }
       }
     },
@@ -4547,6 +5321,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "登录 %@…"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bei %@ anmelden…"
           }
         }
       }
@@ -4583,6 +5363,12 @@
             "state": "translated",
             "value": "Запустите grok login — команда выполнит вход и обновит читаемый токен."
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Führe grok login aus — das meldet dich an und erneuert das hier gelesene Token."
+          }
         }
       }
     },
@@ -4617,6 +5403,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Использование берётся из ключа opencode-go, который OpenCode сохраняет при входе — подключите Go в OpenCode (`opencode auth login`), и панель начнёт его читать."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die Nutzung hängt am opencode-go-Schlüssel, den OpenCode bei der Anmeldung speichert — verbinde Go innerhalb von OpenCode (`opencode auth login`), und die Notch liest ihn."
           }
         }
       }
@@ -4653,6 +5445,12 @@
             "state": "translated",
             "value": "Использование берётся из ключа Z.ai GLM Coding Plan, который хранит инструмент разработки — settings.json Claude Code, ZCode или OpenCode. Настройте ключ там, и панель начнёт его читать."
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die Nutzung hängt an einem Z.ai-GLM-Coding-Plan-Schlüssel, den ein Coding-Tool besitzt — Claude Codes settings.json, ZCode oder OpenCode. Richte dort einen ein, und die Notch liest ihn."
+          }
         }
       }
     },
@@ -4687,6 +5485,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Один раз запустите `%@` — команда выполнит вход и обновит читаемый токен. Для смены аккаунта используйте там /login."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Führe einmal `%@` aus — das meldet dich an und erneuert das hier gelesene Token. Verwende dort /login, um das Konto zu wechseln."
           }
         }
       }
@@ -4723,6 +5527,12 @@
             "state": "translated",
             "value": "%@ 套餐无限制 — 没有可计量的额度"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unbegrenzt im %@-Tarif — nichts zu messen"
+          }
         }
       }
     },
@@ -4757,6 +5567,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "В тарифе %@ пока нечего измерять для Cursor"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Der %@-Tarif hat für Cursor noch nichts zu messen"
           }
         }
       }
@@ -4793,6 +5609,12 @@
             "state": "translated",
             "value": "Codex не сообщил ни одного окна использования"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Codex hat keine Nutzungsfenster gemeldet"
+          }
         }
       }
     },
@@ -4827,6 +5649,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Для этого ключа нет подписки OpenCode Go"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kein OpenCode-Go-Abo auf diesem Schlüssel"
           }
         }
       }
@@ -4863,6 +5691,12 @@
             "state": "translated",
             "value": "Для этого аккаунта Grok пока нет измеряемого использования"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Grok hat für dieses Konto noch nichts zu messen"
+          }
         }
       }
     },
@@ -4897,6 +5731,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "设置…"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Einstellungen…"
           }
         }
       }
@@ -4933,6 +5773,12 @@
             "state": "translated",
             "value": "退出 Codenotch"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Codenotch beenden"
+          }
         }
       }
     },
@@ -4967,6 +5813,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "保持展开"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Offen halten"
           }
         }
       }
@@ -5003,6 +5855,12 @@
             "state": "translated",
             "value": "立即刷新"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Jetzt aktualisieren"
+          }
         }
       }
     },
@@ -5037,6 +5895,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Для Codenotch включён режим «Показывать всегда». Измените его в настройках."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Codenotch ist auf „Immer anzeigen“ eingestellt. Ändere das in den Einstellungen."
           }
         }
       }
@@ -5073,6 +5937,12 @@
             "state": "translated",
             "value": "正在检查…"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wird geprüft…"
+          }
         }
       }
     },
@@ -5107,6 +5977,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Codenotch 已是最新版本。"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Codenotch ist auf dem neuesten Stand."
           }
         }
       }
@@ -5143,6 +6019,12 @@
             "state": "translated",
             "value": "版本 %@ 可用，即将安装。"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Version %@ ist verfügbar und wird in Kürze installiert."
+          }
         }
       }
     },
@@ -5177,6 +6059,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Не удалось связаться с сервером обновлений. Codenotch повторит попытку автоматически — с этой копией всё в порядке."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Der Update-Server war nicht erreichbar. Codenotch versucht es von selbst noch einmal — mit dieser Kopie ist alles in Ordnung."
           }
         }
       }
@@ -5213,6 +6101,12 @@
             "state": "translated",
             "value": "Два новых провайдера и восстановленный аккаунт с активным тарифом."
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zwei weitere Anbieter, und ein Live-Kontotarif, der stillschweigend verloren ging."
+          }
         }
       }
     },
@@ -5247,6 +6141,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Grok — новое кольцо"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Grok ist ein neuer Ring"
           }
         }
       }
@@ -5283,6 +6183,12 @@
             "state": "translated",
             "value": "Недельный лимит Grok Build в SuperGrok, читаемый из того же платёжного API, что использует CLI, с сессией из ~/.grok/auth.json."
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SuperGroks wöchentliches Grok-Build-Kontingent, gelesen vom selben Abrechnungs-Endpunkt wie die CLI, mit der Sitzung aus ~/.grok/auth.json."
+          }
         }
       }
     },
@@ -5317,6 +6223,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Тариф Go в OpenCode — новое кольцо"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OpenCodes Go-Tarif ist ein neuer Ring"
           }
         }
       }
@@ -5353,6 +6265,12 @@
             "state": "translated",
             "value": "Читает официальный API использования тарифа Go с ключом, который OpenCode сохраняет при входе — второй вход не нужен."
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liest den offiziellen Nutzungs-Endpunkt des Go-Tarifs mit dem Schlüssel, den OpenCode selbst bei der Anmeldung speichert — keine zweite Anmeldung nötig."
+          }
         }
       }
     },
@@ -5387,6 +6305,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Настоящий аккаунт Codex перестал считаться"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ein echtes Codex-Konto wurde nicht erfasst"
           }
         }
       }
@@ -5423,6 +6347,12 @@
             "state": "translated",
             "value": "Актуальное чтение Codex распознавало только окна на 5 часов и 7 дней. У бесплатного аккаунта настоящим был лимит на 30 дней, который незаметно пропускался, поэтому отслеживаемый аккаунт показывался без измеряемого использования."
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Codex' Live-Messwert erkannte nur ein 5-Stunden- und ein 7-Tage-Fenster. Das tatsächliche Limit eines Kontos mit kostenlosem Tarif war ein 30-Tage-Limit, das unbemerkt durchrutschte und bei einem eigentlich erfassten Konto als „nichts zu messen“ angezeigt wurde."
+          }
         }
       }
     },
@@ -5457,6 +6387,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Выключение провайдера теперь действительно останавливает его"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Einen Anbieter auszuschalten stoppt ihn jetzt wirklich"
           }
         }
       }
@@ -5493,6 +6429,12 @@
             "state": "translated",
             "value": "Открытие настроек всё ещё могло читать аккаунт выключенного провайдера, а уже выполнявшийся ответ мог вернуть только что удалённое показание."
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Das Öffnen der Einstellungen konnte noch das Konto eines abgeschalteten Anbieters lesen, und eine bereits unterwegs befindliche Antwort konnte einen Messwert wiederherstellen, den du gerade erst vergessen lassen wolltest."
+          }
         }
       }
     },
@@ -5527,6 +6469,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Сборка для разработчиков работает без сертификата"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mitwirkende können ohne Zertifikat bauen"
           }
         }
       }
@@ -5563,6 +6511,12 @@
             "state": "translated",
             "value": "make build и make test теперь автоматически подписывают сборку, если Developer ID сопровождающего отсутствует — аккаунт Apple для работы над проектом не нужен."
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "make build und make test signieren sich jetzt automatisch selbst, wenn die Developer ID des Maintainers fehlt — für die Mitarbeit ist kein Apple-Konto nötig."
+          }
         }
       }
     },
@@ -5597,6 +6551,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Выход из сна больше не удаляет показание."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Das Aufwachen aus dem Ruhezustand löscht keinen Messwert mehr."
           }
         }
       }
@@ -5633,6 +6593,12 @@
             "state": "translated",
             "value": "Кольцо переживает выход Mac из сна"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ein Ring übersteht das Aufwecken deines Mac"
+          }
         }
       }
     },
@@ -5667,6 +6633,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Короткий период после сна, когда macOS ещё не разрешает запрос к связке ключей, ошибочно считался выходом из аккаунта — показание удалялось и на экране оставалось «ожидание первого показания». Теперь число помечается устаревшим и чтение возобновляется автоматически."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ein kurzes Zeitfenster direkt nach dem Ruhezustand, in dem macOS noch keine Schlüsselbund-Abfrage zulässt, wurde fälschlich als Abmeldung gewertet — das löschte den Messwert und ließ „wartet auf den ersten Messwert“ auf dem Bildschirm stehen. Die Zahl wird jetzt nur als veraltet markiert statt verworfen und erholt sich von selbst wieder."
           }
         }
       }
@@ -5703,6 +6675,12 @@
             "state": "translated",
             "value": "Два новых аккаунта, четыре исправления сообщества и корректная обработка дубликатов."
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zwei weitere Konten, vier Community-Korrekturen, und ehrliche Duplikate."
+          }
         }
       }
     },
@@ -5737,6 +6715,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Несколько аккаунтов Claude Code"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mehrere Claude-Code-Konten"
           }
         }
       }
@@ -5773,6 +6757,12 @@
             "state": "translated",
             "value": "Используете CLAUDE_CONFIG_DIR для рабочего входа? Теперь у него есть отдельное кольцо, лимиты и строка в настройках рядом с личным аккаунтом."
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hältst du eine Arbeitsanmeldung mit CLAUDE_CONFIG_DIR getrennt? Sie bekommt jetzt einen eigenen Ring, eigene Limits und eine eigene Zeile in den Einstellungen, neben deiner persönlichen."
+          }
         }
       }
     },
@@ -5807,6 +6797,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Добавлен GLM"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GLM hinzugefügt"
           }
         }
       }
@@ -5843,6 +6839,12 @@
             "state": "translated",
             "value": "Тариф Z.ai Coding Plan теперь тоже читается в реальном времени с ключом из уже авторизованного инструмента."
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Auch Z.ais Coding Plan liest jetzt live, mit einem Schlüssel, der von einem Tool geliehen wird, das bereits einen besitzt."
+          }
         }
       }
     },
@@ -5877,6 +6879,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Зависшее кольцо Claude восстанавливается само"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ein hängengebliebener Claude-Ring erholt sich von selbst"
           }
         }
       }
@@ -5913,6 +6921,12 @@
             "state": "translated",
             "value": "Кратковременная ошибка — чаще всего при выходе Mac из сна — раньше блокировала кольцо до перезапуска приложения. Теперь оно очищается при следующей проверке."
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ein einziger kurzer Fehler — meistens beim Aufwachen des Mac aus dem Ruhezustand — sperrte den Ring bisher, bis die App neu gestartet wurde. Jetzt löst er sich bei der nächsten Prüfung von selbst."
+          }
         }
       }
     },
@@ -5947,6 +6961,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Сеансы Cursor перестают сообщать о завершённой работе"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cursor-Sitzungen melden bereits beendete Arbeit nicht mehr"
           }
         }
       }
@@ -5983,6 +7003,12 @@
             "state": "translated",
             "value": "После сбоя или оставленный чат мог считаться «всё ещё работающим» день и дольше. Теперь приложение замечает фактическое завершение работы."
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ein abgestürzter oder verlassener Chat konnte einen Tag oder länger als „noch in Arbeit“ angezeigt werden. Jetzt wird erkannt, wenn das Schreiben tatsächlich aufgehört hat."
+          }
         }
       }
     },
@@ -6017,6 +7043,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Старая копия больше не может оказаться главной"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ein monatealtes Duplikat kann nicht mehr gewinnen"
           }
         }
       }
@@ -6053,6 +7085,12 @@
             "state": "translated",
             "value": "Claude Code создаёт новую запись в связке ключей при каждой смене токена. Давно авторизованный аккаунт мог случайно выбрать старую просроченную запись и навсегда показать «ожидание первого показания»."
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Claude Code legt bei jeder Token-Rotation einen neuen Schlüsselbundeintrag an. Ein länger angemeldetes Konto konnte zufällig einen alten, abgelaufenen Eintrag erwischen und für immer „wartet auf den ersten Messwert“ anzeigen."
+          }
         }
       }
     },
@@ -6087,6 +7125,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Случайный щелчок больше не оставляет панель открытой"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ein versehentlicher Klick hält die Notch nicht mehr offen fest"
           }
         }
       }
@@ -6123,6 +7167,12 @@
             "state": "translated",
             "value": "Щелчок у края экрана до открытия панели мог оставить её открытой без объяснения на экране."
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ein Klick in der Nähe des Bildschirmrands, bevor sich die Notch überhaupt geöffnet hatte, konnte sie offen hängen lassen, ohne dass etwas auf dem Bildschirm den Grund erklärte."
+          }
         }
       }
     },
@@ -6157,6 +7207,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Codex читается в реальном времени, а «Показывать всегда» сохраняется."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Codex liest live, und „Immer anzeigen“ bleibt an."
           }
         }
       }
@@ -6193,6 +7249,12 @@
             "state": "translated",
             "value": "Codex читается в реальном времени, а не из журнала"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Codex wird live gelesen statt aus einem Protokoll"
+          }
         }
       }
     },
@@ -6227,6 +7289,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Число бралась из файла, который Codex записывает во время хода, поэтому могло устареть на несколько дней. Теперь Codenotch спрашивает сам Codex и показывает данные его панели."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die Zahl stammte aus einer Datei, die Codex während eines Turns schreibt, war also so alt wie deine letzte Nutzung — in einem Fall drei Tage veraltet. Codenotch fragt jetzt Codex selbst und stimmt mit dessen eigenem Panel überein."
           }
         }
       }
@@ -6263,6 +7331,12 @@
             "state": "translated",
             "value": "Кольцо Codex видит настольное приложение"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Der Codex-Ring bemerkt jetzt die Desktop-App"
+          }
         }
       }
     },
@@ -6297,6 +7371,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Раньше отслеживались только файлы CLI и расширения VS Code, поэтому работа в настольном приложении не запускала вращение кольца."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Es wurden bisher nur die Dateien beobachtet, die die CLI und die VS-Code-Erweiterung schreiben, sodass Arbeit in der Desktop-App den Ring nie zum Drehen brachte."
           }
         }
       }
@@ -6333,6 +7413,12 @@
             "state": "translated",
             "value": "«Показывать всегда» больше не выключается само"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "„Immer anzeigen“ schaltet sich nicht mehr von selbst ab"
+          }
         }
       }
     },
@@ -6367,6 +7453,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Щелчок по панели менял тот же флаг, что и настройка, поэтому случайный щелчок незаметно возвращал режим показа при наведении."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ein Klick auf die Notch änderte dieselbe Einstellung wie die Option selbst, sodass ein versehentlicher Klick sie stillschweigend wieder auf „bei Hover anzeigen“ zurückstellte."
           }
         }
       }
@@ -6403,6 +7495,12 @@
             "state": "translated",
             "value": "Гораздо меньше запросов связки ключей"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Deutlich weniger Schlüsselbund-Abfragen"
+          }
         }
       }
     },
@@ -6437,6 +7535,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "После истечения токена каждая проверка обращалась к связке ключей и показывала запрос раз в минуту. Теперь секрет читается только после изменения владельцем, а отказ не повторяется по таймеру."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sobald ein Token ablief, griff jede Prüfung erneut auf den Schlüsselbund zu — eine Abfrage pro Minute. Jetzt wird das Geheimnis nur gelesen, wenn die besitzende App es geändert hat, und eine Ablehnung wird nie zeitgesteuert wiederholt."
           }
         }
       }
@@ -6473,6 +7577,12 @@
             "state": "translated",
             "value": "Приостановленный лимит отображается как приостановленный"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ein pausiertes Limit wird als pausiert angezeigt"
+          }
         }
       }
     },
@@ -6507,6 +7617,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Некоторые лимиты достигаются, хотя основной показатель ещё показывает запас. Кольцо теперь показывает расход и время снятия ограничения."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Manche Limits werden erreicht, während die Hauptzahl noch Spielraum zeigt. Der Ring zeigt sich als aufgebraucht an und sagt, wann sich das ändert."
           }
         }
       }
@@ -6543,6 +7659,12 @@
             "state": "translated",
             "value": "Длинные сообщения больше не обрезаются"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lange Nachrichten werden nicht mehr abgeschnitten"
+          }
         }
       }
     },
@@ -6577,6 +7699,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Подсказка с пояснением теперь выделяет под него строку независимо от длины текста."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ein Tooltip mit etwas zu erklären reservierte dafür nur eine Zeile, egal wie viel er zu sagen hatte."
           }
         }
       }
@@ -6613,6 +7741,12 @@
             "state": "translated",
             "value": "Каждый сеанс и подсказка, помещающаяся на экране."
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Jede Sitzung, und ein Tooltip, der auf den Bildschirm passt."
+          }
         }
       }
     },
@@ -6647,6 +7781,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Подсказки больше не обрезаются"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tooltips werden nicht mehr abgeschnitten"
           }
         }
       }
@@ -6683,6 +7823,12 @@
             "state": "translated",
             "value": "Карточка центрируется относительно своего кольца. Раньше у первого и последнего провайдера её половина выходила за край панели вместе с заголовком; теперь место резервируется."
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eine Karte wird auf dem Ring zentriert, zu dem sie gehört — beim ersten und letzten Anbieter ragte deshalb die Hälfte über den Rand des Panels hinaus, und was dabei verloren ging, war der Titel. Das Panel hält dafür jetzt Platz frei."
+          }
         }
       }
     },
@@ -6717,6 +7863,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Столько сеансов, сколько помещается на экране"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "So viele Sitzungen, wie auf den Bildschirm passen"
           }
         }
       }
@@ -6753,6 +7905,12 @@
             "state": "translated",
             "value": "Раньше список всегда ограничивался четырьмя пунктами. Теперь он подстраивается под экран: до десяти на большом, а «и ещё N» появляется только при нехватке места."
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die Liste war bisher unabhängig vom Gerät auf vier begrenzt. Jetzt richtet sie sich nach dem Bildschirm: zehn auf einem großen, und „und N weitere“ nur, wenn für den Rest wirklich kein Platz ist."
+          }
         }
       }
     },
@@ -6787,6 +7945,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Сначала показываются те, кому вы нужны"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die, die dich brauchen, kommen zuerst"
           }
         }
       }
@@ -6823,6 +7987,12 @@
             "state": "translated",
             "value": "Сначала ожидание, затем работа и простой — при сокращении списка исчезает наименее важное."
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erst wartend, dann beschäftigt, dann untätig — was also zusammengefasst wegfällt, ist das Unwichtigste."
+          }
         }
       }
     },
@@ -6857,6 +8027,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Настоящие числа Antigravity и переключатель, который не включается обратно."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Antigravitys echte Zahlen, und ein Schalter, der ausgeschaltet bleibt."
           }
         }
       }
@@ -6893,6 +8069,12 @@
             "state": "translated",
             "value": "Antigravity показывает настоящий лимит"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Antigravity zeigt sein tatsächliches Kontingent"
+          }
         }
       }
     },
@@ -6927,6 +8109,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Google не отвечает Codenotch напрямую, поэтому приложение спрашивает языковой сервер Antigravity — тот же источник использует панель использования Antigravity."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Google antwortet Codenotch nicht direkt, deshalb fragt es stattdessen Antigravitys eigenen Language-Server — dieselbe Quelle, aus der auch Antigravitys Nutzungsanzeige ihre Zahl bezieht."
           }
         }
       }
@@ -6963,6 +8151,12 @@
             "state": "translated",
             "value": "Использование читается в обоих направлениях"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nutzung lässt sich von beiden Seiten lesen"
+          }
         }
       }
     },
@@ -6997,6 +8191,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "«Использовано 12% · осталось 88%», поэтому показание совпадает с тем, какую сторону показывает поставщик."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "„12 % verwendet · 88 % übrig“, damit ein Messwert zu der Seite passt, die dein Anbieter gerade zeigt."
           }
         }
       }
@@ -7033,6 +8233,12 @@
             "state": "translated",
             "value": "Возможность повторить отклонённый запрос связки ключей"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ein Weg zurück nach einer abgelehnten Schlüsselbund-Abfrage"
+          }
         }
       }
     },
@@ -7067,6 +8273,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Отказ больше не выглядит как выход из аккаунта, а «Разрешить доступ…» повторяет запрос macOS."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ablehnen sieht nicht mehr wie eine Abmeldung aus, und „Zugriff erlauben…“ fragt macOS erneut."
           }
         }
       }
@@ -7103,6 +8315,12 @@
             "state": "translated",
             "value": "Выключение провайдера теперь сохраняется"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Einen Anbieter auszuschalten bleibt jetzt bestehen"
+          }
         }
       }
     },
@@ -7137,6 +8355,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Чтение прекращается, а последнее показание сохраняется, поэтому кольцо возвращается при следующем запуске."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Es wurde nicht mehr gelesen, aber der letzte Messwert blieb erhalten, sodass der Ring beim nächsten Start zurückkam."
           }
         }
       }
@@ -7173,6 +8397,12 @@
             "state": "translated",
             "value": "Далёкий сброс показывает дату"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Weit entfernte Zurücksetzungen zeigen ein Datum"
+          }
         }
       }
     },
@@ -7207,6 +8437,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Для лимита, обновляющегося через четыре недели, показывалось «Пн», что выглядело как ближайший понедельник. Теперь показывается «28 сен»."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ein Limit, das erst in vier Wochen erneuert wird, zeigte „Mo“ an, was wie dieser Montag wirkte. Jetzt steht dort „28. Sep.“."
           }
         }
       }
@@ -7243,6 +8479,12 @@
             "state": "translated",
             "value": "Первый выпуск."
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die erste Version."
+          }
         }
       }
     },
@@ -7277,6 +8519,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Разместите панель где угодно"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die Notch überall platzieren"
           }
         }
       }
@@ -7313,6 +8561,12 @@
             "state": "translated",
             "value": "Справа, слева, сверху или снизу. Панель не перекрывает Dock и строку меню и перемещается вместе с Dock."
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rechts, links, oben oder unten. Sie hält Abstand zu Dock und Menüleiste und folgt, wenn sich das Dock bewegt."
+          }
         }
       }
     },
@@ -7347,6 +8601,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Она объединяется с выемкой Mac"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sie verschmilzt mit der Notch deines Mac"
           }
         }
       }
@@ -7383,6 +8643,12 @@
             "state": "translated",
             "value": "У верхнего края она повторяет форму аппаратной выемки, поэтому выглядит единым элементом, а не панелью под ней."
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Am oberen Rand nimmt sie die Form der Hardware an, sodass beide wie eine Einheit wirken statt wie ein darunter geparkter Balken."
+          }
         }
       }
     },
@@ -7417,6 +8683,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Claude, Cursor, Codex и Gemini"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Claude, Cursor, Codex und Gemini"
           }
         }
       }
@@ -7453,6 +8725,12 @@
             "state": "translated",
             "value": "Данные читаются из уже авторизованного на этом Mac инструмента. Codenotch никогда не спрашивает пароль."
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Jeder wird aus dem Tool gelesen, das auf diesem Mac bereits angemeldet ist. Codenotch fragt nie nach einem Passwort."
+          }
         }
       }
     },
@@ -7487,6 +8765,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Выберите, где показывать Codenotch"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wählen, wo Codenotch erscheint"
           }
         }
       }
@@ -7523,6 +8807,12 @@
             "state": "translated",
             "value": "В Dock, в строке меню или нигде."
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Im Dock, in der Menüleiste oder gar nicht."
+          }
         }
       }
     },
@@ -7554,6 +8844,12 @@
           }
         },
         "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Codenotch"
+          }
+        },
+        "de": {
           "stringUnit": {
             "state": "translated",
             "value": "Codenotch"
@@ -7593,6 +8889,12 @@
             "state": "translated",
             "value": "Использовано %@%% · осталось %@%%"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@%% verwendet · %@%% übrig"
+          }
         }
       }
     },
@@ -7627,6 +8929,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "осталось %@"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ übrig"
           }
         }
       }
@@ -7663,6 +8971,12 @@
             "state": "translated",
             "value": "использовано %@"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ verwendet"
+          }
         }
       }
     },
@@ -7697,6 +9011,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Войдите через GitHub CLI, чтобы читать использование Copilot"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Melde dich mit der GitHub-CLI an, um deine Copilot-Nutzung zu lesen"
           }
         }
       }
@@ -7733,6 +9053,12 @@
             "state": "translated",
             "value": "Выполните вход через GitHub CLI командой `gh auth login`, затем включите GitHub Copilot."
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Melde dich mit `gh auth login` bei der GitHub-CLI an und aktiviere dann GitHub Copilot."
+          }
         }
       }
     },
@@ -7767,6 +9093,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "GitHub Copilot не сообщил измеряемых квот"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GitHub Copilot hat keine messbaren Kontingente gemeldet"
           }
         }
       }
@@ -7803,6 +9135,12 @@
             "state": "translated",
             "value": "Вход не требуется: показатель складывается из данных о собственных вызовах Gemini CLI, OpenCode и Hermes. Ваш API-ключ никогда не читается."
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Es gibt nichts, wo man sich anmelden müsste: Die Zahl wird aus dem zusammengerechnet, was Gemini CLI, OpenCode und Hermes über ihre eigenen Aufrufe aufgezeichnet haben. Dein API-Schlüssel wird nie gelesen."
+          }
         }
       }
     },
@@ -7837,6 +9175,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Сеансы Gemini CLI, OpenCode или Hermes не найдены"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine Gemini-CLI-, OpenCode- oder Hermes-Sitzungen gefunden"
           }
         }
       }
@@ -7873,6 +9217,12 @@
             "state": "translated",
             "value": "Один раз запустите `%@` — команда выполнит вход и станет источником этих показаний. Для смены аккаунта используйте там /login."
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Führe einmal `%@` aus — das meldet dich an, und daher stammen diese Messwerte. Verwende dort /login, um das Konto zu wechseln."
+          }
         }
       }
     },
@@ -7907,6 +9257,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Ограниченное"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eingegrenzt"
           }
         }
       }
@@ -7943,6 +9299,12 @@
             "state": "translated",
             "value": "Автоматическое использование"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Auto-Nutzung"
+          }
         }
       }
     },
@@ -7977,6 +9339,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Команда по запросу"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Team bei Bedarf"
           }
         }
       }
@@ -8013,6 +9381,12 @@
             "state": "translated",
             "value": "全部刷新"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alle aktualisieren"
+          }
         }
       }
     },
@@ -8047,6 +9421,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "重置日期"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rücksetzdatum"
           }
         }
       }
@@ -8083,6 +9463,12 @@
             "state": "translated",
             "value": "剩余时间"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verbleibende Zeit"
+          }
         }
       }
     },
@@ -8117,6 +9503,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Минуты, если до сброса меньше часа; иначе дата и время сброса."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Minuten bei unter einer Stunde; sonst Datum und Uhrzeit der Zurücksetzung."
           }
         }
       }
@@ -8153,6 +9545,12 @@
             "state": "translated",
             "value": "Время до сброса использования, например 3 дня 3 ч или 3 ч 20 мин."
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zeit bis zur Zurücksetzung der Nutzung, etwa 3 Tage 3 Std. oder 3 Std. 20 Min."
+          }
         }
       }
     },
@@ -8187,6 +9585,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Сброс через %lld дн. %lld ч"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zurücksetzung in %lld Tag %lld Std."
           }
         }
       }
@@ -8223,6 +9627,12 @@
             "state": "translated",
             "value": "Сброс через %lld дн. %lld ч"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zurücksetzung in %lld Tagen %lld Std."
+          }
         }
       }
     },
@@ -8257,6 +9667,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Сброс через %lld ч %lld мин"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zurücksetzung in %lld Std. %lld Min."
           }
         }
       }
@@ -8293,6 +9709,12 @@
             "state": "translated",
             "value": "На экране ничего нет. Если значок приложения находится в строке меню, показания остаются в её меню. Иначе снова откройте Codenotch из папки «Программы», чтобы вернуть эти настройки."
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nichts auf dem Bildschirm. Wenn App-Symbol auf Menüleiste steht, bleiben die Messwerte im Menü der Menüleiste. Andernfalls öffne Codenotch erneut aus dem Programme-Ordner, um diese Einstellungen zurückzuholen."
+          }
         }
       }
     },
@@ -8327,6 +9749,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "主显示器"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hauptbildschirm"
           }
         }
       }
@@ -8363,6 +9791,12 @@
             "state": "translated",
             "value": "所有显示器"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alle Bildschirme"
+          }
         }
       }
     },
@@ -8397,6 +9831,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Панель появляется только на дисплее со строкой меню."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die Notch erscheint nur auf dem Bildschirm mit der Menüleiste."
           }
         }
       }
@@ -8433,6 +9873,12 @@
             "state": "translated",
             "value": "На каждом дисплее есть своя панель, и наведение открывает только её."
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Jeder Bildschirm bekommt seine eigene Notch, und Hover öffnet jeweils nur diese eine."
+          }
         }
       }
     },
@@ -8467,6 +9913,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "3 秒"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "3 Sekunden"
           }
         }
       }
@@ -8503,6 +9955,12 @@
             "state": "translated",
             "value": "5 秒"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "5 Sekunden"
+          }
         }
       }
     },
@@ -8537,6 +9995,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "10 秒"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "10 Sekunden"
           }
         }
       }
@@ -8573,6 +10037,12 @@
             "state": "translated",
             "value": "Достаточно долго, чтобы заметить, и достаточно коротко, чтобы не мешать."
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lang genug, um es zu bemerken, kurz genug, um es zu ignorieren."
+          }
         }
       }
     },
@@ -8607,6 +10077,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Достаточно долго, чтобы прочитать название сеанса и открыть его."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lang genug, um den Namen der Sitzung zu lesen und danach zu greifen."
           }
         }
       }
@@ -8643,6 +10119,12 @@
             "state": "translated",
             "value": "Остаётся открытой, пока вы не успеете на неё посмотреть."
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bleibt, bis du die Gelegenheit hattest, hinzusehen."
+          }
         }
       }
     },
@@ -8677,6 +10159,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Акцентный цвет устройства"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Akzentfarbe des Geräts"
           }
         }
       }
@@ -8713,6 +10201,12 @@
             "state": "translated",
             "value": "Подключён"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verbunden"
+          }
         }
       }
     },
@@ -8747,6 +10241,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Не подключён"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nicht verbunden"
           }
         }
       }
@@ -8783,6 +10283,12 @@
             "state": "translated",
             "value": "Аккаунты"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Konten"
+          }
         }
       }
     },
@@ -8817,6 +10323,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Уведомления"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Benachrichtigungen"
           }
         }
       }
@@ -8853,6 +10365,12 @@
             "state": "translated",
             "value": "Ничего не подключено, поэтому панели нечего отображать."
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nichts ist verbunden, daher hat die Notch keine Ringe zu zeichnen."
+          }
         }
       }
     },
@@ -8887,6 +10405,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Панель отображает эти кольца в таком порядке. Перетащите кольцо за маркер, чтобы изменить порядок."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die Notch zeichnet diese in dieser Reihenfolge. Ziehe eines an seinem Griff, um es zu verschieben."
           }
         }
       }
@@ -8923,6 +10447,12 @@
             "state": "translated",
             "value": "У этих провайдеров нет кольца. Включите один, и он добавится в конец списка выше."
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Diese haben keinen Ring zum Platzieren. Schalte eines ein, und es reiht sich am Ende der obigen Liste ein."
+          }
         }
       }
     },
@@ -8957,6 +10487,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Панель"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Notch"
           }
         }
       }
@@ -8993,6 +10529,12 @@
             "state": "translated",
             "value": "Время сброса"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rücksetzzeit"
+          }
         }
       }
     },
@@ -9027,6 +10569,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Дисплеи"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bildschirme"
           }
         }
       }
@@ -9063,6 +10611,12 @@
             "state": "translated",
             "value": "Дисплей"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bildschirm"
+          }
         }
       }
     },
@@ -9097,6 +10651,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Следовать за активным окном"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aktivem Fenster folgen"
           }
         }
       }
@@ -9133,6 +10693,12 @@
             "state": "translated",
             "value": "Недоступный дисплей"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nicht verfügbarer Bildschirm"
+          }
         }
       }
     },
@@ -9167,6 +10733,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Приложение"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "App"
           }
         }
       }
@@ -9203,6 +10775,12 @@
             "state": "translated",
             "value": "Акцентный цвет"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Akzentfarbe"
+          }
         }
       }
     },
@@ -9237,6 +10815,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "При завершении сеанса"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wenn eine Sitzung endet"
           }
         }
       }
@@ -9273,6 +10857,12 @@
             "state": "translated",
             "value": "Ненадолго открыть панель"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die Notch kurz öffnen"
+          }
         }
       }
     },
@@ -9307,6 +10897,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "На"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dauer"
           }
         }
       }
@@ -9343,6 +10939,12 @@
             "state": "translated",
             "value": "Воспроизводить звук"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Einen Ton abspielen"
+          }
         }
       }
     },
@@ -9377,6 +10979,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Завершено"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abgeschlossen"
           }
         }
       }
@@ -9413,6 +11021,12 @@
             "state": "translated",
             "value": "Ожидает вас"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wartet auf dich"
+          }
         }
       }
     },
@@ -9447,6 +11061,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Оповещения о порогах"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Schwellenwert-Benachrichtigungen"
           }
         }
       }
@@ -9483,6 +11103,12 @@
             "state": "translated",
             "value": "Скрыть боковую панель"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Seitenleiste ausblenden"
+          }
         }
       }
     },
@@ -9517,6 +11143,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Показать боковую панель"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Seitenleiste anzeigen"
           }
         }
       }
@@ -9553,6 +11185,12 @@
             "state": "translated",
             "value": "Выбрано"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ausgewählt"
+          }
         }
       }
     },
@@ -9587,6 +11225,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Не выбрано"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nicht ausgewählt"
           }
         }
       }
@@ -9623,6 +11267,12 @@
             "state": "translated",
             "value": "%@ (отсутствует)"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ (fehlt)"
+          }
         }
       }
     },
@@ -9657,6 +11307,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Воспроизвести %@"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ abspielen"
           }
         }
       }
@@ -9693,6 +11349,12 @@
             "state": "translated",
             "value": "Месячный бюджет"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Monatsbudget"
+          }
         }
       }
     },
@@ -9727,6 +11389,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Нет"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine"
           }
         }
       }
@@ -9763,6 +11431,12 @@
             "state": "translated",
             "value": "токенов"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tokens"
+          }
         }
       }
     },
@@ -9797,6 +11471,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Достигнут лимит %@"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@-Limit erreicht"
           }
         }
       }
@@ -9833,6 +11513,12 @@
             "state": "translated",
             "value": "Использование %@ — %lld%%"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ liegt bei %lld%%"
+          }
         }
       }
     },
@@ -9867,6 +11553,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Лимит %@ исчерпан."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sein %@-Limit ist aufgebraucht."
           }
         }
       }
@@ -9903,6 +11595,12 @@
             "state": "translated",
             "value": "Лимит %@ исчерпан — сброс %@"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sein %@-Limit ist aufgebraucht — Zurücksetzung %@"
+          }
         }
       }
     },
@@ -9937,6 +11635,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "已用其 %@ 额度的 %lld%%。"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld%% des %@-Limits verwendet."
           }
         }
       }
@@ -9973,6 +11677,12 @@
             "state": "translated",
             "value": "Перемещается на дисплей с окном, получающим ввод с клавиатуры."
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wechselt zu dem Bildschirm, auf dem sich das Fenster mit der Tastatureingabe befindet."
+          }
         }
       }
     },
@@ -10007,6 +11717,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Закреплено на %@."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "An %@ geheftet."
           }
         }
       }
@@ -10043,6 +11759,12 @@
             "state": "translated",
             "value": "Этот дисплей отключён. Codenotch следует за активным окном, пока дисплей не вернётся."
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dieser Bildschirm ist getrennt. Codenotch folgt dem aktiven Fenster, bis er zurückkommt."
+          }
         }
       }
     },
@@ -10077,6 +11799,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Перетащите, чтобы изменить порядок. Панель отображает кольца в этом порядке."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ziehen, um die Reihenfolge zu ändern. Die Notch zeichnet die Ringe in dieser Reihenfolge."
           }
         }
       }
@@ -10113,6 +11841,12 @@
             "state": "translated",
             "value": "Включите, чтобы добавить провайдеру кольцо на панели."
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Schalte das ein, um ihm einen Ring in der Notch zu geben."
+          }
         }
       }
     },
@@ -10147,6 +11881,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Оповещения для %@ отключены. Нажмите, чтобы включить их."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Benachrichtigungen für %@ sind stummgeschaltet. Klicken, um sie wieder zu aktivieren."
           }
         }
       }
@@ -10183,6 +11923,12 @@
             "state": "translated",
             "value": "Оповещать, когда %@ достигает 80% и 100% лимита."
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Benachrichtigen, wenn %@ 80 % und 100 % eines Limits überschreitet."
+          }
         }
       }
     },
@@ -10217,6 +11963,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Заполняет кольцо до выбранного предела; Google не публикует предел для API-ключа."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Füllt den Ring gegen eine selbst gewählte Obergrenze; Google veröffentlicht keine für einen API-Schlüssel."
           }
         }
       }
@@ -10253,6 +12005,12 @@
             "state": "translated",
             "value": "Codenotch читает использование из инструментов, уже авторизованных на этом Mac, и никогда не спрашивает пароль. Установите и авторизуйтесь в Claude Code (терминальном инструменте, не приложении Claude), Cursor (редакторе или cursor-agent), Codex, Antigravity, GLM, Grok, OpenCode, GitHub Copilot или Gemini API через Gemini CLI, OpenCode или Hermes — и кольцо появится на панели."
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Codenotch liest die Nutzung von Tools, die auf diesem Mac bereits angemeldet sind — es fragt nie nach deinem Passwort. Installiere eines von Claude Code (das Terminal-Tool, nicht die Claude-App), Cursor (den Editor oder cursor-agent), Codex, Antigravity, GLM, Grok, OpenCode, GitHub Copilot oder einen Gemini-API-Schlüssel (über Gemini CLI, OpenCode oder Hermes) und melde dich an — der zugehörige Ring erscheint dann in der Notch."
+          }
         }
       }
     },
@@ -10287,6 +12045,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "macOS один раз запросит доступ к сохранённым входам Claude Code, Antigravity и cursor-agent. Выберите «Разрешать всегда» — обычное «Разрешить» приводит к повторному запросу."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macOS fragt einmal um Erlaubnis, die gespeicherten Anmeldungen von Claude Code, Antigravity und cursor-agent zu lesen. Wähle „Immer erlauben“ — bei einfachem „Erlauben“ fragt es jedes Mal erneut."
           }
         }
       }
@@ -10323,6 +12087,12 @@
             "state": "translated",
             "value": "Меняйте порядок колец, выбирайте дисплей и получайте уведомления о приближении лимита."
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ringe neu anordnen, einen Bildschirm wählen, und benachrichtigt werden, wenn ein Limit nahe ist."
+          }
         }
       }
     },
@@ -10357,6 +12127,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Перетащите, чтобы изменить порядок колец"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ziehen, um die Ringe neu anzuordnen"
           }
         }
       }
@@ -10393,6 +12169,12 @@
             "state": "translated",
             "value": "Настройки разделены на «Подключённые» и «Не подключённые»; перетащите подключённую строку за маркер, чтобы изменить порядок на панели."
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die Einstellungen gliedern sich in Verbunden und Nicht verbunden; ziehe eine verbundene Zeile an ihrem Griff, um die Zeichenreihenfolge der Notch zu ändern."
+          }
         }
       }
     },
@@ -10427,6 +12209,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Закрепите панель на одном дисплее или показывайте её на всех"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die Notch an einen Bildschirm heften oder auf allen anzeigen"
           }
         }
       }
@@ -10463,6 +12251,12 @@
             "state": "translated",
             "value": "Выбор дисплея в разделе «Внешний вид» предлагает основной дисплей или все дисплеи; второй выбор закрепляет панель на указанном экране."
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eine Bildschirmauswahl im Erscheinungsbild bietet den Hauptbildschirm oder alle Bildschirme an; eine zweite Auswahl heftet eine einzelne Notch an einen bestimmten Bildschirm."
+          }
         }
       }
     },
@@ -10497,6 +12291,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Кольцо сообщает о достижении 80% и 100%"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ein Ring meldet, wenn er 80 % und 100 % überschreitet"
           }
         }
       }
@@ -10533,6 +12333,12 @@
             "state": "translated",
             "value": "Системное уведомление при каждом пересечении порога; для каждого провайдера его можно отключить в строке настроек."
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eine Systembenachrichtigung pro Überschreitung, die sich pro Anbieter in dessen eigener Einstellungszeile stummschalten lässt."
+          }
         }
       }
     },
@@ -10567,6 +12373,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "GitHub Copilot — новое кольцо"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GitHub Copilot ist ein neuer Ring"
           }
         }
       }
@@ -10603,6 +12415,12 @@
             "state": "translated",
             "value": "Читает квоту Copilot через API GitHub, используя уже существующую сессию GitHub CLI на Mac."
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liest den Copilot-Kontingent-Endpunkt von GitHub über die bereits auf dem Mac vorhandene GitHub-CLI-Sitzung."
+          }
         }
       }
     },
@@ -10637,6 +12455,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Сообщать о завершении сеанса"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Meldet, wenn eine Sitzung endet"
           }
         }
       }
@@ -10673,6 +12497,12 @@
             "state": "translated",
             "value": "Панель открывается на несколько секунд и издаёт сигнал, когда агент завершает работу или начинает ждать вас; щелчок открывает сеанс."
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die Notch öffnet sich von selbst für ein paar Sekunden und spielt einen Ton, wenn ein Agent aufhört zu arbeiten oder anfängt, auf dich zu warten; ein Klick springt dorthin."
+          }
         }
       }
     },
@@ -10707,6 +12537,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Перетаскивайте панель вдоль края с ⌥"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mit ⌥ die Pille am Rand entlangziehen"
           }
         }
       }
@@ -10743,6 +12579,12 @@
             "state": "translated",
             "value": "Сдвиньте её, чтобы освободить место для другого приложения в строке меню; положение запоминается для каждого края."
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Schiebe sie so, dass sie eine andere an derselben Stelle verankerte Menüleisten-App nicht überlappt; wird pro Rand gemerkt."
+          }
         }
       }
     },
@@ -10777,6 +12619,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Выберите акцентный цвет"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Akzentfarbe wählen"
           }
         }
       }
@@ -10813,6 +12661,12 @@
             "state": "translated",
             "value": "По умолчанию используется акцент устройства или фиксированный цвет положительного состояния кольца; янтарный и красный цвета предупреждений не меняются."
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Standardmäßig die Geräte-Akzentfarbe, oder eine feste Farbe für den positiven Zustand des Rings — die Warnfarben Gelb und Rot bleiben in jedem Fall fest."
+          }
         }
       }
     },
@@ -10847,6 +12701,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Обратный отсчёт вместо даты сброса"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ein Countdown statt eines Rücksetzdatums"
           }
         }
       }
@@ -10883,6 +12743,12 @@
             "state": "translated",
             "value": "В выборе времени сброса в разделе «Внешний вид» можно показывать «Сброс через 3 ч 20 мин» вместо даты и времени."
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die Rücksetzzeit-Auswahl im Erscheinungsbild kann statt Datum und Uhrzeit „Zurücksetzung in 3 Std. 20 Min.“ anzeigen."
+          }
         }
       }
     },
@@ -10917,6 +12783,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Корректное чтение Cursor через cursor-agent и корпоративных тарифов"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cursor über cursor-agent lesen, Enterprise-Tarife jetzt korrekt"
           }
         }
       }
@@ -10953,6 +12825,12 @@
             "state": "translated",
             "value": "Вход в Cursor только через CLI теперь получает кольцо, а корпоративные и командные тарифы показывают настоящее использование."
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eine reine CLI-Anmeldung bei Cursor bekommt jetzt einen eigenen Ring, und Enterprise-/Team-Tarife zeigen die tatsächliche Nutzung, statt zu melden, dass es nichts zu messen gibt."
+          }
         }
       }
     },
@@ -10987,6 +12865,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Меньше запросов связки ключей для Claude и Antigravity"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Weniger Schlüsselbund-Abfragen für Claude und Antigravity"
           }
         }
       }
@@ -11023,6 +12907,12 @@
             "state": "translated",
             "value": "Claude сначала читает /usage собственного CLI и обращается к связке ключей только как к запасному варианту; Antigravity сначала опрашивает языковой сервер."
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Claude liest zuerst /usage der eigenen CLI und greift nur als Ausweichlösung auf den Schlüsselbund zu; bei Antigravity wird vorher der Language-Server befragt."
+          }
         }
       }
     },
@@ -11057,6 +12947,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Использование меньше 1% больше не отображается как 0%"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nutzung unter 1 % wird nicht mehr als 0 % angezeigt"
           }
         }
       }
@@ -11093,6 +12989,12 @@
             "state": "translated",
             "value": "Показание меньше одного процента отображается с десятичной долей («<0,1%»), а не округляется до нуля."
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ein Messwert unter einem Prozent zeigt eine Nachkommastelle („<0,1 %“) an, statt auf nichts abgerundet zu werden."
+          }
         }
       }
     },
@@ -11127,6 +13029,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Разработчики могут собирать без подписи Xcode"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mitwirkende können ohne Xcode-Signierung bauen"
           }
         }
       }
@@ -11163,6 +13071,12 @@
             "state": "translated",
             "value": "make build и make test автоматически подписывают сборку при отсутствии сертификата сопровождающего, а CI запускает тесты при каждом push и pull request."
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "make build und make test signieren sich automatisch selbst, wenn das Zertifikat des Maintainers fehlt, und die CI führt die Testsuite jetzt bei jedem Push und Pull Request aus."
+          }
         }
       }
     },
@@ -11197,6 +13111,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "跟随系统"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "System folgen"
           }
         }
       }
@@ -11233,6 +13153,12 @@
             "state": "translated",
             "value": "与 Mac 的首选语言一致。"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Entspricht der bevorzugten Sprache des Mac."
+          }
         }
       }
     },
@@ -11267,6 +13193,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "即使 Mac 不是这种语言，Codenotch 也使用它。"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Codenotch verwendet diese Sprache, auch wenn der Mac es nicht tut."
           }
         }
       }
@@ -11303,6 +13235,12 @@
             "state": "translated",
             "value": "语言"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sprache"
+          }
         }
       }
     },
@@ -11337,6 +13275,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Показывать темп использования"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nutzungstempo anzeigen"
           }
         }
       }
@@ -11373,6 +13317,12 @@
             "state": "translated",
             "value": "Сравнивает каждый лимит по времени с оставшимся до сброса временем и показывает дефицит или запас квоты."
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vergleicht jedes zeitgebundene Kontingent mit der bis zur Zurücksetzung verbleibenden Zeit und zeigt, ob ein Kontingent im Defizit oder in Reserve ist."
+          }
         }
       }
     },
@@ -11407,6 +13357,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Размер"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Größe"
           }
         }
       }
@@ -11443,6 +13399,12 @@
             "state": "translated",
             "value": "Маленький"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Klein"
+          }
         }
       }
     },
@@ -11477,6 +13439,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Средний"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mittel"
           }
         }
       }
@@ -11513,6 +13481,12 @@
             "state": "translated",
             "value": "Большой"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Groß"
+          }
         }
       }
     },
@@ -11547,6 +13521,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Занимает минимум места у края. Читается вблизи, но не издалека."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Braucht am Rand am wenigsten Platz. Lesbar, aber nicht quer über den Schreibtisch hinweg."
           }
         }
       }
@@ -11583,6 +13563,12 @@
             "state": "translated",
             "value": "Размер, для которого была отрисована панель."
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die Größe, für die die Notch gezeichnet wurde."
+          }
         }
       }
     },
@@ -11617,6 +13603,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Легче читать одним взглядом, но сложнее не заметить."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Auf einen Blick leichter zu lesen, und schwerer zu übersehen."
           }
         }
       }
@@ -11653,6 +13645,12 @@
             "state": "translated",
             "value": "Удерживайте ⌥ и перетаскивайте панель вдоль края. Для каждого края запоминается последнее положение."
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Halte ⌥ gedrückt und ziehe die Notch, um sie am Rand entlang zu verschieben. Jeder Rand merkt sich, wo du sie zuletzt abgelegt hast."
+          }
         }
       }
     },
@@ -11687,6 +13685,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "重新居中"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zentrieren"
           }
         }
       }
@@ -11723,6 +13727,12 @@
             "state": "translated",
             "value": "дефицит %@%"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ % Defizit"
+          }
         }
       }
     },
@@ -11757,6 +13767,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "резерв %@%"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ % Reserve"
           }
         }
       }
@@ -11793,6 +13809,12 @@
             "state": "translated",
             "value": "空闲"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Leerlauf"
+          }
         }
       }
     },
@@ -11827,6 +13849,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Войдите в Codex в ~/.codex-%@, чтобы читать использование"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Melde dich in ~/.codex-%@ bei Codex an, um deine Nutzung zu lesen"
           }
         }
       }
@@ -11863,6 +13891,12 @@
             "state": "translated",
             "value": "Войдите через приложение Command Code, чтобы читать использование"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Melde dich mit der Command-Code-App an, um deine Nutzung zu lesen"
+          }
         }
       }
     },
@@ -11897,6 +13931,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Введите API-ключ Ollama в настройках или экспортируйте OLLAMA_API_KEY"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gib in den Einstellungen einen Ollama-API-Schlüssel ein oder exportiere OLLAMA_API_KEY"
           }
         }
       }
@@ -11933,6 +13973,12 @@
             "state": "translated",
             "value": "Запустите Ollama, чтобы отслеживать локальные модели"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Starte Ollama, um deine lokalen Modelle zu überwachen"
+          }
         }
       }
     },
@@ -11967,6 +14013,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Введите API-ключ Ollama ниже или экспортируйте OLLAMA_API_KEY в оболочке."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gib unten einen Ollama-API-Schlüssel ein oder exportiere OLLAMA_API_KEY in deiner Shell."
           }
         }
       }
@@ -12003,6 +14055,12 @@
             "state": "translated",
             "value": "Войдите через приложение Command Code — оно записывает ~/.commandcode/auth.json, откуда панель читает данные."
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Melde dich mit der Command-Code-App an — sie schreibt ~/.commandcode/auth.json, und die Notch liest diese Datei."
+          }
         }
       }
     },
@@ -12037,6 +14095,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Для этого аккаунта Command Code пока нет измеряемого использования"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Command Code hat für dieses Konto noch nichts zu messen"
           }
         }
       }
@@ -12073,6 +14137,12 @@
             "state": "translated",
             "value": "Месячное использование"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Monatliche Nutzung"
+          }
         }
       }
     },
@@ -12107,6 +14177,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Использование сеанса"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sitzungsnutzung"
           }
         }
       }
@@ -12143,6 +14219,12 @@
             "state": "translated",
             "value": "Недельное использование"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wöchentliche Nutzung"
+          }
         }
       }
     },
@@ -12177,6 +14259,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Локальные модели"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lokale Modelle"
           }
         }
       }
@@ -12213,6 +14301,12 @@
             "state": "translated",
             "value": "Локальный компьютер"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Localhost"
+          }
         }
       }
     },
@@ -12248,6 +14342,12 @@
             "state": "translated",
             "value": "Codenotch читает использование из инструментов, уже авторизованных на этом Mac, и никогда не спрашивает пароль. Установите и авторизуйтесь в Claude Code (терминальном инструменте, не приложении Claude), Cursor (редакторе или cursor-agent), Codex, Antigravity, GLM, Grok, OpenCode, Command Code, GitHub Copilot или Gemini API через Gemini CLI, OpenCode или Hermes — и кольцо появится на панели."
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Codenotch liest die Nutzung von Tools, die auf diesem Mac bereits angemeldet sind — es fragt nie nach deinem Passwort. Installiere eines von Claude Code (das Terminal-Tool, nicht die Claude-App), Cursor (den Editor oder cursor-agent), Codex, Antigravity, GLM, Grok, OpenCode, Command Code, GitHub Copilot oder einen Gemini-API-Schlüssel (über Gemini CLI, OpenCode oder Hermes) und melde dich an — der zugehörige Ring erscheint dann in der Notch."
+          }
         }
       }
     },
@@ -12270,6 +14370,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "завершено"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "abgeschlossen"
           }
         }
       }
@@ -12294,6 +14400,12 @@
             "state": "translated",
             "value": "已完成"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abgeschlossen"
+          }
         }
       }
     },
@@ -12316,6 +14428,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "等待中"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wartend"
           }
         }
       }
@@ -12340,6 +14458,12 @@
             "state": "translated",
             "value": "Локальный сеанс"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lokale Sitzung"
+          }
         }
       }
     },
@@ -12362,6 +14486,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "使用中"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aktiv"
           }
         }
       }
@@ -12386,6 +14516,12 @@
             "state": "translated",
             "value": "Убедитесь, что Antigravity IDE запущена, чтобы читать этот аккаунт."
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stelle sicher, dass die Antigravity-IDE läuft, um dieses Konto zu lesen."
+          }
         }
       }
     },
@@ -12408,6 +14544,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "自动"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Automatisch"
           }
         }
       }
@@ -12432,6 +14574,12 @@
             "state": "translated",
             "value": "Лимит на 5 часов"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "5-Stunden-Limit"
+          }
         }
       }
     },
@@ -12454,6 +14602,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Недельный лимит"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wochenlimit"
           }
         }
       }
@@ -12478,6 +14632,12 @@
             "state": "translated",
             "value": "Жидкое стекло"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass"
+          }
         }
       }
     },
@@ -12500,6 +14660,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Сплошной чёрный"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Deckend Schwarz"
           }
         }
       }
@@ -12524,6 +14690,12 @@
             "state": "translated",
             "value": "Системное жидкое стекло. Следует настройкам внешнего вида Mac, включая прозрачное или тонированное стекло и светлый или тёмный режим."
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "System-Liquid-Glass. Folgt den Erscheinungsbild-Einstellungen dieses Mac, einschließlich Klarem oder Getöntem Glas sowie hellem oder dunklem Modus."
+          }
         }
       }
     },
@@ -12546,6 +14718,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Исходная непрозрачная чёрная панель. Всегда тёмная независимо от внешнего вида Mac."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die ursprüngliche, deckend schwarze Notch. Immer dunkel, unabhängig vom Erscheinungsbild des Mac."
           }
         }
       }
@@ -12570,6 +14748,12 @@
             "state": "translated",
             "value": "Второе недельное кольцо, Liquid Glass, французский язык и Claude Desktop читаются напрямую из собственного кэша."
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ein zweiter Ring für die Woche, Liquid Glass, Französisch, und Claude Desktop wird direkt aus dem eigenen Cache gelesen."
+          }
         }
       }
     },
@@ -12592,6 +14776,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Неделя получает отдельное кольцо"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die Woche bekommt ihren eigenen Ring"
           }
         }
       }
@@ -12616,6 +14806,12 @@
             "state": "translated",
             "value": "Вторая дуга внутри основного кольца или снаружи для провайдеров с недельным и сеансовым лимитами. По умолчанию выключена; переключатель находится во «Внешнем виде»."
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ein zweiter Bogen, innerhalb oder außerhalb des Hauptrings, für Anbieter, die neben einem Sitzungslimit auch ein Wochenlimit veröffentlichen. Standardmäßig aus; der Schalter dafür ist im Erscheinungsbild."
+          }
         }
       }
     },
@@ -12639,6 +14835,12 @@
             "state": "translated",
             "value": "Открытая панель, её подсказка и кнопка настроек используют системную стеклянную поверхность и преломляют фон. При уменьшении прозрачности они становятся сплошными."
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die geöffnete Notch, ihr Tooltip und die Einstellungskugel nutzen die systemeigene Glasoberfläche, sodass sie brechen, was dahinterliegt, statt einfach darauf zu sitzen. „Transparenz reduzieren“ macht sie deckend."
+          }
         }
       }
     },
@@ -12658,6 +14860,12 @@
           }
         },
         "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Français"
+          }
+        },
+        "de": {
           "stringUnit": {
             "state": "translated",
             "value": "Français"
@@ -12685,6 +14893,12 @@
             "state": "translated",
             "value": "Третий язык во «Внешнем виде» наряду с английским и 简体中文."
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eine dritte Sprache im Erscheinungsbild, neben English und 简体中文."
+          }
         }
       }
     },
@@ -12707,6 +14921,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Использование Claude Desktop из собственного кэша"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Claude-Desktop-Nutzung, gelesen aus dem eigenen Cache"
           }
         }
       }
@@ -12731,6 +14951,12 @@
             "state": "translated",
             "value": "Третий способ читать аккаунт Claude, когда CLI и токен не отвечают. Данные никуда не отправляются: кэш находится на этом Mac и только распаковывается."
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ein dritter Weg, ein Claude-Konto auszulesen, wenn CLI und Token nicht antworten können. Es wird nichts irgendwohin gesendet: Der Cache liegt auf diesem Mac und wird nur entpackt."
+          }
         }
       }
     },
@@ -12753,6 +14979,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Claude Code найден там, куда его установил npm"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Claude Code wird auch dort gefunden, wo npm es ablegt"
           }
         }
       }
@@ -12777,6 +15009,12 @@
             "state": "translated",
             "value": "Установки через nvm, Volta или pnpm обнаруживаются так же, как остальные, и для них снова работает фоновое обновление входа."
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eine Installation unter nvm, Volta oder pnpm wird jetzt wie jede andere erkannt, wodurch auch die automatische Anmeldeerneuerung im Hintergrund für diese Setups wieder funktioniert."
+          }
         }
       }
     },
@@ -12799,6 +15037,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Больше никаких папок с расшифровками"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine zurückgelassenen Transkript-Ordner mehr"
           }
         }
       }
@@ -12823,6 +15067,12 @@
             "state": "translated",
             "value": "Раньше чтение Claude запускалось в новой папке при каждой проверке, а Claude Code создавал там папку расшифровки. Теперь используется одно место и режим печати без записи сеанса."
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Das Lesen der Claude-Nutzung lief bisher bei jeder Abfrage in einem neuen Verzeichnis, und Claude Code legte dafür jedes Mal einen Transkript-Ordner an. Jetzt läuft es von einem einzigen Ort aus im Print-Modus und schreibt gar keine Sitzung mehr."
+          }
         }
       }
     },
@@ -12845,6 +15095,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Время сброса следует часам Mac"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rücksetzzeiten folgen der Uhrzeitanzeige des Mac"
           }
         }
       }
@@ -12869,6 +15125,12 @@
             "state": "translated",
             "value": "На Mac с 24-часовым форматом время сброса показывается в 24-часовом формате, без AM и PM."
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ein Mac mit 24-Stunden-Format zeigt Rücksetzzeiten im 24-Stunden-Format statt vormittags/nachmittags."
+          }
         }
       }
     },
@@ -12891,6 +15153,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Завершённый сеанс отображается как завершённый"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eine beendete Sitzung zeigt das auch an"
           }
         }
       }
@@ -12915,6 +15183,12 @@
             "state": "translated",
             "value": "Сеансы агентов содержат состояние успеха, поэтому завершённый запуск отличается от текущего."
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Agenten-Sitzungen tragen jetzt einen Erfolgsstatus, sodass ein abgeschlossener Lauf anders aussieht als ein noch laufender."
+          }
         }
       }
     },
@@ -12937,6 +15211,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Antigravity: выбор основного лимита"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Antigravity: welches Limit führend ist"
           }
         }
       }
@@ -12961,6 +15241,12 @@
             "state": "translated",
             "value": "Основное кольцо может следовать выбранному лимиту, а не самому строгому, и установка только через CLI считается полноценным аккаунтом."
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Der Hauptring kann einem bestimmten Limit folgen, statt automatisch dem knappsten, und eine reine CLI-Installation zählt jetzt als echtes Konto."
+          }
         }
       }
     },
@@ -12983,6 +15269,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Панель, объединённая с выемкой, просыпается только от аппаратной выемки"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nur die Hardware-Notch weckt eine damit verschmolzene Notch"
           }
         }
       }
@@ -13007,6 +15299,12 @@
             "state": "translated",
             "value": "Панель, объединённая с камерой, больше не просыпается от указателя в любой точке верхнего края."
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eine mit der Kameraaussparung verschmolzene Notch wacht nicht mehr durch den Zeiger an einer beliebigen Stelle der gesamten Oberkante auf."
+          }
         }
       }
     },
@@ -13029,6 +15327,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Недельное кольцо"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wochenring"
           }
         }
       }
@@ -13053,6 +15357,12 @@
             "state": "translated",
             "value": "Поверхность"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Oberfläche"
+          }
         }
       }
     },
@@ -13075,6 +15385,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Показания панели"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Notch zeigt"
           }
         }
       }
@@ -13099,6 +15415,12 @@
             "state": "translated",
             "value": "Выберите лимит, который отображается на основной панели Antigravity."
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wählen, welches Limit für Antigravity in der Hauptnotch angezeigt wird."
+          }
         }
       }
     },
@@ -13121,6 +15443,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "关闭"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aus"
           }
         }
       }
@@ -13145,6 +15473,12 @@
             "state": "translated",
             "value": "内侧"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Innen"
+          }
         }
       }
     },
@@ -13167,6 +15501,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "外侧"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Außen"
           }
         }
       }
@@ -13191,6 +15531,12 @@
             "state": "translated",
             "value": "Одно кольцо на провайдера с основным лимитом. Недельная квота остаётся в карточке при наведении."
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ein Ring pro Anbieter, der das Hauptlimit zeigt. Das Wochenkontingent bleibt in der Hover-Karte."
+          }
         }
       }
     },
@@ -13213,6 +15559,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Тонкое кольцо недельного лимита внутри основного. Оно делит зазор с индикатором работы."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ein dünnerer Ring für das Wochenlimit, innerhalb des Hauptrings gezogen. Er teilt sich den Zwischenraum mit der Arbeitsanzeige."
           }
         }
       }
@@ -13237,6 +15589,12 @@
             "state": "translated",
             "value": "Тонкое кольцо недельного лимита вокруг основного, в промежутке между кольцом и краем панели."
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ein dünnerer Ring für das Wochenlimit, außen um den Hauptring gezogen, im Zwischenraum zwischen Ring und Notch-Rand."
+          }
         }
       }
     },
@@ -13259,6 +15617,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Запустите %@ в Терминале, чтобы войти в %@."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Führe %@ im Terminal aus, um dich bei %@ anzumelden."
           }
         }
       }
@@ -13283,6 +15647,12 @@
             "state": "translated",
             "value": "Запросов сегодня · последний запуск %@"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Anfragen heute · zuletzt verwendet %@"
+          }
         }
       }
     },
@@ -13305,6 +15675,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "вчера"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "gestern"
           }
         }
       }
@@ -13329,6 +15705,12 @@
             "state": "translated",
             "value": "%lld дн. назад"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "vor %lld Tagen"
+          }
         }
       }
     },
@@ -13351,6 +15733,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Личный"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Persönlich"
           }
         }
       }
@@ -13375,6 +15763,12 @@
             "state": "translated",
             "value": "Модели Gemini"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gemini-Modelle"
+          }
         }
       }
     },
@@ -13397,6 +15791,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Лимит на 5 часов"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "5-Stunden-Limit"
           }
         }
       }
@@ -13421,6 +15821,12 @@
             "state": "translated",
             "value": "Модели Claude и GPT"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Claude- und GPT-Modelle"
+          }
         }
       }
     },
@@ -13443,6 +15849,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Вопрос"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Frage"
           }
         }
       }
@@ -13467,6 +15879,12 @@
             "state": "translated",
             "value": "Подтверждение"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Genehmigung"
+          }
         }
       }
     },
@@ -13489,6 +15907,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Разрешение"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Berechtigung"
           }
         }
       }
@@ -13513,6 +15937,12 @@
             "state": "translated",
             "value": "требуется ваш ответ"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "braucht deine Eingabe"
+          }
         }
       }
     },
@@ -13535,6 +15965,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Работает в %@"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Arbeitet in %@"
           }
         }
       }
@@ -13559,6 +15995,12 @@
             "state": "translated",
             "value": "Подключение"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verbindung"
+          }
         }
       }
     },
@@ -13581,6 +16023,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Предустановка"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Voreinstellung"
           }
         }
       }
@@ -13605,6 +16053,12 @@
             "state": "translated",
             "value": "Пользовательский"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Benutzerdefiniert"
+          }
         }
       }
     },
@@ -13627,6 +16081,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Размер предустановки"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Voreingestellte Größe"
           }
         }
       }
@@ -13651,6 +16111,12 @@
             "state": "translated",
             "value": "Масштабирует всю поверхность — кольца, текст и подсказку — сохраняя пропорции. 100% — исходный размер панели."
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Skaliert die gesamte Oberfläche — Ringe, Text und Tooltip zusammen —, sodass die Proportionen wie gezeichnet bleiben. 100 % ist die Größe, für die die Notch entworfen wurde."
+          }
         }
       }
     },
@@ -13673,6 +16139,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "API-ключ Ollama"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ollama-API-Schlüssel"
           }
         }
       }
@@ -13697,6 +16169,12 @@
             "state": "translated",
             "value": "Вставьте ключ"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Schlüssel einfügen"
+          }
         }
       }
     },
@@ -13719,6 +16197,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "保存"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Speichern"
           }
         }
       }
@@ -13743,6 +16227,12 @@
             "state": "translated",
             "value": "已保存"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gespeichert"
+          }
         }
       }
     },
@@ -13765,6 +16255,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Для использования %@ нужно обновить вход — один раз запустите `claude` в терминале."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die Anmeldung für die %@-Nutzung muss erneuert werden — führe einmal `claude` in einem Terminal aus."
           }
         }
       }
@@ -13789,6 +16285,12 @@
             "state": "translated",
             "value": "%@ %@ · через Ollama"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ %@ · über Ollama"
+          }
         }
       }
     },
@@ -13811,6 +16313,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Скрыто на панели · Загружено в Ollama"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vor der Notch verborgen · In Ollama geladen"
           }
         }
       }
@@ -13835,6 +16343,12 @@
             "state": "translated",
             "value": "Показывать или скрывать эту модель на панели. В Ollama она остаётся загруженной."
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dieses Modell in der Notch anzeigen oder ausblenden. Es bleibt in Ollama geladen."
+          }
         }
       }
     },
@@ -13857,6 +16371,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Размышление"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Denkt nach"
           }
         }
       }
@@ -13881,6 +16401,12 @@
             "state": "translated",
             "value": "%@ · Локально"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ · Lokal"
+          }
         }
       }
     },
@@ -13903,6 +16429,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "За этот период использование Ollama ещё не записано."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Für diesen Zeitraum ist noch keine Ollama-Nutzung erfasst."
           }
         }
       }
@@ -13927,6 +16459,12 @@
             "state": "translated",
             "value": "Неиспользованные сбросы"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ungenutzte Zurücksetzungen"
+          }
         }
       }
     },
@@ -13949,6 +16487,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Нет неиспользованных сбросов"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine ungenutzten Zurücksetzungen"
           }
         }
       }
@@ -13973,6 +16517,12 @@
             "state": "translated",
             "value": "1 неиспользованный сброс"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 ungenutzte Zurücksetzung"
+          }
         }
       }
     },
@@ -13995,6 +16545,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "%lld неиспользованных сбросов"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld ungenutzte Zurücksetzungen"
           }
         }
       }
@@ -14019,6 +16575,12 @@
             "state": "translated",
             "value": "Истекает %@"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Läuft ab am %@"
+          }
         }
       }
     },
@@ -14042,6 +16604,12 @@
             "state": "translated",
             "value": "Следующий истекает %@"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Läuft als Nächstes am %@ ab"
+          }
         }
       }
     },
@@ -14052,6 +16620,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "当某家服务的主额度越过 80% 时发一条系统通知，100% 时再发一次 — 每次越过只发一次，要等额度窗口滚动过后才会再发。可在「账号」里该行旁边的铃铛上静音。"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eine Systembenachrichtigung, sobald das Hauptlimit eines Anbieters 80 % überschreitet, und erneut bei 100 % — jeweils einmal pro Überschreitung, danach erst wieder, wenn sich das Zeitfenster erneuert hat. Über die Glocke neben seiner Zeile in Konten lässt sich ein Anbieter stummschalten."
           }
         }
       }
@@ -14064,6 +16638,12 @@
             "state": "translated",
             "value": "Codenotch 已经知道助手何时停下来、或停下来问你。刘海展开时点一下，会把那个会话的应用带到前台 — 是应用，不是标签页：只有部分终端允许外部选定标签，所以提示里会写会话名称。"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Codenotch weiß bereits in dem Moment Bescheid, in dem ein Agent aufhört zu arbeiten oder dich etwas fragt. Ein Klick auf die geöffnete Notch holt die App dieser Sitzung in den Vordergrund — die App, nicht den Tab: Nur manche Terminals erlauben es, von außen einen Tab auszuwählen, deshalb nennt der Tooltip stattdessen die Sitzung."
+          }
         }
       }
     },
@@ -14074,6 +16654,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "声音走普通输出，不是界面音效通道 — 所以在系统设置 → 声音里关掉「播放用户界面声音效果」之后仍然听得见。"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Der Ton wird über die normale Audioausgabe abgespielt, nicht über den Kanal für Bedienklänge — er ist also auch zu hören, wenn „Bedienklänge abspielen“ in Systemeinstellungen → Ton ausgeschaltet ist."
           }
         }
       }
@@ -14086,6 +16672,12 @@
             "state": "translated",
             "value": "大多数读数借自已经持有该账号的工具。DeepSeek 是例外：点「登录」会打开 Codenotch 自己的 WebView，在这里退出只会清掉这次会话和已保存的读数。"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die meisten Messwerte werden von einem Tool geliehen, das das Konto bereits besitzt. DeepSeek ist die Ausnahme: Ein Klick auf „Anmelden“ öffnet eine eigene WebView von Codenotch, und eine Abmeldung hier löscht nur diese Sitzung und ihren gespeicherten Messwert."
+          }
         }
       }
     },
@@ -14096,6 +16688,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "累计 token"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tokens insgesamt"
           }
         }
       }
@@ -14108,6 +16706,12 @@
             "state": "translated",
             "value": "峰值 token"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Spitzenwert Tokens"
+          }
         }
       }
     },
@@ -14118,6 +16722,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "最长对话"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Längster Chat"
           }
         }
       }
@@ -14130,6 +16740,12 @@
             "state": "translated",
             "value": "当前连续"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aktuelle Serie"
+          }
         }
       }
     },
@@ -14140,6 +16756,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "最长连续"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Längste Serie"
           }
         }
       }
@@ -14152,6 +16774,12 @@
             "state": "translated",
             "value": "今日"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Heute"
+          }
         }
       }
     },
@@ -14162,6 +16790,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "30 天 token"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "30-Tage-Tokens"
           }
         }
       }
@@ -14174,6 +16808,12 @@
             "state": "translated",
             "value": "待出"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ausstehend"
+          }
         }
       }
     },
@@ -14184,6 +16824,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "已花费"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aufgebraucht"
           }
         }
       }
@@ -14196,6 +16842,12 @@
             "state": "translated",
             "value": "剩余"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verbleibend"
+          }
         }
       }
     },
@@ -14206,6 +16858,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "已充值"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aufgeladen"
           }
         }
       }
@@ -14218,6 +16876,12 @@
             "state": "translated",
             "value": "用量明细"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nutzungsdetails"
+          }
         }
       }
     },
@@ -14228,6 +16892,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Token"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tokens"
           }
         }
       }
@@ -14240,6 +16910,12 @@
             "state": "translated",
             "value": "费用"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kosten"
+          }
         }
       }
     },
@@ -14250,6 +16926,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "请求"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Anfragen"
           }
         }
       }
@@ -14262,6 +16944,12 @@
             "state": "translated",
             "value": "API 密钥"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API-Schlüssel"
+          }
         }
       }
     },
@@ -14272,6 +16960,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "每日 token"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tägliche Tokens"
           }
         }
       }
@@ -14284,6 +16978,12 @@
             "state": "translated",
             "value": "每日费用"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tägliche Kosten"
+          }
         }
       }
     },
@@ -14294,6 +16994,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "峰值 %@"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Spitzenwert %@"
           }
         }
       }
@@ -14306,6 +17012,12 @@
             "state": "translated",
             "value": "账号用量（%@）"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kontonutzung (%@)"
+          }
         }
       }
     },
@@ -14316,6 +17028,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "未在监视。"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Überwachung aus."
           }
         }
       }
@@ -14328,6 +17046,12 @@
             "state": "translated",
             "value": "打开 LM Studio"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "LM Studio öffnen"
+          }
         }
       }
     },
@@ -14338,6 +17062,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "打开 Ollama"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ollama öffnen"
           }
         }
       }
@@ -14350,6 +17080,12 @@
             "state": "translated",
             "value": "服务器地址"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Serveradresse"
+          }
         }
       }
     },
@@ -14360,6 +17096,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "检查连接"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verbindung prüfen"
           }
         }
       }
@@ -14372,6 +17114,12 @@
             "state": "translated",
             "value": "应用"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Übernehmen"
+          }
         }
       }
     },
@@ -14382,6 +17130,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "API 令牌"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API-Token"
           }
         }
       }
@@ -14394,6 +17148,12 @@
             "state": "translated",
             "value": "移除"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Entfernen"
+          }
         }
       }
     },
@@ -14404,6 +17164,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "正在检查 LM Studio…"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "LM Studio wird geprüft…"
           }
         }
       }
@@ -14416,6 +17182,12 @@
             "state": "translated",
             "value": "正在连接 LM Studio…"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verbindung zu LM Studio wird hergestellt…"
+          }
         }
       }
     },
@@ -14426,6 +17198,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "正在检查 Ollama…"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ollama wird geprüft…"
           }
         }
       }
@@ -14438,6 +17216,12 @@
             "state": "translated",
             "value": "正在连接 Ollama…"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verbindung zu Ollama wird hergestellt…"
+          }
         }
       }
     },
@@ -14448,6 +17232,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "已加载的模型会出现在「账号 → 已连接」，每秒检查一次。不显示嵌入模型。"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Geladene Modelle erscheinen unter Konten → Verbunden und werden jede Sekunde geprüft. Embedding-Modelle werden nicht angezeigt."
           }
         }
       }
@@ -14460,6 +17250,12 @@
             "state": "translated",
             "value": "已保存令牌，每次请求都会带上。"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ein Token wird gespeichert und mit jeder Anfrage gesendet."
+          }
         }
       }
     },
@@ -14470,6 +17266,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "仅当 LM Studio 服务器要求令牌时才需要（开发者 → 服务器设置）。不填则请求不带 Authorization 头。"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nur nötig, wenn der Server von LM Studio ein Token verlangt (Developer → Server Settings). Ohne Token werden Anfragen ohne Authorization-Header gesendet."
           }
         }
       }
@@ -14482,6 +17284,12 @@
             "state": "translated",
             "value": "检测到的模型会出现在「账号 → 已连接」。模型加载和卸载每秒检查一次。"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erkannte Modelle erscheinen unter Konten → Verbunden. Laden und Entladen von Modellen wird jede Sekunde geprüft."
+          }
         }
       }
     },
@@ -14493,6 +17301,12 @@
             "state": "translated",
             "value": "测量速度与思考"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Geschwindigkeit und Denken messen"
+          }
         }
       }
     },
@@ -14503,6 +17317,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "要测量回复，把聊天客户端指向 http://127.0.0.1:11435，并保持 Codenotch 打开。"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Um Antworten zu messen, richte deinen Chat-Client auf http://127.0.0.1:11435 und lass Codenotch geöffnet."
           }
         }
       }

--- a/Sources/Settings/AppLanguage.swift
+++ b/Sources/Settings/AppLanguage.swift
@@ -9,6 +9,7 @@ enum AppLanguage: String, CaseIterable, Identifiable {
     case system = "system"
     case english = "en"
     case french = "fr"
+    case german = "de"
     case japanese = "ja"
     case brazilianPortuguese = "pt-BR"
     case russian = "ru"
@@ -27,6 +28,7 @@ enum AppLanguage: String, CaseIterable, Identifiable {
         case .system:              return nil
         case .english:             return Locale(identifier: "en")
         case .french:              return Locale(identifier: "fr")
+        case .german:              return Locale(identifier: "de")
         case .japanese:            return Locale(identifier: "ja")
         case .brazilianPortuguese: return Locale(identifier: "pt-BR")
         case .russian:             return Locale(identifier: "ru")
@@ -34,14 +36,15 @@ enum AppLanguage: String, CaseIterable, Identifiable {
         }
     }
 
-    /// English, Français, 日本語, Português (Brasil), Русский and 简体中文 stay in their
-    /// own language so the row is recognizable when the rest of Settings is in
-    /// another one.
+    /// English, Français, Deutsch, 日本語, Português (Brasil), Русский and 简体中文 stay
+    /// in their own language so the row is recognizable when the rest of
+    /// Settings is in another one.
     var title: String {
         switch self {
         case .system:              return L10n.t("Follow System")
         case .english:             return "English"
         case .french:              return "Français"
+        case .german:              return "Deutsch"
         case .japanese:            return "日本語"
         case .brazilianPortuguese: return "Português (Brasil)"
         case .russian:             return "Русский"
@@ -53,7 +56,7 @@ enum AppLanguage: String, CaseIterable, Identifiable {
         switch self {
         case .system:
             return L10n.t("Matches the Mac's preferred language.")
-        case .english, .french, .japanese, .brazilianPortuguese, .russian, .simplifiedChinese:
+        case .english, .french, .german, .japanese, .brazilianPortuguese, .russian, .simplifiedChinese:
             return L10n.t("Codenotch uses this language even if the Mac does not.")
         }
     }

--- a/Tests/AppLanguageTests.swift
+++ b/Tests/AppLanguageTests.swift
@@ -78,6 +78,18 @@ final class AppLanguageTests: XCTestCase {
         XCTAssertEqual(L10n.locale.identifier, "ja")
     }
 
+    func testGermanIsOfferedAndMapsToDe() {
+        XCTAssertTrue(AppLanguage.allCases.contains(.german))
+        XCTAssertEqual(AppLanguage.german.title, "Deutsch")
+        XCTAssertEqual(AppLanguage.german.locale?.identifier, "de")
+    }
+
+    func testApplyGermanStoresTheOverride() {
+        L10n.apply(.german)
+        L10n.testLocale = nil
+        XCTAssertEqual(L10n.locale.identifier, "de")
+    }
+
     func testRussianIsOfferedAndMapsToRu() {
         XCTAssertTrue(AppLanguage.allCases.contains(.russian))
         XCTAssertEqual(AppLanguage.russian.title, "Русский")

--- a/Tests/LocalizationTests.swift
+++ b/Tests/LocalizationTests.swift
@@ -7,6 +7,7 @@ import XCTest
 final class LocalizationTests: XCTestCase {
     private let zhHans = Locale(identifier: "zh-Hans")
     private let french = Locale(identifier: "fr")
+    private let german = Locale(identifier: "de")
     private let japanese = Locale(identifier: "ja")
     private let russian = Locale(identifier: "ru")
     private let brazilianPortuguese = Locale(identifier: "pt-BR")
@@ -228,6 +229,84 @@ final class LocalizationTests: XCTestCase {
         )
     }
 
+    // MARK: - German
+
+    func testElapsedCopyInGerman() {
+        XCTAssertEqual(
+            ElapsedCopy.text(since: now.addingTimeInterval(-5), now: now, locale: german),
+            "gerade eben"
+        )
+        XCTAssertEqual(
+            ElapsedCopy.text(since: now.addingTimeInterval(-6 * 60), now: now, locale: german),
+            "6 Min"
+        )
+        XCTAssertEqual(
+            ElapsedCopy.text(since: now.addingTimeInterval(-60 * 60), now: now, locale: german),
+            "1 Std"
+        )
+        XCTAssertEqual(
+            ElapsedCopy.text(since: now.addingTimeInterval(-65 * 60), now: now, locale: german),
+            "1 Std 5 Min"
+        )
+        XCTAssertEqual(
+            ElapsedCopy.ago(since: now.addingTimeInterval(-6 * 60), now: now, locale: german),
+            "vor 6 Min"
+        )
+    }
+
+    func testResetCopyUnderAnHourInGerman() {
+        XCTAssertEqual(
+            ResetCopy.text(for: resetNow.addingTimeInterval(51 * 60), now: resetNow, locale: german),
+            "Zurücksetzung in 51 Min."
+        )
+        XCTAssertEqual(
+            ResetCopy.text(for: resetNow.addingTimeInterval(-5), now: resetNow, locale: german),
+            "Wird zurückgesetzt…"
+        )
+    }
+
+    func testWindowSummaryInGerman() {
+        XCTAssertEqual(
+            percentWindow(0.12).summary(locale: german),
+            "12% verwendet · 88% übrig"
+        )
+        XCTAssertEqual(
+            LimitWindow(id: "w", label: "Requests", used: 8).summary(locale: german),
+            "8 verwendet"
+        )
+        XCTAssertEqual(
+            LimitWindow(id: "w", label: "Requests", remaining: 3).summary(locale: german),
+            "3 übrig"
+        )
+        XCTAssertEqual(
+            LimitWindow(id: "w", label: "Requests").summary(locale: german),
+            "Kein Messwert"
+        )
+    }
+
+    func testMenuCopyInGerman() {
+        XCTAssertEqual(L10n.t("Always show", locale: german), "Immer anzeigen")
+        XCTAssertEqual(L10n.t("Settings…", locale: german), "Einstellungen…")
+    }
+
+    func testSignInCopyInGerman() {
+        XCTAssertEqual(
+            L10n.t("Sign in to \("Perplexity")", locale: german),
+            "Bei Perplexity anmelden"
+        )
+    }
+
+    /// The German keeps every format specifier in the order the English put
+    /// them, so an `Int` still lands on `%lld` and a `String` on `%@` — the
+    /// same trap the Simplified Chinese threshold alert fell into by
+    /// reordering without positional specifiers.
+    func testThresholdAlertKeepsArgumentOrderInGerman() {
+        XCTAssertEqual(
+            L10n.t("\(80)% of its \("weekly") limit used.", locale: german),
+            "80% des weekly-Limits verwendet."
+        )
+    }
+
     // MARK: - Brazilian Portuguese
 
     func testElapsedCopyInBrazilianPortuguese() {
@@ -423,7 +502,7 @@ final class LocalizationTests: XCTestCase {
     func testEveryOfferedLanguageResolves() {
         XCTAssertEqual(
             AppLanguage.allCases.map(\.rawValue),
-            ["system", "en", "fr", "ja", "pt-BR", "ru", "zh-Hans"]
+            ["system", "en", "fr", "de", "ja", "pt-BR", "ru", "zh-Hans"]
         )
         XCTAssertNil(AppLanguage.system.locale)
         for language in AppLanguage.allCases where language != .system {

--- a/project.yml
+++ b/project.yml
@@ -74,6 +74,7 @@ targets:
         CFBundleLocalizations:
           - en
           - fr
+          - de
           - ja
           - pt-BR
           - ru


### PR DESCRIPTION
Adds Deutsch as a fourth language in Appearance, alongside Français, 日本語, Português (Brasil), Русский and 简体中文. All 470 keys in the catalog are translated, so no German string falls back to English.

`de` joins `CFBundleLocalizations`, the `AppLanguage` picker, and `project.yml`/`Info.plist` — between `fr` and `ja`, mirroring where `ja` was inserted in the earlier Japanese localization (#136).

Format specifiers keep the English order in every key, including the two-argument threshold alert, avoiding the crash a prior Simplified Chinese translation introduced by reordering `%lld`/`%@` without positional specifiers (see #136).

Tests mirror the French/Japanese ones: elapsed copy, reset copy, window summary, menu copy, sign-in copy, the threshold alert argument order, and `testEveryOfferedLanguageResolves` grows by one entry.

Not run here: this was built on a machine without Xcode/macOS, so `make test` was not executed — only JSON/text consistency was verified (every catalog key has a `de` entry, and the new test strings match the new translations byte-for-byte). Happy to fix anything a real build/test run turns up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)