### PR TITLE
Add configurable DeepSeek peak/off-peak pricing and improve sign-in sync

### DIFF
--- a/Sources/App/AppDelegate.swift
+++ b/Sources/App/AppDelegate.swift
@@ -145,7 +145,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 order: preferences.providerOrder
             )
             deepSeek.onAuthenticated = { [weak store] in
-                store?.refresh(providerID: "deepseek")
+                store?.providerAuthenticationChanged(providerID: "deepseek")
             }
 
             let updater = Updater()
@@ -303,6 +303,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             preferences.$notchVisibility
                 .receive(on: RunLoop.main)
                 .sink { [weak fleet] in fleet?.apply($0) }
+                .store(in: &cancellables)
+
+            preferences.$deepSeekPricingEnabled
+                .receive(on: RunLoop.main)
+                .sink { [weak fleet] in fleet?.apply(deepSeekPricingEnabled: $0) }
+                .store(in: &cancellables)
+
+            preferences.$deepSeekPricingSchedule
+                .receive(on: RunLoop.main)
+                .sink { [weak fleet] in fleet?.apply(deepSeekPricingSchedule: $0) }
                 .store(in: &cancellables)
 
             preferences.$notchEdge
@@ -612,6 +622,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         fleet.apply(weeklyRing: preferences.weeklyRing)
         fleet.apply(showsMoveHandle: preferences.showsMoveHandle)
         fleet.apply(surfaceStyle: preferences.notchSurfaceStyle)
+        fleet.apply(deepSeekPricingEnabled: preferences.deepSeekPricingEnabled)
+        fleet.apply(deepSeekPricingSchedule: preferences.deepSeekPricingSchedule)
         fleet.show()
     }
 

--- a/Sources/Features/DeepSeekUsageDetail.swift
+++ b/Sources/Features/DeepSeekUsageDetail.swift
@@ -5,6 +5,10 @@ import SwiftUI
 /// cost and API-key/model aggregation explicit.
 struct DeepSeekUsageDetail: View {
     let detail: ProviderUsageDetail
+    let now: Date
+    let schedule: DeepSeekPricing.Schedule
+    let showsPricing: Bool
+    @Environment(\.codenotchAccentColor) private var accentColor
 
     private var timeZoneText: String {
         let absolute = abs(detail.timeZoneSeconds)
@@ -32,6 +36,41 @@ struct DeepSeekUsageDetail: View {
         Self.money(detail.totalCost, currency: detail.currency)
     }
 
+    private var pricingText: String {
+        switch DeepSeekPricing.phase(at: now, schedule: schedule) {
+        case .peak:
+            return L10n.t("Peak pricing · 2× off-peak")
+        case .offPeak:
+            return L10n.t("Off-peak pricing · baseline")
+        }
+    }
+
+    private var pricingColor: Color {
+        switch DeepSeekPricing.phase(at: now, schedule: schedule) {
+        case .peak: return Palette.watch
+        case .offPeak: return accentColor
+        }
+    }
+
+    private var nextPricingTransition: DeepSeekPricing.Transition {
+        DeepSeekPricing.nextTransition(after: now, schedule: schedule)
+    }
+
+    private var nextPricingLabel: String {
+        switch nextPricingTransition.phase {
+        case .peak: return L10n.t("Next peak")
+        case .offPeak: return L10n.t("Next off-peak")
+        }
+    }
+
+    private var nextPricingTime: String {
+        let formatter = ResetCopy.formatter(for: Calendar.current)
+        formatter.locale = L10n.locale
+        formatter.timeZone = .current
+        formatter.setLocalizedDateFormatFromTemplate("E j:mm")
+        return formatter.string(from: nextPricingTransition.date)
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             Rectangle()
@@ -50,6 +89,25 @@ struct DeepSeekUsageDetail: View {
             }
             .frame(width: NotchLayout.cardTextWidth)
             .padding(.top, NotchLayout.blockSpacing)
+
+            if showsPricing {
+                Rectangle()
+                    .fill(Palette.ringTrack)
+                    .frame(height: NotchLayout.hairline)
+                    .padding(.top, NotchLayout.blockSpacing)
+
+                SplitRow(leading: L10n.t("Pricing"), trailing: pricingText,
+                         trailingColor: pricingColor)
+                    .padding(.top, NotchLayout.blockSpacing)
+
+                SplitRow(leading: nextPricingLabel, trailing: nextPricingTime)
+                    .padding(.top, NotchLayout.usageDetailIdentityGap)
+            }
+
+            Rectangle()
+                .fill(Palette.ringTrack)
+                .frame(height: NotchLayout.hairline)
+                .padding(.top, NotchLayout.blockSpacing)
 
             DeepSeekUsageChart(title: L10n.t("Daily tokens"), values: points.map { Double($0.tokens) }, formatter: {
                 UsageFormat.tokens(Int($0))

--- a/Sources/Features/TooltipCard.swift
+++ b/Sources/Features/TooltipCard.swift
@@ -995,6 +995,8 @@ struct TooltipCard: View {
     /// rather than fixed, so a big screen hides nothing.
     var sessionCap: Int = NotchLayout.defaultSessionCap
     var resetTimeFormat: ResetTimeFormat = .automatic
+    var deepSeekPricingEnabled: Bool = true
+    var deepSeekPricingSchedule: DeepSeekPricing.Schedule = .current
     var tailOffset: CGFloat = 0
     /// A tap on a session row jumps to that session's terminal — nil leaves
     /// the rows as plain text.
@@ -1026,7 +1028,8 @@ struct TooltipCard: View {
             localModelName: snapshot.localModel?.name,
             showsLocalPerformance: snapshot.showsLocalPerformance,
                 localLedgerRows: snapshot.localLedgerRowCount,
-            compactRowCount: snapshot.compactRowCount
+            compactRowCount: snapshot.compactRowCount,
+            showsDeepSeekPricing: deepSeekPricingEnabled
         )
     }
 
@@ -1047,7 +1050,9 @@ struct TooltipCard: View {
                         CodexUsageSection(usage: tokenUsage, now: now)
                     }
                     if let usageDetail = snapshot.usageDetail, usageDetail.hasUsage {
-                        DeepSeekUsageDetail(detail: usageDetail)
+                        DeepSeekUsageDetail(detail: usageDetail, now: now,
+                                            schedule: deepSeekPricingSchedule,
+                                            showsPricing: deepSeekPricingEnabled)
                     }
                     if let activity, snapshot.localModel == nil {
                         SessionList(summary: activity, now: now, cap: sessionCap,

--- a/Sources/Localizable.xcstrings
+++ b/Sources/Localizable.xcstrings
@@ -14221,6 +14221,61 @@
         }
       }
     },
+    "Pricing": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "计价"
+          }
+        }
+      }
+    },
+    "Peak pricing · 2× off-peak": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "高峰计价 · 闲时 2 倍"
+          }
+        }
+      }
+    },
+    "Off-peak pricing · baseline": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "闲时计价 · 基准价"
+          }
+        }
+      }
+    },
+    "Next off-peak": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "下次闲时"
+          }
+        }
+      }
+    },
+    "Next peak": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "下次高峰"
+          }
+        }
+      }
+    },
     "Tokens": {
       "extractionState": "manual",
       "localizations": {
@@ -14505,6 +14560,120 @@
             "value": "要测量回复，把聊天客户端指向 http://127.0.0.1:11435，并保持 Codenotch 打开。"
           }
         }
+      }
+    },
+    "Peak/off-peak pricing": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "峰谷计价" } }
+      }
+    },
+    "Show DeepSeek pricing": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "显示 DeepSeek 计价" } }
+      }
+    },
+    "Shows the current billing phase and the next peak/off-peak change on the DeepSeek usage card.": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "在 DeepSeek 用量卡片上显示当前计价阶段和下次峰谷切换时间。" } }
+      }
+    },
+    "Peak rule": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "高峰规则" } }
+      }
+    },
+    "The schedule is maintained locally because it cannot be read reliably from an official API. Times below are UTC; the card converts the next change to your local time.": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "由于无法可靠地从官方接口读取，这个规则由本地维护。以下时间为 UTC；卡片会将下次切换转换为你的本地时间。" } }
+      }
+    },
+    "Peak days": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "高峰日" } }
+      }
+    },
+    "Sun": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "周日" } }
+      }
+    },
+    "Mon": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "周一" } }
+      }
+    },
+    "Tue": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "周二" } }
+      }
+    },
+    "Wed": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "周三" } }
+      }
+    },
+    "Thu": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "周四" } }
+      }
+    },
+    "Fri": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "周五" } }
+      }
+    },
+    "Sat": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "周六" } }
+      }
+    },
+    "Window 1": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "时段 1" } }
+      }
+    },
+    "Window 2": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "时段 2" } }
+      }
+    },
+    "Start": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "开始" } }
+      }
+    },
+    "End": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "结束" } }
+      }
+    },
+    "to": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "至" } }
+      }
+    },
+    "Restore current default rule": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "恢复当前默认规则" } }
       }
     }
   },

--- a/Sources/Model/UsageStore.swift
+++ b/Sources/Model/UsageStore.swift
@@ -25,6 +25,10 @@ final class UsageStore: ObservableObject {
     /// reading went unnoticed for twelve hours. Reading it off the snapshot
     /// would reproduce the bug.
     @Published private(set) var needsRenewal: Set<String> = []
+    /// Bumped when a provider's authentication state changes. Settings listens
+    /// to this separately from usage snapshots so it can re-read account
+    /// summaries without re-reading every credential on every polling pass.
+    @Published private(set) var providerAccountRevision = 0
 
     private let providers: [UsageProvider]
     /// Provider IDs block fetching before credential access. Model IDs only hide
@@ -506,6 +510,13 @@ final class UsageStore: ObservableObject {
         }
 
         return openAccountSource(providerID: providerID)
+    }
+
+    /// Tell consumers that a provider has just confirmed authentication. The
+    /// refresh updates the notch; the revision updates Settings' account row.
+    func providerAuthenticationChanged(providerID: String) {
+        providerAccountRevision &+= 1
+        refresh(providerID: providerID)
     }
 
     /// Say that a provider's saved login needs renewing by hand.

--- a/Sources/Notch/NotchFleet.swift
+++ b/Sources/Notch/NotchFleet.swift
@@ -56,6 +56,8 @@ final class NotchFleet {
     private var weeklyRing: WeeklyRing = .off
     private var showsMoveHandle = true
     private var surfaceStyle: NotchSurfaceStyle = .glass
+    private var deepSeekPricingEnabled = true
+    private var deepSeekPricingSchedule = DeepSeekPricing.Schedule.current
     /// The ⌥-drag nudge along the current edge. One value for the whole
     /// fleet, the same as `edge` itself — displays do not each get their own
     /// edge, so they do not each get their own nudge either.
@@ -184,6 +186,20 @@ final class NotchFleet {
         self.surfaceStyle = surfaceStyle
         for controller in controllers.values {
             controller.model.surfaceStyle = surfaceStyle
+        }
+    }
+
+    func apply(deepSeekPricingEnabled: Bool) {
+        self.deepSeekPricingEnabled = deepSeekPricingEnabled
+        for controller in controllers.values {
+            controller.model.deepSeekPricingEnabled = deepSeekPricingEnabled
+        }
+    }
+
+    func apply(deepSeekPricingSchedule: DeepSeekPricing.Schedule) {
+        self.deepSeekPricingSchedule = deepSeekPricingSchedule
+        for controller in controllers.values {
+            controller.model.deepSeekPricingSchedule = deepSeekPricingSchedule
         }
     }
 
@@ -373,6 +389,8 @@ final class NotchFleet {
         controller.model.weeklyRing = weeklyRing
         controller.model.showsMoveHandle = showsMoveHandle
         controller.model.surfaceStyle = surfaceStyle
+        controller.model.deepSeekPricingEnabled = deepSeekPricingEnabled
+        controller.model.deepSeekPricingSchedule = deepSeekPricingSchedule
         controller.onRefresh = onRefresh
         controller.onRefreshProvider = onRefreshProvider
         controller.onOpenSettings = onOpenSettings

--- a/Sources/Notch/NotchLayout.swift
+++ b/Sources/Notch/NotchLayout.swift
@@ -317,12 +317,18 @@ enum NotchLayout {
     /// The tooltip's height for a given number of limit windows and live
     /// sessions. Worked out here rather than left to SwiftUI so the hover region
     /// can be computed before the card is ever laid out.
-    static func usageDetailHeight(_ groupCount: Int) -> CGFloat {
+    static func usageDetailHeight(_ groupCount: Int, showsPricing: Bool = true) -> CGFloat {
         guard groupCount > 0 else { return 0 }
         let summary = hairline + blockSpacing + cardBodyLineHeight
             + blockSpacing + 2 * cardBodyLineHeight + moneyStatGap
         let chart = cardBodyLineHeight + usageDetailLabelToBar + usageDetailChartHeight
-        return blockSpacing + summary + blockSpacing + 2 * chart + usageDetailChartGap
+        let usageDivider = blockSpacing + hairline
+        let pricing = showsPricing
+            ? blockSpacing + 2 * cardBodyLineHeight + usageDetailIdentityGap
+            : 0
+        let chartDivider = blockSpacing + hairline
+        return blockSpacing + summary + (showsPricing ? usageDivider : 0) + pricing + chartDivider
+            + blockSpacing + 2 * chart + usageDetailChartGap
     }
 
     static func cardHeight(windowCount: Int, groupCount: Int = 0,
@@ -336,7 +342,8 @@ enum NotchLayout {
                            hasResetCredits: Bool = false,
                            localModelName: String? = nil, showsLocalPerformance: Bool = false,
                            localLedgerRows: Int = 0,
-                           compactRowCount: Int = 0) -> CGFloat {
+                           compactRowCount: Int = 0,
+                           showsDeepSeekPricing: Bool = true) -> CGFloat {
         let header = max(glyphSize, cardTitleLineHeight)
             + (hasPlan ? cardBodyLineHeight : 0)
         var height = 2 * cardPadding + header
@@ -390,7 +397,8 @@ enum NotchLayout {
             height += codexUsageTop + hairline + codexResetCreditsHeight
         }
 
-        height += usageDetailHeight(usageDetailGroupCount)
+        height += usageDetailHeight(usageDetailGroupCount,
+                                    showsPricing: showsDeepSeekPricing)
 
         if hasTokenUsage {
             height += codexUsageTop + hairline + blockSpacing

--- a/Sources/Notch/NotchRootView.swift
+++ b/Sources/Notch/NotchRootView.swift
@@ -106,6 +106,8 @@ struct NotchRootView: View {
                         direction: model.edge.tooltipDirection,
                         sessionCap: model.sessionCap,
                         resetTimeFormat: model.resetTimeFormat,
+                        deepSeekPricingEnabled: model.deepSeekPricingEnabled,
+                        deepSeekPricingSchedule: model.deepSeekPricingSchedule,
                         tailOffset: tooltipTailOffset(index: index, snapshot: snapshot),
                         onFocusSession: model.onFocusSession
                     )
@@ -384,7 +386,8 @@ struct NotchRootView: View {
                 localModelName: snapshot.localModel?.name,
                 showsLocalPerformance: snapshot.showsLocalPerformance,
                 localLedgerRows: snapshot.localLedgerRowCount,
-                compactRowCount: snapshot.compactRowCount
+                compactRowCount: snapshot.compactRowCount,
+                showsDeepSeekPricing: model.deepSeekPricingEnabled
             )
             : NotchLayout.cardWidth
     }
@@ -416,7 +419,8 @@ struct NotchRootView: View {
                 localModelName: snapshot.localModel?.name,
                 showsLocalPerformance: snapshot.showsLocalPerformance,
                 localLedgerRows: snapshot.localLedgerRowCount,
-                compactRowCount: snapshot.compactRowCount
+                compactRowCount: snapshot.compactRowCount,
+                showsDeepSeekPricing: model.deepSeekPricingEnabled
             )
         // The ring it points at has moved with the notch, so the tail follows
         // it — but the card beyond the tail is drawn at its own size, and

--- a/Sources/Notch/NotchViewModel.swift
+++ b/Sources/Notch/NotchViewModel.swift
@@ -191,6 +191,11 @@ final class NotchViewModel: ObservableObject {
     /// Mirrors the persisted Appearance choice so the separate notch window
     /// redraws immediately when Settings changes it.
     @Published var surfaceStyle: NotchSurfaceStyle = .glass
+    /// Whether DeepSeek's billing phase rows are visible in its usage card.
+    @Published var deepSeekPricingEnabled = true
+    /// The rule used by the DeepSeek card, mirrored from Preferences so a
+    /// settings change is reflected in every notch immediately.
+    @Published var deepSeekPricingSchedule = DeepSeekPricing.Schedule.current
     /// The display's own notch, when this edge has to share the bezel with one.
     ///
     /// Set by the window controller from the screen the panel is on, because
@@ -584,7 +589,8 @@ final class NotchViewModel: ObservableObject {
                 localModelName: snapshot.localModel?.name,
                 showsLocalPerformance: snapshot.showsLocalPerformance,
                 localLedgerRows: snapshot.localLedgerRowCount,
-                compactRowCount: snapshot.compactRowCount)
+                compactRowCount: snapshot.compactRowCount,
+                showsDeepSeekPricing: deepSeekPricingEnabled)
         }.max() ?? 0
     }
 

--- a/Sources/Notch/NotchWindowController.swift
+++ b/Sources/Notch/NotchWindowController.swift
@@ -413,7 +413,8 @@ final class NotchWindowController {
             localModelName: snapshot.localModel?.name,
             showsLocalPerformance: snapshot.showsLocalPerformance,
                 localLedgerRows: snapshot.localLedgerRowCount,
-            compactRowCount: snapshot.compactRowCount
+            compactRowCount: snapshot.compactRowCount,
+            showsDeepSeekPricing: model.deepSeekPricingEnabled
         )
         // Across the stack the region is the card, its tail, and the gap the
         // pointer has to cross. Along it, the card's own extent.

--- a/Sources/Providers/DeepSeekPricing.swift
+++ b/Sources/Providers/DeepSeekPricing.swift
@@ -1,0 +1,115 @@
+import Foundation
+
+/// The currently published DeepSeek API peak/off-peak schedule.
+///
+/// DeepSeek publishes the schedule in UTC, so it is intentionally independent
+/// of the Mac's local time zone. The UI can then show the user's local clock
+/// while this type remains the single source of truth for the billing phase.
+enum DeepSeekPricing {
+    struct Schedule: Codable, Equatable {
+        struct Window: Codable, Equatable {
+            var startMinute: Int
+            var endMinute: Int
+        }
+
+        /// Gregorian weekdays use Sunday = 1 ... Saturday = 7, matching
+        /// Foundation's `Calendar.Component.weekday` values.
+        var peakWeekdays: Set<Int>
+        var windows: [Window]
+
+        /// The currently published rule. This is the first-launch value and
+        /// also the target of the reset button in Settings.
+        static let current = Schedule(
+            peakWeekdays: [2, 3, 4, 5, 6],
+            windows: [
+                Window(startMinute: 60, endMinute: 240),
+                Window(startMinute: 360, endMinute: 600)
+            ]
+        )
+
+        /// Keep values loaded from UserDefaults safe even if a future build
+        /// changes the editor or an older build wrote malformed data.
+        var normalized: Schedule {
+            let weekdays = peakWeekdays.filter { (1...7).contains($0) }
+            var validWindows = windows.prefix(2).map { window in
+                Window(startMinute: min(max(window.startMinute, 0), 1_440),
+                       endMinute: min(max(window.endMinute, 0), 1_440))
+            }
+            while validWindows.count < 2 {
+                validWindows.append(Self.current.windows[validWindows.count])
+            }
+            return Schedule(peakWeekdays: weekdays,
+                            windows: validWindows)
+        }
+    }
+
+    enum Phase: Equatable {
+        case peak
+        case offPeak
+    }
+
+    struct Transition: Equatable {
+        let phase: Phase
+        let date: Date
+    }
+
+    static func phase(at date: Date) -> Phase {
+        phase(at: date, schedule: .current)
+    }
+
+    static func phase(at date: Date, schedule: Schedule) -> Phase {
+        let calendar = utcCalendar
+
+        let components = calendar.dateComponents([.weekday, .hour, .minute], from: date)
+        guard let weekday = components.weekday,
+              let hour = components.hour,
+              let minute = components.minute,
+              schedule.peakWeekdays.contains(weekday) else {
+            return .offPeak
+        }
+
+        let minuteOfDay = hour * 60 + minute
+        return schedule.windows.contains {
+            $0.startMinute <= minuteOfDay && minuteOfDay < $0.endMinute
+        } ? .peak : .offPeak
+    }
+
+    static func nextTransition(after date: Date) -> Transition {
+        nextTransition(after: date, schedule: .current)
+    }
+
+    static func nextTransition(after date: Date, schedule: Schedule) -> Transition {
+        let calendar = utcCalendar
+        let start = calendar.startOfDay(for: date)
+
+        let boundaries = Set(schedule.windows.flatMap { [$0.startMinute, $0.endMinute] })
+        // Looking ahead eight days covers the Friday-to-Monday gap as well.
+        for dayOffset in 0...8 {
+            guard let day = calendar.date(byAdding: .day, value: dayOffset, to: start) else {
+                continue
+            }
+            for minuteOfDay in boundaries.sorted() {
+                guard let candidate = calendar.date(byAdding: .minute,
+                                                    value: minuteOfDay,
+                                                    to: day),
+                      candidate > date else { continue }
+                let nextPhase = phase(at: candidate, schedule: schedule)
+                guard nextPhase != phase(at: candidate.addingTimeInterval(-1),
+                                         schedule: schedule) else {
+                    continue
+                }
+                return Transition(phase: nextPhase, date: candidate)
+            }
+        }
+
+        // The loop always finds a transition, but keep a deterministic result
+        // if Foundation ever behaves unexpectedly around a calendar boundary.
+        return Transition(phase: .offPeak, date: date.addingTimeInterval(8 * 86_400))
+    }
+
+    private static var utcCalendar: Calendar {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+        return calendar
+    }
+}

--- a/Sources/Providers/Sites.swift
+++ b/Sources/Providers/Sites.swift
@@ -106,7 +106,11 @@ enum Sites {
             const digest = await crypto.subtle.digest('SHA-256', bytes);
             const fingerprint = Array.from(new Uint8Array(digest))
                 .map(byte => byte.toString(16).padStart(2, '0')).join('');
-            return JSON.stringify({ authenticated: true, fingerprint });
+            return JSON.stringify({
+                authenticated: true,
+                fingerprint,
+                storageMutations: Number(window.__notchAuthStorageMutations || 0)
+            });
         } catch (_) { return JSON.stringify({ authenticated: false }); }
         """#,
         detailParse: DeepSeekUsage.detail(fromJSON:),

--- a/Sources/Providers/Sites.swift
+++ b/Sources/Providers/Sites.swift
@@ -93,7 +93,11 @@ enum Sites {
             const token = extract(JSON.parse(raw)) || raw.trim();
             if (!token) return false;
             const response = await fetch('/api/v0/users/get_user_summary', {
-                credentials: 'include', headers: { 'Accept': 'application/json', 'Authorization': token.startsWith('Bearer ') ? token : 'Bearer ' + token }
+                credentials: 'include', headers: {
+                    'Accept': 'application/json',
+                    'x-client-platform': 'web',
+                    'Authorization': token.startsWith('Bearer ') ? token : 'Bearer ' + token
+                }
             });
             if (response.status < 200 || response.status >= 300) {
                 return JSON.stringify({ authenticated: false });

--- a/Sources/Providers/Sites.swift
+++ b/Sources/Providers/Sites.swift
@@ -106,11 +106,7 @@ enum Sites {
             const digest = await crypto.subtle.digest('SHA-256', bytes);
             const fingerprint = Array.from(new Uint8Array(digest))
                 .map(byte => byte.toString(16).padStart(2, '0')).join('');
-            return JSON.stringify({
-                authenticated: true,
-                fingerprint,
-                storageMutations: Number(window.__notchAuthStorageMutations || 0)
-            });
+            return JSON.stringify({ authenticated: true, fingerprint });
         } catch (_) { return JSON.stringify({ authenticated: false }); }
         """#,
         detailParse: DeepSeekUsage.detail(fromJSON:),

--- a/Sources/Providers/WebSessionProvider.swift
+++ b/Sources/Providers/WebSessionProvider.swift
@@ -9,23 +9,17 @@ struct WebSessionAuthenticationGate: Equatable {
     private(set) var sawLogout = false
     private let requiresNewFingerprint: Bool
     private var unauthenticatedSamples = 0
-    private var sessionMutations = 0
 
     init(baselineFingerprint: String?, requiresNewFingerprint: Bool = true) {
         self.baselineFingerprint = baselineFingerprint
         self.requiresNewFingerprint = requiresNewFingerprint
     }
 
-    /// A sign-in window commits after a real logout/login transition or an
-    /// observed session-storage mutation in this page load. Switching accounts
-    /// additionally requires a new session identity. This keeps an already-
-    /// authenticated old page from being mistaken for the new account.
-    mutating func observe(
-        authenticated: Bool,
-        fingerprint: String?,
-        storageMutations: Int = 0
-    ) -> Bool {
-        if storageMutations > 0 { sessionMutations = storageMutations }
+    /// A sign-in window commits only after a real logout/login transition.
+    /// Switching accounts additionally requires a new session identity. This
+    /// keeps an already-authenticated old page from being mistaken for the new
+    /// account.
+    mutating func observe(authenticated: Bool, fingerprint: String?) -> Bool {
         guard authenticated else {
             unauthenticatedSamples += 1
             // A normal sign-in only needs one settled logged-out sample because
@@ -39,7 +33,7 @@ struct WebSessionAuthenticationGate: Equatable {
         }
 
         unauthenticatedSamples = 0
-        guard sawLogout || (!requiresNewFingerprint && sessionMutations > 0) else {
+        guard sawLogout else {
             if baselineFingerprint == nil { baselineFingerprint = fingerprint }
             return false
         }
@@ -199,30 +193,7 @@ final class WebSessionProvider: NSObject, UsageProvider {
         configuration.userContentController.addUserScript(WKUserScript(
             source: #"""
             window.__notchCalls = [];
-            window.__notchAuthStorageMutations = 0;
             (function () {
-                const storage = window.localStorage;
-                const setItem = Storage.prototype.setItem;
-                Storage.prototype.setItem = function (key, value) {
-                    if (this === storage && key === 'userToken') {
-                        window.__notchAuthStorageMutations += 1;
-                    }
-                    return setItem.apply(this, arguments);
-                };
-                const removeItem = Storage.prototype.removeItem;
-                Storage.prototype.removeItem = function (key) {
-                    if (this === storage && key === 'userToken') {
-                        window.__notchAuthStorageMutations += 1;
-                    }
-                    return removeItem.apply(this, arguments);
-                };
-                const clear = Storage.prototype.clear;
-                Storage.prototype.clear = function () {
-                    if (this === storage && this.getItem('userToken')) {
-                        window.__notchAuthStorageMutations += 1;
-                    }
-                    return clear.apply(this, arguments);
-                };
                 const fetchImpl = window.fetch;
                 window.fetch = function (...args) {
                     try {
@@ -243,7 +214,6 @@ final class WebSessionProvider: NSObject, UsageProvider {
         ))
         let webView = WKWebView(frame: NSRect(x: 0, y: 0, width: 1100, height: 800),
                                 configuration: configuration)
-        webView.navigationDelegate = self
         self.webView = webView
         return webView
     }
@@ -401,7 +371,6 @@ final class WebSessionProvider: NSObject, UsageProvider {
         if let signInWindow {
             signInWindow.makeKeyAndOrderFront(nil)
             NSApp.activate(ignoringOtherApps: true)
-            watchForAuthentication()
             return
         }
         let window = NSWindow(
@@ -437,60 +406,19 @@ final class WebSessionProvider: NSObject, UsageProvider {
             return
         }
         isLoaded = false
-        // A new load may still expose the previous document through `url` for
-        // a moment. Waiting for `WKNavigationDelegate.didFinish` prevents the
-        // probe from reading that stale page and closing a fresh login window
-        // before the user can interact with it.
-    }
-
-    private func watchForAuthentication() {
-        guard signInWindow != nil, let probe = site.authProbeScript, let webView else { return }
-        signInProbeTask?.cancel()
-        signInProbeTask = Task { [weak self, weak webView] in
-            for attempt in 0..<240 {
-                if attempt > 0 {
-                    try? await Task.sleep(nanoseconds: 1_000_000_000)
-                }
-                guard !Task.isCancelled, let self, let webView else { return }
-                // `url` can continue to point at the old same-origin document
-                // while a new navigation is in flight. Never authenticate from
-                // that document; `didFinish` starts a new watcher once the
-                // page is settled.
-                guard !webView.isLoading else { continue }
-                guard Self.matchesOrigin(webView.url, expected: site.origin) else { continue }
-                let result = try? await webView.callAsyncJavaScript(
-                    probe, arguments: [:], in: nil, contentWorld: .page
-                )
-                guard let state = Self.authenticationState(from: result) else { continue }
-                if var gate = self.switchGate {
-                    if gate.observe(
-                        authenticated: state.authenticated,
-                        fingerprint: state.fingerprint,
-                        storageMutations: state.storageMutations
-                    ) {
-                        self.switchGate = nil
-                        self.lastAuthFingerprint = state.fingerprint
-                        self.authenticationDidComplete()
-                    } else {
-                        self.switchGate = gate
-                    }
-                } else if state.authenticated {
-                    self.lastAuthFingerprint = state.fingerprint
-                    self.authenticationDidComplete()
-                }
-            }
-        }
+        // Authentication is confirmed once, after the user closes the window.
+        // Keeping the page open avoids false positives while the site is still
+        // loading or restoring its existing session.
     }
 
     private struct AuthenticationState {
         let authenticated: Bool
         let fingerprint: String?
-        let storageMutations: Int
     }
 
     private static func authenticationState(from result: Any?) -> AuthenticationState? {
         if let authenticated = result as? Bool {
-            return AuthenticationState(authenticated: authenticated, fingerprint: nil, storageMutations: 0)
+            return AuthenticationState(authenticated: authenticated, fingerprint: nil)
         }
         guard let text = result as? String,
               let data = text.data(using: .utf8),
@@ -498,8 +426,7 @@ final class WebSessionProvider: NSObject, UsageProvider {
               let authenticated = object["authenticated"] as? Bool
         else { return nil }
         return AuthenticationState(authenticated: authenticated,
-                                   fingerprint: object["fingerprint"] as? String,
-                                   storageMutations: object["storageMutations"] as? Int ?? 0)
+                                   fingerprint: object["fingerprint"] as? String)
     }
 
     private func authenticationDidComplete() {
@@ -511,12 +438,6 @@ final class WebSessionProvider: NSObject, UsageProvider {
         signInWindow = nil
         isLoaded = false
         onAuthenticated?()
-    }
-}
-
-extension WebSessionProvider: WKNavigationDelegate {
-    func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
-        watchForAuthentication()
     }
 }
 

--- a/Sources/Providers/WebSessionProvider.swift
+++ b/Sources/Providers/WebSessionProvider.swift
@@ -22,7 +22,13 @@ struct WebSessionAuthenticationGate: Equatable {
     mutating func observe(authenticated: Bool, fingerprint: String?) -> Bool {
         guard authenticated else {
             unauthenticatedSamples += 1
-            if unauthenticatedSamples >= 2 { sawLogout = true }
+            // A normal sign-in only needs one settled logged-out sample because
+            // the page is newly opened for this flow. Switching accounts keeps
+            // two samples to avoid treating a transient probe failure as a
+            // completed logout of the old account.
+            if unauthenticatedSamples >= (requiresNewFingerprint ? 2 : 1) {
+                sawLogout = true
+            }
             return false
         }
 
@@ -411,8 +417,10 @@ final class WebSessionProvider: NSObject, UsageProvider {
         guard signInWindow != nil, let probe = site.authProbeScript, let webView else { return }
         signInProbeTask?.cancel()
         signInProbeTask = Task { [weak self, weak webView] in
-            for _ in 0..<240 {
-                try? await Task.sleep(nanoseconds: 1_000_000_000)
+            for attempt in 0..<240 {
+                if attempt > 0 {
+                    try? await Task.sleep(nanoseconds: 1_000_000_000)
+                }
                 guard !Task.isCancelled, let self, let webView else { return }
                 // `url` can continue to point at the old same-origin document
                 // while a new navigation is in flight. Never authenticate from

--- a/Sources/Providers/WebSessionProvider.swift
+++ b/Sources/Providers/WebSessionProvider.swift
@@ -7,14 +7,17 @@ import os
 struct WebSessionAuthenticationGate: Equatable {
     private(set) var baselineFingerprint: String?
     private(set) var sawLogout = false
+    private let requiresNewFingerprint: Bool
     private var unauthenticatedSamples = 0
 
-    init(baselineFingerprint: String?) {
+    init(baselineFingerprint: String?, requiresNewFingerprint: Bool = true) {
         self.baselineFingerprint = baselineFingerprint
+        self.requiresNewFingerprint = requiresNewFingerprint
     }
 
-    /// A switch commits only after a real logout/login transition. This keeps
-    /// an already-authenticated old page from being mistaken for the new
+    /// A sign-in window commits only after a real logout/login transition.
+    /// Switching accounts additionally requires a new session identity. This
+    /// keeps an already-authenticated old page from being mistaken for the new
     /// account and avoids false positives from one transient probe failure.
     mutating func observe(authenticated: Bool, fingerprint: String?) -> Bool {
         guard authenticated else {
@@ -29,13 +32,28 @@ struct WebSessionAuthenticationGate: Equatable {
             return false
         }
 
-        // Providers with no fingerprint can still use the explicit
-        // logout/login transition. DeepSeek supplies one, so the same-account
-        // re-login does not look like an account switch unless its session
-        // identity changed.
-        guard baselineFingerprint == nil || fingerprint == nil || fingerprint != baselineFingerprint
-        else { return false }
+        // A normal sign-in only needs a real logged-out -> logged-in
+        // transition. Switching accounts additionally requires a different
+        // fingerprint, so signing back into the old account cannot commit a
+        // switch accidentally.
+        if requiresNewFingerprint {
+            guard baselineFingerprint == nil || fingerprint == nil || fingerprint != baselineFingerprint
+            else { return false }
+        }
         return true
+    }
+
+    /// A user closing the window is an explicit end to the flow, so one final
+    /// authenticated probe can commit a completed login even when the polling
+    /// task did not get a chance to observe the two logged-out samples first.
+    /// A switch still cannot commit the existing account on close.
+    func acceptsAuthenticatedStateOnManualClose(
+        authenticated: Bool,
+        fingerprint: String?
+    ) -> Bool {
+        guard authenticated else { return false }
+        guard requiresNewFingerprint else { return true }
+        return baselineFingerprint == nil || fingerprint == nil || fingerprint != baselineFingerprint
     }
 }
 
@@ -335,9 +353,14 @@ final class WebSessionProvider: NSObject, UsageProvider {
     }
 
     private func presentSignIn(switching: Bool) {
-        switchGate = switching
-            ? WebSessionAuthenticationGate(baselineFingerprint: lastAuthFingerprint)
-            : nil
+        // Both flows must see an actual unauthenticated page before accepting
+        // an authenticated probe. Otherwise a stale but valid WebView session
+        // makes ordinary Sign in close immediately. The switching flow keeps
+        // the additional different-fingerprint requirement.
+        switchGate = WebSessionAuthenticationGate(
+            baselineFingerprint: lastAuthFingerprint,
+            requiresNewFingerprint: switching
+        )
         let webView = makeWebViewIfNeeded()
         if let signInWindow {
             signInWindow.makeKeyAndOrderFront(nil)
@@ -378,7 +401,10 @@ final class WebSessionProvider: NSObject, UsageProvider {
             return
         }
         isLoaded = false
-        watchForAuthentication()
+        // A new load may still expose the previous document through `url` for
+        // a moment. Waiting for `WKNavigationDelegate.didFinish` prevents the
+        // probe from reading that stale page and closing a fresh login window
+        // before the user can interact with it.
     }
 
     private func watchForAuthentication() {
@@ -388,6 +414,11 @@ final class WebSessionProvider: NSObject, UsageProvider {
             for _ in 0..<240 {
                 try? await Task.sleep(nanoseconds: 1_000_000_000)
                 guard !Task.isCancelled, let self, let webView else { return }
+                // `url` can continue to point at the old same-origin document
+                // while a new navigation is in flight. Never authenticate from
+                // that document; `didFinish` starts a new watcher once the
+                // page is settled.
+                guard !webView.isLoading else { continue }
                 guard Self.matchesOrigin(webView.url, expected: site.origin) else { continue }
                 let result = try? await webView.callAsyncJavaScript(
                     probe, arguments: [:], in: nil, contentWorld: .page
@@ -448,11 +479,35 @@ extension WebSessionProvider: WKNavigationDelegate {
 extension WebSessionProvider: NSWindowDelegate {
     func windowWillClose(_ notification: Notification) {
         guard let window = notification.object as? NSWindow, window === signInWindow else { return }
+        let pendingGate = switchGate
+        let pendingWebView = webView
         signInWindow = nil
         signInProbeTask?.cancel()
         signInProbeTask = nil
-        // Closing a switch window is a cancellation, not a successful account
-        // change. Leave the committed session and usage untouched.
         switchGate = nil
+
+        // Closing before login is a cancellation. If the page is already
+        // authenticated, however, the user may simply have closed it after
+        // finishing the login before the polling task noticed. Confirm that
+        // final state and publish it so Settings does not need a relaunch.
+        guard let pendingGate,
+              let probe = site.authProbeScript,
+              let pendingWebView else { return }
+        let expectedOrigin = site.origin
+        signInProbeTask = Task { [weak self, weak pendingWebView] in
+            guard let self, let pendingWebView else { return }
+            guard !pendingWebView.isLoading,
+                  Self.matchesOrigin(pendingWebView.url, expected: expectedOrigin),
+                  let result = try? await pendingWebView.callAsyncJavaScript(
+                      probe, arguments: [:], in: nil, contentWorld: .page
+                  ),
+                  let state = Self.authenticationState(from: result),
+                  pendingGate.acceptsAuthenticatedStateOnManualClose(
+                      authenticated: state.authenticated,
+                      fingerprint: state.fingerprint)
+            else { return }
+            self.lastAuthFingerprint = state.fingerprint
+            self.authenticationDidComplete()
+        }
     }
 }

--- a/Sources/Providers/WebSessionProvider.swift
+++ b/Sources/Providers/WebSessionProvider.swift
@@ -9,17 +9,23 @@ struct WebSessionAuthenticationGate: Equatable {
     private(set) var sawLogout = false
     private let requiresNewFingerprint: Bool
     private var unauthenticatedSamples = 0
+    private var sessionMutations = 0
 
     init(baselineFingerprint: String?, requiresNewFingerprint: Bool = true) {
         self.baselineFingerprint = baselineFingerprint
         self.requiresNewFingerprint = requiresNewFingerprint
     }
 
-    /// A sign-in window commits only after a real logout/login transition.
-    /// Switching accounts additionally requires a new session identity. This
-    /// keeps an already-authenticated old page from being mistaken for the new
-    /// account and avoids false positives from one transient probe failure.
-    mutating func observe(authenticated: Bool, fingerprint: String?) -> Bool {
+    /// A sign-in window commits after a real logout/login transition or an
+    /// observed session-storage mutation in this page load. Switching accounts
+    /// additionally requires a new session identity. This keeps an already-
+    /// authenticated old page from being mistaken for the new account.
+    mutating func observe(
+        authenticated: Bool,
+        fingerprint: String?,
+        storageMutations: Int = 0
+    ) -> Bool {
+        if storageMutations > 0 { sessionMutations = storageMutations }
         guard authenticated else {
             unauthenticatedSamples += 1
             // A normal sign-in only needs one settled logged-out sample because
@@ -33,7 +39,7 @@ struct WebSessionAuthenticationGate: Equatable {
         }
 
         unauthenticatedSamples = 0
-        guard sawLogout else {
+        guard sawLogout || (!requiresNewFingerprint && sessionMutations > 0) else {
             if baselineFingerprint == nil { baselineFingerprint = fingerprint }
             return false
         }
@@ -51,7 +57,7 @@ struct WebSessionAuthenticationGate: Equatable {
 
     /// A user closing the window is an explicit end to the flow, so one final
     /// authenticated probe can commit a completed login even when the polling
-    /// task did not get a chance to observe the two logged-out samples first.
+    /// task did not get a chance to observe the logged-out state first.
     /// A switch still cannot commit the existing account on close.
     func acceptsAuthenticatedStateOnManualClose(
         authenticated: Bool,
@@ -61,6 +67,7 @@ struct WebSessionAuthenticationGate: Equatable {
         guard requiresNewFingerprint else { return true }
         return baselineFingerprint == nil || fingerprint == nil || fingerprint != baselineFingerprint
     }
+
 }
 
 /// Reads a provider's usage from the endpoint its own web app uses, by running
@@ -192,7 +199,30 @@ final class WebSessionProvider: NSObject, UsageProvider {
         configuration.userContentController.addUserScript(WKUserScript(
             source: #"""
             window.__notchCalls = [];
+            window.__notchAuthStorageMutations = 0;
             (function () {
+                const storage = window.localStorage;
+                const setItem = Storage.prototype.setItem;
+                Storage.prototype.setItem = function (key, value) {
+                    if (this === storage && key === 'userToken') {
+                        window.__notchAuthStorageMutations += 1;
+                    }
+                    return setItem.apply(this, arguments);
+                };
+                const removeItem = Storage.prototype.removeItem;
+                Storage.prototype.removeItem = function (key) {
+                    if (this === storage && key === 'userToken') {
+                        window.__notchAuthStorageMutations += 1;
+                    }
+                    return removeItem.apply(this, arguments);
+                };
+                const clear = Storage.prototype.clear;
+                Storage.prototype.clear = function () {
+                    if (this === storage && this.getItem('userToken')) {
+                        window.__notchAuthStorageMutations += 1;
+                    }
+                    return clear.apply(this, arguments);
+                };
                 const fetchImpl = window.fetch;
                 window.fetch = function (...args) {
                     try {
@@ -433,7 +463,11 @@ final class WebSessionProvider: NSObject, UsageProvider {
                 )
                 guard let state = Self.authenticationState(from: result) else { continue }
                 if var gate = self.switchGate {
-                    if gate.observe(authenticated: state.authenticated, fingerprint: state.fingerprint) {
+                    if gate.observe(
+                        authenticated: state.authenticated,
+                        fingerprint: state.fingerprint,
+                        storageMutations: state.storageMutations
+                    ) {
                         self.switchGate = nil
                         self.lastAuthFingerprint = state.fingerprint
                         self.authenticationDidComplete()
@@ -451,11 +485,12 @@ final class WebSessionProvider: NSObject, UsageProvider {
     private struct AuthenticationState {
         let authenticated: Bool
         let fingerprint: String?
+        let storageMutations: Int
     }
 
     private static func authenticationState(from result: Any?) -> AuthenticationState? {
         if let authenticated = result as? Bool {
-            return AuthenticationState(authenticated: authenticated, fingerprint: nil)
+            return AuthenticationState(authenticated: authenticated, fingerprint: nil, storageMutations: 0)
         }
         guard let text = result as? String,
               let data = text.data(using: .utf8),
@@ -463,7 +498,8 @@ final class WebSessionProvider: NSObject, UsageProvider {
               let authenticated = object["authenticated"] as? Bool
         else { return nil }
         return AuthenticationState(authenticated: authenticated,
-                                   fingerprint: object["fingerprint"] as? String)
+                                   fingerprint: object["fingerprint"] as? String,
+                                   storageMutations: object["storageMutations"] as? Int ?? 0)
     }
 
     private func authenticationDidComplete() {

--- a/Sources/Settings/DeepSeekPricingSettingsView.swift
+++ b/Sources/Settings/DeepSeekPricingSettingsView.swift
@@ -1,0 +1,144 @@
+import SwiftUI
+
+/// Settings for the locally maintained DeepSeek billing schedule.
+///
+/// DeepSeek publishes the rule in UTC, so the editor intentionally says UTC
+/// rather than silently converting the stored values to the Mac's timezone.
+struct DeepSeekPricingSettingsView: View {
+    @ObservedObject var preferences: Preferences
+
+    private static let weekdayOrder = [2, 3, 4, 5, 6, 7, 1]
+
+    private var schedule: DeepSeekPricing.Schedule {
+        preferences.deepSeekPricingSchedule.normalized
+    }
+
+    var body: some View {
+        Form {
+            Section(L10n.t("Peak/off-peak pricing")) {
+                Toggle(L10n.t("Show DeepSeek pricing"),
+                       isOn: $preferences.deepSeekPricingEnabled)
+
+                Text(L10n.t("Shows the current billing phase and the next peak/off-peak change on the DeepSeek usage card."))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            Section(L10n.t("Peak rule")) {
+                Text(L10n.t("The schedule is maintained locally because it cannot be read reliably from an official API. Times below are UTC; the card converts the next change to your local time."))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                VStack(alignment: .leading, spacing: 8) {
+                    Text(L10n.t("Peak days"))
+                        .foregroundStyle(.secondary)
+                    LazyVGrid(columns: Array(repeating: GridItem(.flexible(), spacing: 8), count: 4),
+                              alignment: .leading, spacing: 6) {
+                        ForEach(Self.weekdayOrder, id: \.self) { weekday in
+                            Toggle(weekdayTitle(weekday), isOn: weekdayBinding(weekday))
+                                .toggleStyle(.checkbox)
+                        }
+                    }
+                }
+
+                PeakWindowRow(title: L10n.t("Window 1"),
+                              start: timeBinding(window: 0, start: true),
+                              end: timeBinding(window: 0, start: false))
+                PeakWindowRow(title: L10n.t("Window 2"),
+                              start: timeBinding(window: 1, start: true),
+                              end: timeBinding(window: 1, start: false))
+            }
+            .disabled(!preferences.deepSeekPricingEnabled)
+
+            Section {
+                Button(L10n.t("Restore current default rule")) {
+                    preferences.resetDeepSeekPricingSchedule()
+                }
+            }
+        }
+        .formStyle(.grouped)
+    }
+
+    private func weekdayTitle(_ weekday: Int) -> String {
+        switch weekday {
+        case 1: return L10n.t("Sun")
+        case 2: return L10n.t("Mon")
+        case 3: return L10n.t("Tue")
+        case 4: return L10n.t("Wed")
+        case 5: return L10n.t("Thu")
+        case 6: return L10n.t("Fri")
+        default: return L10n.t("Sat")
+        }
+    }
+
+    private func weekdayBinding(_ weekday: Int) -> Binding<Bool> {
+        Binding(
+            get: { schedule.peakWeekdays.contains(weekday) },
+            set: { enabled in
+                var next = schedule
+                if enabled {
+                    next.peakWeekdays.insert(weekday)
+                } else {
+                    next.peakWeekdays.remove(weekday)
+                }
+                preferences.deepSeekPricingSchedule = next
+            }
+        )
+    }
+
+    private func timeBinding(window index: Int, start: Bool) -> Binding<Int> {
+        Binding(
+            get: {
+                let window = schedule.windows.indices.contains(index)
+                    ? schedule.windows[index]
+                    : DeepSeekPricing.Schedule.current.windows[index]
+                return start ? window.startMinute : window.endMinute
+            },
+            set: { value in
+                var next = schedule
+                guard next.windows.indices.contains(index) else { return }
+                var window = next.windows[index]
+                if start {
+                    window.startMinute = min(value, max(0, window.endMinute - 30))
+                } else {
+                    window.endMinute = max(value, min(1_440, window.startMinute + 30))
+                }
+                next.windows[index] = window
+                preferences.deepSeekPricingSchedule = next
+            }
+        )
+    }
+}
+
+private struct PeakWindowRow: View {
+    let title: String
+    @Binding var start: Int
+    @Binding var end: Int
+
+    var body: some View {
+        HStack {
+            Text(title)
+            Spacer()
+            Picker(L10n.t("Start"), selection: $start) {
+                ForEach(Array(stride(from: 0, through: 1_440, by: 30)), id: \.self) { minute in
+                    Text(timeText(minute)).tag(minute)
+                }
+            }
+            .labelsHidden()
+            Text(L10n.t("to"))
+                .foregroundStyle(.secondary)
+            Picker(L10n.t("End"), selection: $end) {
+                ForEach(Array(stride(from: 0, through: 1_440, by: 30)), id: \.self) { minute in
+                    Text(timeText(minute)).tag(minute)
+                }
+            }
+            .labelsHidden()
+        }
+    }
+
+    private func timeText(_ minute: Int) -> String {
+        String(format: "%02d:%02d", minute / 60, minute % 60)
+    }
+}

--- a/Sources/Settings/Preferences.swift
+++ b/Sources/Settings/Preferences.swift
@@ -151,6 +151,32 @@ final class Preferences: ObservableObject {
         didSet { defaults.set(showUsagePace, forKey: Self.showUsagePaceKey) }
     }
 
+    /// Whether DeepSeek's current peak/off-peak billing phase is shown in its
+    /// usage card. Enabled by default because the card's pricing rows are
+    /// useful only when the rule is visible and understood.
+    @Published var deepSeekPricingEnabled: Bool {
+        didSet { defaults.set(deepSeekPricingEnabled, forKey: Keys.deepSeekPricingEnabled) }
+    }
+
+    /// The locally maintained DeepSeek billing rule. It is stored as one
+    /// Codable value so adding another rule field does not scatter more keys
+    /// through the preferences store.
+    @Published var deepSeekPricingSchedule: DeepSeekPricing.Schedule {
+        didSet {
+            let normalized = deepSeekPricingSchedule.normalized
+            if normalized != deepSeekPricingSchedule {
+                deepSeekPricingSchedule = normalized
+                return
+            }
+            guard let data = try? JSONEncoder().encode(deepSeekPricingSchedule) else { return }
+            defaults.set(data, forKey: Keys.deepSeekPricingSchedule)
+        }
+    }
+
+    func resetDeepSeekPricingSchedule() {
+        deepSeekPricingSchedule = .current
+    }
+
     /// Whether the weekly limit gets a ring of its own, and where it sits.
     @Published var weeklyRing: WeeklyRing {
         didSet { defaults.set(weeklyRing.rawValue, forKey: Keys.weeklyRing) }
@@ -339,6 +365,8 @@ final class Preferences: ObservableObject {
         static let geminiAPIMonthlyTokenBudget = "geminiAPIMonthlyTokenBudget"
         static let antigravityHeadlineLimit = "antigravityHeadlineLimit"
         static let antigravityHeadlineModel = "antigravityHeadlineModel"
+        static let deepSeekPricingEnabled = "deepSeekPricingEnabled"
+        static let deepSeekPricingSchedule = "deepSeekPricingSchedule"
     }
 
     /// The budget read straight from disk, off the main actor.
@@ -471,6 +499,13 @@ final class Preferences: ObservableObject {
         self.resetTimeFormat = defaults.string(forKey: Keys.resetTimeFormat)
             .flatMap(ResetTimeFormat.init(rawValue:)) ?? .automatic
         self.showUsagePace = defaults.bool(forKey: Self.showUsagePaceKey)
+        self.deepSeekPricingEnabled = defaults.object(forKey: Keys.deepSeekPricingEnabled) as? Bool ?? true
+        if let data = defaults.data(forKey: Keys.deepSeekPricingSchedule),
+           let schedule = try? JSONDecoder().decode(DeepSeekPricing.Schedule.self, from: data) {
+            self.deepSeekPricingSchedule = schedule.normalized
+        } else {
+            self.deepSeekPricingSchedule = .current
+        }
         // Absent means never chosen. Main display only, because that is what a
         // single-panel setup always did — all-displays on a fresh install
         // would put notches where none were expected.

--- a/Sources/Settings/SettingsView.swift
+++ b/Sources/Settings/SettingsView.swift
@@ -26,13 +26,14 @@ extension View {
 /// crossing-and-notification machinery it switches is Notifications' to
 /// explain.
 private enum SettingsSection: String, CaseIterable, Identifiable, Hashable {
-    case accounts, ollama, lmstudio, appearance, notifications, general
+    case accounts, deepseek, ollama, lmstudio, appearance, notifications, general
 
     var id: String { rawValue }
 
     var title: String {
         switch self {
         case .accounts:      return L10n.t("Accounts")
+        case .deepseek:      return "DeepSeek"
         case .ollama:        return "Ollama"   // a product name, the same in every language
         case .lmstudio:      return "LM Studio"
         case .appearance:    return L10n.t("Appearance")
@@ -44,6 +45,7 @@ private enum SettingsSection: String, CaseIterable, Identifiable, Hashable {
     var icon: String {
         switch self {
         case .accounts:      return "person.crop.circle.fill"
+        case .deepseek:      return "chart.line.uptrend.xyaxis"
         case .ollama:        return "desktopcomputer"
         case .lmstudio:      return "cpu"
         case .appearance:    return "paintbrush.fill"
@@ -58,6 +60,7 @@ private enum SettingsSection: String, CaseIterable, Identifiable, Hashable {
     var tint: Color {
         switch self {
         case .accounts:      return .blue
+        case .deepseek:      return .orange
         case .ollama:        return .teal
         case .lmstudio:      return .purple
         case .appearance:    return .indigo
@@ -265,6 +268,14 @@ struct SettingsView: View {
                 }
                 accounts = ProviderOrder.arrange(updated, by: preferences.providerOrder, id: \.id)
             }
+        .onReceive((usageStore?.$providerAccountRevision.eraseToAnyPublisher()
+                    ?? Empty<Int, Never>().eraseToAnyPublisher())
+            .receive(on: RunLoop.main)) { _ in
+                // Authentication can finish in a separate WebView window while
+                // this pane remains alive. Re-read only the account summaries
+                // for that explicit event, not on every usage poll.
+                accounts = providers()
+            }
     }
 
     /// The subject list, drawn as a card floating inside the window rather
@@ -437,6 +448,7 @@ struct SettingsView: View {
     private func paneContent(for section: SettingsSection) -> some View {
         switch section {
         case .accounts:      accountsPane
+        case .deepseek:      DeepSeekPricingSettingsView(preferences: preferences)
         case .ollama:
             if let usageStore {
                 Form {

--- a/Tests/DeepSeekUsageTests.swift
+++ b/Tests/DeepSeekUsageTests.swift
@@ -4,6 +4,63 @@ import SwiftUI
 
 @MainActor
 final class DeepSeekUsageTests: XCTestCase {
+    func testPricingUsesDeepSeekUTCWeekdayAndWindows() throws {
+        let formatter = ISO8601DateFormatter()
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+
+        XCTAssertEqual(DeepSeekPricing.phase(at: try XCTUnwrap(formatter.date(from: "2026-09-14T02:00:00Z"))), .peak)
+        XCTAssertEqual(DeepSeekPricing.phase(at: try XCTUnwrap(formatter.date(from: "2026-09-14T04:00:00Z"))), .offPeak)
+        XCTAssertEqual(DeepSeekPricing.phase(at: try XCTUnwrap(formatter.date(from: "2026-09-14T07:00:00Z"))), .peak)
+        XCTAssertEqual(DeepSeekPricing.phase(at: try XCTUnwrap(formatter.date(from: "2026-09-14T10:00:00Z"))), .offPeak)
+        XCTAssertEqual(DeepSeekPricing.phase(at: try XCTUnwrap(formatter.date(from: "2026-09-13T02:00:00Z"))), .offPeak)
+    }
+
+    func testPricingFindsTheNextLocalBillingPhaseBoundaryInUTC() throws {
+        let formatter = ISO8601DateFormatter()
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        let now = try XCTUnwrap(formatter.date(from: "2026-09-14T02:30:00Z"))
+        let transition = DeepSeekPricing.nextTransition(after: now)
+
+        XCTAssertEqual(transition.phase, .offPeak)
+        XCTAssertEqual(transition.date,
+                       try XCTUnwrap(formatter.date(from: "2026-09-14T04:00:00Z")))
+
+        let friday = try XCTUnwrap(formatter.date(from: "2026-09-18T10:30:00Z"))
+        let monday = DeepSeekPricing.nextTransition(after: friday)
+        XCTAssertEqual(monday.phase, .peak)
+        XCTAssertEqual(monday.date,
+                       try XCTUnwrap(formatter.date(from: "2026-09-21T01:00:00Z")))
+    }
+
+    func testPricingUsesTheMaintainedSchedule() throws {
+        let formatter = ISO8601DateFormatter()
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        let schedule = DeepSeekPricing.Schedule(
+            peakWeekdays: [2],
+            windows: [.init(startMinute: 120, endMinute: 180)]
+        )
+
+        XCTAssertEqual(DeepSeekPricing.phase(
+            at: try XCTUnwrap(formatter.date(from: "2026-09-14T02:30:00Z")),
+            schedule: schedule
+        ), .peak)
+        XCTAssertEqual(DeepSeekPricing.phase(
+            at: try XCTUnwrap(formatter.date(from: "2026-09-14T03:00:00Z")),
+            schedule: schedule
+        ), .offPeak)
+        XCTAssertEqual(DeepSeekPricing.phase(
+            at: try XCTUnwrap(formatter.date(from: "2026-09-15T02:30:00Z")),
+            schedule: schedule
+        ), .offPeak)
+    }
+
+    func testDisablingPricingOnlyRemovesPricingRowsFromTheCardHeight() {
+        XCTAssertGreaterThan(
+            NotchLayout.usageDetailHeight(1, showsPricing: true),
+            NotchLayout.usageDetailHeight(1, showsPricing: false)
+        )
+    }
+
     func testSwitchGateIgnoresTheExistingSession() {
         var gate = WebSessionAuthenticationGate(baselineFingerprint: "old")
 
@@ -11,6 +68,54 @@ final class DeepSeekUsageTests: XCTestCase {
         XCTAssertFalse(gate.observe(authenticated: false, fingerprint: nil))
         XCTAssertFalse(gate.observe(authenticated: true, fingerprint: "old"))
         XCTAssertFalse(gate.observe(authenticated: true, fingerprint: "old"))
+    }
+
+    func testNormalSignInDoesNotCommitAnExistingSessionBeforeLogout() {
+        var gate = WebSessionAuthenticationGate(
+            baselineFingerprint: "old",
+            requiresNewFingerprint: false
+        )
+
+        XCTAssertFalse(gate.observe(authenticated: true, fingerprint: "old"))
+        XCTAssertFalse(gate.observe(authenticated: true, fingerprint: "old"))
+        XCTAssertFalse(gate.observe(authenticated: false, fingerprint: nil))
+        XCTAssertFalse(gate.observe(authenticated: false, fingerprint: nil))
+        XCTAssertTrue(gate.observe(authenticated: true, fingerprint: "old"))
+    }
+
+    func testManualCloseCanCommitACompletedNormalSignIn() {
+        let gate = WebSessionAuthenticationGate(
+            baselineFingerprint: "old",
+            requiresNewFingerprint: false
+        )
+
+        XCTAssertTrue(gate.acceptsAuthenticatedStateOnManualClose(
+            authenticated: true,
+            fingerprint: "old"
+        ))
+        XCTAssertFalse(gate.acceptsAuthenticatedStateOnManualClose(
+            authenticated: false,
+            fingerprint: nil
+        ))
+    }
+
+    func testManualCloseCannotCommitTheExistingAccountDuringASwitch() {
+        let gate = WebSessionAuthenticationGate(baselineFingerprint: "old")
+
+        XCTAssertFalse(gate.acceptsAuthenticatedStateOnManualClose(
+            authenticated: true,
+            fingerprint: "old"
+        ))
+        XCTAssertTrue(gate.acceptsAuthenticatedStateOnManualClose(
+            authenticated: true,
+            fingerprint: "new"
+        ))
+    }
+
+    func testDeepSeekAuthenticationProbeUsesThePlatformHeader() {
+        let probe = try! XCTUnwrap(Sites.deepSeek.authProbeScript)
+
+        XCTAssertTrue(probe.contains("'x-client-platform': 'web'"))
     }
 
     func testSwitchGateCommitsOnlyAfterLogoutAndANewSession() {

--- a/Tests/DeepSeekUsageTests.swift
+++ b/Tests/DeepSeekUsageTests.swift
@@ -77,8 +77,6 @@ final class DeepSeekUsageTests: XCTestCase {
         )
 
         XCTAssertFalse(gate.observe(authenticated: true, fingerprint: "old"))
-        XCTAssertFalse(gate.observe(authenticated: true, fingerprint: "old"))
-        XCTAssertFalse(gate.observe(authenticated: false, fingerprint: nil))
         XCTAssertFalse(gate.observe(authenticated: false, fingerprint: nil))
         XCTAssertTrue(gate.observe(authenticated: true, fingerprint: "old"))
     }

--- a/Tests/DeepSeekUsageTests.swift
+++ b/Tests/DeepSeekUsageTests.swift
@@ -81,6 +81,19 @@ final class DeepSeekUsageTests: XCTestCase {
         XCTAssertTrue(gate.observe(authenticated: true, fingerprint: "old"))
     }
 
+    func testNormalSignInCanCommitWhenTheSessionTokenChangedInThisPage() {
+        var gate = WebSessionAuthenticationGate(
+            baselineFingerprint: "old",
+            requiresNewFingerprint: false
+        )
+
+        XCTAssertTrue(gate.observe(
+            authenticated: true,
+            fingerprint: "new",
+            storageMutations: 1
+        ))
+    }
+
     func testManualCloseCanCommitACompletedNormalSignIn() {
         let gate = WebSessionAuthenticationGate(
             baselineFingerprint: "old",
@@ -114,6 +127,7 @@ final class DeepSeekUsageTests: XCTestCase {
         let probe = try! XCTUnwrap(Sites.deepSeek.authProbeScript)
 
         XCTAssertTrue(probe.contains("'x-client-platform': 'web'"))
+        XCTAssertTrue(probe.contains("storageMutations"))
     }
 
     func testSwitchGateCommitsOnlyAfterLogoutAndANewSession() {

--- a/Tests/DeepSeekUsageTests.swift
+++ b/Tests/DeepSeekUsageTests.swift
@@ -81,19 +81,6 @@ final class DeepSeekUsageTests: XCTestCase {
         XCTAssertTrue(gate.observe(authenticated: true, fingerprint: "old"))
     }
 
-    func testNormalSignInCanCommitWhenTheSessionTokenChangedInThisPage() {
-        var gate = WebSessionAuthenticationGate(
-            baselineFingerprint: "old",
-            requiresNewFingerprint: false
-        )
-
-        XCTAssertTrue(gate.observe(
-            authenticated: true,
-            fingerprint: "new",
-            storageMutations: 1
-        ))
-    }
-
     func testManualCloseCanCommitACompletedNormalSignIn() {
         let gate = WebSessionAuthenticationGate(
             baselineFingerprint: "old",
@@ -127,7 +114,6 @@ final class DeepSeekUsageTests: XCTestCase {
         let probe = try! XCTUnwrap(Sites.deepSeek.authProbeScript)
 
         XCTAssertTrue(probe.contains("'x-client-platform': 'web'"))
-        XCTAssertTrue(probe.contains("storageMutations"))
     }
 
     func testSwitchGateCommitsOnlyAfterLogoutAndANewSession() {

--- a/Tests/PreferencesTests.swift
+++ b/Tests/PreferencesTests.swift
@@ -69,6 +69,26 @@ final class PreferencesMigrationTests: XCTestCase {
         XCTAssertEqual(preferences.notchEdge, .right)
         XCTAssertEqual(preferences.notchSize, .medium)
         XCTAssertEqual(preferences.weeklyRing, .off)
+        XCTAssertTrue(preferences.deepSeekPricingEnabled)
+        XCTAssertEqual(preferences.deepSeekPricingSchedule, .current)
+    }
+
+    func testDeepSeekPricingSettingsSurviveARelaunchAndCanBeReset() {
+        let (fresh, name) = makeDefaults()
+        let preferences = Preferences(defaults: fresh)
+        preferences.deepSeekPricingEnabled = false
+        preferences.deepSeekPricingSchedule = DeepSeekPricing.Schedule(
+            peakWeekdays: [2],
+            windows: [.init(startMinute: 120, endMinute: 180)]
+        )
+
+        let reloaded = Preferences(defaults: UserDefaults(suiteName: name)!)
+        XCTAssertFalse(reloaded.deepSeekPricingEnabled)
+        XCTAssertEqual(reloaded.deepSeekPricingSchedule.peakWeekdays, [2])
+        XCTAssertEqual(reloaded.deepSeekPricingSchedule.windows.first?.startMinute, 120)
+
+        reloaded.resetDeepSeekPricingSchedule()
+        XCTAssertEqual(reloaded.deepSeekPricingSchedule, .current)
     }
 
     /// Off by default, and it has to stay chosen once it is chosen: an extra


### PR DESCRIPTION
## Summary

- Add configurable DeepSeek peak and off-peak pricing rules.
- Add a DeepSeek pricing settings tab with editable weekdays and UTC time windows.
- Allow users to enable or disable pricing information on the usage card.
- Display pricing status, next phase transition, and separators between card sections.
- Improve DeepSeek sign-in state synchronization after manually closing the login window.
- Keep the login window open after authentication to avoid premature dismissal.

## Sign-in Behavior

DeepSeek authentication is confirmed when the user closes the login window. The final authentication probe then updates the persisted sign-in state and refreshes the Settings page without requiring an application restart.

Automatic window closing was intentionally removed because the web page can temporarily expose stale or partially initialized session data during navigation.

## Default Pricing Schedule

- Weekdays: Monday to Friday
- Peak periods: `01:00-04:00 UTC` and `06:00-10:00 UTC`
- Off-peak periods: all remaining times
- Peak pricing: `2x` the off-peak price

The default rules can be restored from Settings.

## Testing

- DeepSeek usage and pricing tests: 14 passed
- Web session sign-in tests: 3 passed
- Total targeted tests: 17 passed