### PR TITLE
Make DeepSeek peak pricing windows fully configurable

### DIFF
--- a/Sources/Localizable.xcstrings
+++ b/Sources/Localizable.xcstrings
@@ -17643,6 +17643,39 @@
         }
       }
     },
+    "Window %lld": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "时段 %lld"
+          }
+        }
+      }
+    },
+    "Add peak window": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "添加高峰时段"
+          }
+        }
+      }
+    },
+    "Remove peak window": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "移除高峰时段"
+          }
+        }
+      }
+    },
     "Start": {
       "extractionState": "manual",
       "localizations": {

--- a/Sources/Providers/DeepSeekPricing.swift
+++ b/Sources/Providers/DeepSeekPricing.swift
@@ -28,15 +28,19 @@ enum DeepSeekPricing {
         )
 
         /// Keep values loaded from UserDefaults safe even if a future build
-        /// changes the editor or an older build wrote malformed data.
+        /// changes the editor or an older build wrote malformed data. The
+        /// number of windows is intentionally unbounded: DeepSeek may publish
+        /// more than the two windows in today's default rule.
         var normalized: Schedule {
             let weekdays = peakWeekdays.filter { (1...7).contains($0) }
-            var validWindows = windows.prefix(2).map { window in
-                Window(startMinute: min(max(window.startMinute, 0), 1_440),
-                       endMinute: min(max(window.endMinute, 0), 1_440))
+            var validWindows = windows.compactMap { window -> Window? in
+                let startMinute = min(max(window.startMinute, 0), 1_440)
+                let endMinute = min(max(window.endMinute, 0), 1_440)
+                guard startMinute < endMinute else { return nil }
+                return Window(startMinute: startMinute, endMinute: endMinute)
             }
-            while validWindows.count < 2 {
-                validWindows.append(Self.current.windows[validWindows.count])
+            if validWindows.isEmpty {
+                validWindows = [Self.current.windows[0]]
             }
             return Schedule(peakWeekdays: weekdays,
                             windows: validWindows)

--- a/Sources/Settings/DeepSeekPricingSettingsView.swift
+++ b/Sources/Settings/DeepSeekPricingSettingsView.swift
@@ -43,12 +43,21 @@ struct DeepSeekPricingSettingsView: View {
                     }
                 }
 
-                PeakWindowRow(title: L10n.t("Window 1"),
-                              start: timeBinding(window: 0, start: true),
-                              end: timeBinding(window: 0, start: false))
-                PeakWindowRow(title: L10n.t("Window 2"),
-                              start: timeBinding(window: 1, start: true),
-                              end: timeBinding(window: 1, start: false))
+                ForEach(schedule.windows.indices, id: \.self) { index in
+                    PeakWindowRow(
+                        title: String(format: L10n.t("Window %lld"), index + 1),
+                        start: timeBinding(window: index, start: true),
+                        end: timeBinding(window: index, start: false),
+                        canRemove: schedule.windows.count > 1,
+                        onRemove: { removeWindow(at: index) }
+                    )
+                }
+
+                Button {
+                    addWindow()
+                } label: {
+                    Label(L10n.t("Add peak window"), systemImage: "plus")
+                }
             }
             .disabled(!preferences.deepSeekPricingEnabled)
 
@@ -93,7 +102,7 @@ struct DeepSeekPricingSettingsView: View {
             get: {
                 let window = schedule.windows.indices.contains(index)
                     ? schedule.windows[index]
-                    : DeepSeekPricing.Schedule.current.windows[index]
+                    : .init(startMinute: 0, endMinute: 30)
                 return start ? window.startMinute : window.endMinute
             },
             set: { value in
@@ -101,14 +110,41 @@ struct DeepSeekPricingSettingsView: View {
                 guard next.windows.indices.contains(index) else { return }
                 var window = next.windows[index]
                 if start {
-                    window.startMinute = min(value, max(0, window.endMinute - 30))
+                    window.startMinute = min(max(value, 0), max(0, window.endMinute - 1))
                 } else {
-                    window.endMinute = max(value, min(1_440, window.startMinute + 30))
+                    window.endMinute = max(min(value, 1_440), min(1_440, window.startMinute + 1))
                 }
                 next.windows[index] = window
                 preferences.deepSeekPricingSchedule = next
             }
         )
+    }
+
+    private func addWindow() {
+        var next = schedule
+        let duration = 60
+        let sortedWindows = next.windows.sorted { $0.startMinute < $1.startMinute }
+        var candidateStart = 0
+
+        for window in sortedWindows {
+            if window.startMinute - candidateStart >= duration { break }
+            candidateStart = max(candidateStart, window.endMinute)
+        }
+
+        if candidateStart + duration > 1_440 {
+            candidateStart = 1_440 - duration
+        }
+        next.windows.append(.init(startMinute: candidateStart,
+                                  endMinute: candidateStart + duration))
+        preferences.deepSeekPricingSchedule = next
+    }
+
+    private func removeWindow(at index: Int) {
+        guard schedule.windows.count > 1,
+              schedule.windows.indices.contains(index) else { return }
+        var next = schedule
+        next.windows.remove(at: index)
+        preferences.deepSeekPricingSchedule = next
     }
 }
 
@@ -116,29 +152,68 @@ private struct PeakWindowRow: View {
     let title: String
     @Binding var start: Int
     @Binding var end: Int
+    let canRemove: Bool
+    let onRemove: () -> Void
 
     var body: some View {
         HStack {
             Text(title)
             Spacer()
-            Picker(L10n.t("Start"), selection: $start) {
-                ForEach(Array(stride(from: 0, through: 1_440, by: 30)), id: \.self) { minute in
-                    Text(timeText(minute)).tag(minute)
-                }
-            }
-            .labelsHidden()
+            PeakTimePicker(label: L10n.t("Start"), minuteOfDay: $start)
             Text(L10n.t("to"))
                 .foregroundStyle(.secondary)
-            Picker(L10n.t("End"), selection: $end) {
-                ForEach(Array(stride(from: 0, through: 1_440, by: 30)), id: \.self) { minute in
-                    Text(timeText(minute)).tag(minute)
+            PeakTimePicker(label: L10n.t("End"), minuteOfDay: $end)
+            if canRemove {
+                Button(role: .destructive, action: onRemove) {
+                    Image(systemName: "minus.circle")
                 }
+                .buttonStyle(.borderless)
+                .help(L10n.t("Remove peak window"))
             }
-            .labelsHidden()
+        }
+    }
+}
+
+private struct PeakTimePicker: View {
+    let label: String
+    @Binding var minuteOfDay: Int
+
+    var body: some View {
+        HStack(spacing: 6) {
+            DatePicker(label, selection: dateBinding, displayedComponents: [.hourAndMinute])
+                .datePickerStyle(.stepperField)
+                .labelsHidden()
+                .environment(\.timeZone, Self.utcTimeZone)
         }
     }
 
-    private func timeText(_ minute: Int) -> String {
-        String(format: "%02d:%02d", minute / 60, minute % 60)
+    private static let utcTimeZone = TimeZone(secondsFromGMT: 0)!
+
+    private static var utcCalendar: Calendar {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = utcTimeZone
+        return calendar
+    }
+
+    private static let anchorDate = Date(timeIntervalSince1970: 0)
+
+    private var dateBinding: Binding<Date> {
+        Binding(
+            get: {
+                let minute = min(max(minuteOfDay, 0), 1_440)
+                if minute == 1_440 {
+                    return Self.utcCalendar.date(byAdding: .day, value: 1,
+                                                 to: Self.anchorDate) ?? Self.anchorDate
+                }
+                return Self.utcCalendar.date(bySettingHour: minute / 60,
+                                             minute: minute % 60,
+                                             second: 0,
+                                             of: Self.anchorDate) ?? Self.anchorDate
+            },
+            set: { date in
+                let components = Self.utcCalendar.dateComponents([.hour, .minute], from: date)
+                minuteOfDay = (components.hour ?? 0) * 60 + (components.minute ?? 0)
+            }
+        )
     }
 }

--- a/Tests/DeepSeekUsageTests.swift
+++ b/Tests/DeepSeekUsageTests.swift
@@ -54,6 +54,28 @@ final class DeepSeekUsageTests: XCTestCase {
         ), .offPeak)
     }
 
+    func testPricingSupportsMoreThanTwoPeakWindows() throws {
+        let formatter = ISO8601DateFormatter()
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        let schedule = DeepSeekPricing.Schedule(
+            peakWeekdays: [2],
+            windows: [
+                .init(startMinute: 60, endMinute: 120),
+                .init(startMinute: 360, endMinute: 420),
+                .init(startMinute: 1_080, endMinute: 1_140)
+            ]
+        )
+
+        XCTAssertEqual(DeepSeekPricing.phase(
+            at: try XCTUnwrap(formatter.date(from: "2026-09-14T18:30:00Z")),
+            schedule: schedule
+        ), .peak)
+        XCTAssertEqual(DeepSeekPricing.phase(
+            at: try XCTUnwrap(formatter.date(from: "2026-09-14T19:00:00Z")),
+            schedule: schedule
+        ), .offPeak)
+    }
+
     func testDisablingPricingOnlyRemovesPricingRowsFromTheCardHeight() {
         XCTAssertGreaterThan(
             NotchLayout.usageDetailHeight(1, showsPricing: true),

--- a/Tests/PreferencesTests.swift
+++ b/Tests/PreferencesTests.swift
@@ -210,13 +210,18 @@ final class PreferencesMigrationTests: XCTestCase {
         preferences.deepSeekPricingEnabled = false
         preferences.deepSeekPricingSchedule = DeepSeekPricing.Schedule(
             peakWeekdays: [2],
-            windows: [.init(startMinute: 120, endMinute: 180)]
+            windows: [
+                .init(startMinute: 120, endMinute: 180),
+                .init(startMinute: 360, endMinute: 420),
+                .init(startMinute: 900, endMinute: 960)
+            ]
         )
 
         let reloaded = Preferences(defaults: UserDefaults(suiteName: name)!)
         XCTAssertFalse(reloaded.deepSeekPricingEnabled)
         XCTAssertEqual(reloaded.deepSeekPricingSchedule.peakWeekdays, [2])
-        XCTAssertEqual(reloaded.deepSeekPricingSchedule.windows.first?.startMinute, 120)
+        XCTAssertEqual(reloaded.deepSeekPricingSchedule.windows.count, 3)
+        XCTAssertEqual(reloaded.deepSeekPricingSchedule.windows[2].startMinute, 900)
 
         reloaded.resetDeepSeekPricingSchedule()
         XCTAssertEqual(reloaded.deepSeekPricingSchedule, .current)


### PR DESCRIPTION
## Summary

- Remove the hardcoded two-window limit for DeepSeek peak pricing.
- Allow users to add and remove any number of peak pricing windows.
- Preserve the current two-window schedule as the default.
- Keep pricing calculations based on the complete configured schedule.
- Add validation for invalid or empty time ranges.
- Replace half-hour menus with native macOS `DatePicker` controls.
- Support arbitrary hour and minute values.
- Remove the unnecessary `24:00` shortcut.
- Add localization for the new controls and actions.

## User Experience

DeepSeek pricing windows can now be maintained directly from Settings as the pricing rules evolve. Each window uses UTC and supports minute-level precision through the native macOS time picker.

At least one valid peak window is retained, while additional windows can be added or removed as needed.

## Testing

- DeepSeek usage and pricing tests passed.
- Preferences persistence tests passed.
- 37 related tests passed in total.
- Local macOS build and Settings UI launch verified.